### PR TITLE
allow custom message per event

### DIFF
--- a/context.go
+++ b/context.go
@@ -42,6 +42,15 @@ func Error(ctx context.Context, err error) bool {
 	return true
 }
 
+func SetMessage(ctx context.Context, msg string) bool {
+	e := FromContext(ctx)
+	if e == nil {
+		return false
+	}
+	e.setMessage(msg)
+	return true
+}
+
 // SetLevel sets a requested level override for the event in ctx.
 func SetLevel(ctx context.Context, level Level) bool {
 	e := FromContext(ctx)

--- a/event.go
+++ b/event.go
@@ -10,6 +10,7 @@ import (
 // Event accumulates request-scoped structured fields.
 type Event struct {
 	mu                sync.RWMutex
+	message           string
 	fields            map[string]any
 	startTime         time.Time
 	hasError          bool
@@ -84,10 +85,22 @@ func (e *Event) setError(err error) {
 	}
 }
 
+func (e *Event) setMessage(msg string) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.message = msg
+}
+
 func (e *Event) hasErrorValue() bool {
 	e.mu.RLock()
 	defer e.mu.RUnlock()
 	return e.hasError
+}
+
+func (e *Event) hasMessageValue() bool {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+	return len(e.message) > 0
 }
 
 func (e *Event) startedAt() time.Time {
@@ -122,4 +135,11 @@ func (e *Event) snapshot() snapshot {
 		startTime: e.startTime,
 		hasError:  e.hasError,
 	}
+}
+
+func (e *Event) getMessage() string {
+	e.mu.RLock()
+	defer e.mu.RUnlock()
+
+	return e.message
 }

--- a/event_access.go
+++ b/event_access.go
@@ -11,12 +11,27 @@ func EventFields(e *Event) map[string]any {
 	return e.snapshot().fields
 }
 
+func EventMessage(e *Event) string {
+	if e == nil {
+		return ""
+	}
+	return e.getMessage()
+}
+
 // EventHasError reports whether e has an attached error.
 func EventHasError(e *Event) bool {
 	if e == nil {
 		return false
 	}
 	return e.hasErrorValue()
+}
+
+// EventHasMessage reports whether e has an attached message.
+func EventHasMessage(e *Event) bool {
+	if e == nil {
+		return false
+	}
+	return e.hasMessageValue()
 }
 
 // EventStartTime returns e's start time.

--- a/integration/common/lifecycle.go
+++ b/integration/common/lifecycle.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/happytoolin/happycontext"
+	hc "github.com/happytoolin/happycontext"
 )
 
 // FinalizeInput contains request data required for finalization.
@@ -57,7 +57,13 @@ func FinalizeRequest(cfg hc.Config, in FinalizeInput) {
 	}) {
 		return
 	}
-	cfg.Sink.Write(level, cfg.Message, hc.EventFields(in.Event))
+
+	msg := cfg.Message
+	if hc.EventHasMessage(in.Event) {
+		msg = hc.EventMessage(in.Event)
+	}
+
+	cfg.Sink.Write(level, msg, hc.EventFields(in.Event))
 }
 
 func annotateFailures(ctx context.Context, err error, recovered any) {

--- a/integration/common/lifecycle_test.go
+++ b/integration/common/lifecycle_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/happytoolin/happycontext"
+	hc "github.com/happytoolin/happycontext"
 )
 
 func TestStartRequestAddsBaseFields(t *testing.T) {
@@ -130,6 +130,29 @@ func TestFinalizeRequestAppliesRequestedLevelFloor(t *testing.T) {
 	}
 	if events[0].Level != hc.LevelWarn {
 		t.Fatalf("level = %s, want WARN", events[0].Level)
+	}
+}
+
+func TestFinalizeRequestAppliesEventMessage(t *testing.T) {
+	ctx, event := StartRequest(context.Background(), "GET", "/x")
+	hc.SetMessage(ctx, "hello world")
+	sink := hc.NewTestSink()
+	cfg := NormalizeConfig(hc.Config{Sink: sink, SamplingRate: 1})
+
+	FinalizeRequest(cfg, FinalizeInput{
+		Ctx:        ctx,
+		Event:      event,
+		Method:     "GET",
+		Path:       "/x",
+		StatusCode: 200,
+	})
+
+	events := sink.Events()
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	if events[0].Message != "hello world" {
+		t.Fatalf("Message = %s, want 'hello world", events[0].Message)
 	}
 }
 

--- a/integration/common/lifecycle_test.go
+++ b/integration/common/lifecycle_test.go
@@ -137,7 +137,7 @@ func TestFinalizeRequestAppliesEventMessage(t *testing.T) {
 	ctx, event := StartRequest(context.Background(), "GET", "/x")
 	hc.SetMessage(ctx, "hello world")
 	sink := hc.NewTestSink()
-	cfg := NormalizeConfig(hc.Config{Sink: sink, SamplingRate: 1})
+	cfg := NormalizeConfig(hc.Config{Sink: sink, SamplingRate: 1, Message: "default message"})
 
 	FinalizeRequest(cfg, FinalizeInput{
 		Ctx:        ctx,
@@ -152,7 +152,7 @@ func TestFinalizeRequestAppliesEventMessage(t *testing.T) {
 		t.Fatalf("expected 1 event, got %d", len(events))
 	}
 	if events[0].Message != "hello world" {
-		t.Fatalf("Message = %s, want 'hello world", events[0].Message)
+		t.Fatalf("Message = %s, want 'hello world'", events[0].Message)
 	}
 }
 


### PR DESCRIPTION
The point of this PR is to allow consumer of happycontext to define a message per event. 

One can imagine, when looking at a stream of logs in tools like posthog and seeing the same message for all events isn't quite useful. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Request contexts can carry a custom message that, when present, overrides the default log/finalize message.
  * New helpers expose whether an event has a message and retrieve that message.

* **Tests**
  * Integration test added to verify that a context-set message replaces the default message during request finalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->