### PR TITLE
Document custom message behavior and extend tests

### DIFF
--- a/context.go
+++ b/context.go
@@ -42,6 +42,8 @@ func Error(ctx context.Context, err error) bool {
 	return true
 }
 
+// SetMessage records a per-event message on the event stored in ctx.
+// An empty message is treated as unset during finalization.
 func SetMessage(ctx context.Context, msg string) bool {
 	e := FromContext(ctx)
 	if e == nil {

--- a/context_test.go
+++ b/context_test.go
@@ -19,6 +19,7 @@ func TestContextHelpers(t *testing.T) {
 	Add(ctx, "alias", true)
 	Add(ctx, "b", 2, "c", 3)
 	Error(ctx, errors.New("boom"))
+	SetMessage(ctx, "checkout completed")
 	SetLevel(ctx, LevelWarn)
 	SetRoute(ctx, "/orders/:id")
 
@@ -35,6 +36,12 @@ func TestContextHelpers(t *testing.T) {
 	}
 	if !EventHasError(e) {
 		t.Fatal("expected HasError true")
+	}
+	if !EventHasMessage(e) {
+		t.Fatal("expected HasMessage true")
+	}
+	if msg := EventMessage(e); msg != "checkout completed" {
+		t.Fatalf("expected message %q, got %q", "checkout completed", msg)
 	}
 	if fields["http.route"] != "/orders/:id" {
 		t.Fatalf("expected explicit route field, got %#v", fields["http.route"])
@@ -64,6 +71,9 @@ func TestHelpersWithNilContextAreNoop(t *testing.T) {
 	}
 	if Error(context.TODO(), errors.New("boom")) {
 		t.Fatal("expected Error(no-event-ctx, ...) to return false")
+	}
+	if SetMessage(context.TODO(), "done") {
+		t.Fatal("expected SetMessage(no-event-ctx, ...) to return false")
 	}
 	if SetLevel(context.TODO(), LevelInfo) {
 		t.Fatal("expected SetLevel(no-event-ctx, ...) to return false")

--- a/event_access.go
+++ b/event_access.go
@@ -11,6 +11,7 @@ func EventFields(e *Event) map[string]any {
 	return e.snapshot().fields
 }
 
+// EventMessage returns e's attached message, or an empty string if unset.
 func EventMessage(e *Event) string {
 	if e == nil {
 		return ""

--- a/integration/common/lifecycle_test.go
+++ b/integration/common/lifecycle_test.go
@@ -156,6 +156,29 @@ func TestFinalizeRequestAppliesEventMessage(t *testing.T) {
 	}
 }
 
+func TestFinalizeRequestFallsBackToConfigMessageWhenEventMessageEmpty(t *testing.T) {
+	ctx, event := StartRequest(context.Background(), "GET", "/x")
+	hc.SetMessage(ctx, "")
+	sink := hc.NewTestSink()
+	cfg := NormalizeConfig(hc.Config{Sink: sink, SamplingRate: 1, Message: "default message"})
+
+	FinalizeRequest(cfg, FinalizeInput{
+		Ctx:        ctx,
+		Event:      event,
+		Method:     "GET",
+		Path:       "/x",
+		StatusCode: 200,
+	})
+
+	events := sink.Events()
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	if events[0].Message != "default message" {
+		t.Fatalf("Message = %s, want 'default message'", events[0].Message)
+	}
+}
+
 func TestResolveStatus(t *testing.T) {
 	if got := ResolveStatus(0, nil, nil, false, 0); got != http.StatusOK {
 		t.Fatalf("status = %d, want %d", got, http.StatusOK)

--- a/integration/std/middleware_test.go
+++ b/integration/std/middleware_test.go
@@ -46,6 +46,36 @@ func TestMiddlewareDelegatesToCoreAndLogs(t *testing.T) {
 	}
 }
 
+func TestMiddlewareAppliesCustomMessageFromHandlerContext(t *testing.T) {
+	sink := &memorySink{}
+	mw := Middleware(Config{
+		Sink:         sink,
+		SamplingRate: 1,
+		Message:      "done",
+	})
+
+	h := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !hc.SetMessage(r.Context(), "order shipped") {
+			t.Fatal("expected SetMessage to succeed")
+		}
+		w.WriteHeader(http.StatusAccepted)
+	}))
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, httptest.NewRequest(http.MethodPost, "/orders/123/ship", nil))
+
+	events := sink.Events()
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	if events[0].Message != "order shipped" {
+		t.Fatalf("expected message %q, got %q", "order shipped", events[0].Message)
+	}
+	if events[0].Fields["http.status"] != http.StatusAccepted {
+		t.Fatalf("expected status %d, got %v", http.StatusAccepted, events[0].Fields["http.status"])
+	}
+}
+
 func TestMiddlewarePanicPropagatesAndLogsError(t *testing.T) {
 	sink := &memorySink{}
 	mw := Middleware(Config{


### PR DESCRIPTION
## Summary
- add doc comments for the exported custom-message helpers
- cover `SetMessage` in the context helper tests
- add request finalization and std middleware tests for custom message override and empty-message fallback

## Testing
- go test ./...


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added ability to set custom messages on events dynamically during request handling.
  * Message fallback mechanism: configured defaults are automatically applied when custom messages are not provided.

* **Documentation**
  * Improved documentation clarifying message handling and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->