### PR TITLE
chore: fix go module release tagging

### DIFF
--- a/.github/workflows/go-proxy-sync.yml
+++ b/.github/workflows/go-proxy-sync.yml
@@ -17,9 +17,15 @@ jobs:
       - name: Refresh Go module indexes
         shell: bash
         env:
-          TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
           set -euo pipefail
+          TAG="${RELEASE_TAG##*/}"
+
+          publishable_modfiles() {
+            printf '%s\n' go.mod
+            git ls-files 'adapter/*/go.mod' 'integration/*/go.mod'
+          }
 
           while IFS= read -r modfile; do
             module_path="$(sed -n 's/^module //p' "$modfile" | head -n1)"
@@ -41,4 +47,4 @@ jobs:
               curl -fsSIL --retry 3 --retry-delay 2 "$url" >/dev/null || \
                 echo "non-fatal: could not refresh $url"
             done
-          done < <(printf '%s\n' go.mod && git ls-files '**/go.mod')
+          done < <(publishable_modfiles | sort -u)

--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -1,11 +1,102 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "go",
+  "plugins": [
+    {
+      "type": "linked-versions",
+      "groupName": "happycontext",
+      "components": [
+        "happycontext",
+        "adapter/slog",
+        "adapter/zap",
+        "adapter/zerolog",
+        "integration/echo",
+        "integration/fiber",
+        "integration/fiberv3",
+        "integration/gin",
+        "integration/std"
+      ]
+    }
+  ],
   "packages": {
     ".": {
-      "package-name": "happycontext",
+      "component": "happycontext",
+      "package-name": "github.com/happytoolin/happycontext",
+      "include-component-in-tag": false,
       "include-v-in-tag": true,
       "changelog-path": "CHANGELOG.md"
+    },
+    "adapter/slog": {
+      "component": "adapter/slog",
+      "package-name": "github.com/happytoolin/happycontext/adapter/slog",
+      "tag-separator": "/",
+      "skip-changelog": true,
+      "extra-files": [
+        "go.mod"
+      ]
+    },
+    "adapter/zap": {
+      "component": "adapter/zap",
+      "package-name": "github.com/happytoolin/happycontext/adapter/zap",
+      "tag-separator": "/",
+      "skip-changelog": true,
+      "extra-files": [
+        "go.mod"
+      ]
+    },
+    "adapter/zerolog": {
+      "component": "adapter/zerolog",
+      "package-name": "github.com/happytoolin/happycontext/adapter/zerolog",
+      "tag-separator": "/",
+      "skip-changelog": true,
+      "extra-files": [
+        "go.mod"
+      ]
+    },
+    "integration/echo": {
+      "component": "integration/echo",
+      "package-name": "github.com/happytoolin/happycontext/integration/echo",
+      "tag-separator": "/",
+      "skip-changelog": true,
+      "extra-files": [
+        "go.mod"
+      ]
+    },
+    "integration/fiber": {
+      "component": "integration/fiber",
+      "package-name": "github.com/happytoolin/happycontext/integration/fiber",
+      "tag-separator": "/",
+      "skip-changelog": true,
+      "extra-files": [
+        "go.mod"
+      ]
+    },
+    "integration/fiberv3": {
+      "component": "integration/fiberv3",
+      "package-name": "github.com/happytoolin/happycontext/integration/fiberv3",
+      "tag-separator": "/",
+      "skip-changelog": true,
+      "extra-files": [
+        "go.mod"
+      ]
+    },
+    "integration/gin": {
+      "component": "integration/gin",
+      "package-name": "github.com/happytoolin/happycontext/integration/gin",
+      "tag-separator": "/",
+      "skip-changelog": true,
+      "extra-files": [
+        "go.mod"
+      ]
+    },
+    "integration/std": {
+      "component": "integration/std",
+      "package-name": "github.com/happytoolin/happycontext/integration/std",
+      "tag-separator": "/",
+      "skip-changelog": true,
+      "extra-files": [
+        "go.mod"
+      ]
     }
   }
 }

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,3 +1,11 @@
 {
-  ".": "0.2.0"
+  ".": "0.2.0",
+  "adapter/slog": "0.2.0",
+  "adapter/zap": "0.2.0",
+  "adapter/zerolog": "0.2.0",
+  "integration/echo": "0.2.0",
+  "integration/fiber": "0.2.0",
+  "integration/fiberv3": "0.2.0",
+  "integration/gin": "0.2.0",
+  "integration/std": "0.2.0"
 }

--- a/README.md
+++ b/README.md
@@ -476,6 +476,20 @@ go run ./sampling-custom
 - CI: `.github/workflows/ci.yml`
 - Release automation: `.github/workflows/release.yml`
 - Go proxy sync: `.github/workflows/go-proxy-sync.yml`
+- Root module releases must be tagged as `vX.Y.Z`.
+- Nested Go modules must be tagged as `<subdir>/vX.Y.Z` so `go list -m -versions` can discover them.
+- To backfill historical tags created with the old `happycontext-vX.Y.Z` format, run `./scripts/backfill-go-tags.sh` and push the generated tags.
+
+Published nested modules:
+
+- `adapter/slog`
+- `adapter/zap`
+- `adapter/zerolog`
+- `integration/echo`
+- `integration/fiber`
+- `integration/fiberv3`
+- `integration/gin`
+- `integration/std`
 
 ## References
 

--- a/adapter/slog/go.mod
+++ b/adapter/slog/go.mod
@@ -2,6 +2,6 @@ module github.com/happytoolin/happycontext/adapter/slog
 
 go 1.24
 
-require github.com/happytoolin/happycontext v0.0.0
+require github.com/happytoolin/happycontext v0.0.0 // x-release-please-version
 
 replace github.com/happytoolin/happycontext => ../../

--- a/adapter/zap/go.mod
+++ b/adapter/zap/go.mod
@@ -3,7 +3,7 @@ module github.com/happytoolin/happycontext/adapter/zap
 go 1.24
 
 require (
-	github.com/happytoolin/happycontext v0.0.0
+	github.com/happytoolin/happycontext v0.0.0 // x-release-please-version
 	go.uber.org/zap v1.27.1
 )
 

--- a/adapter/zerolog/go.mod
+++ b/adapter/zerolog/go.mod
@@ -3,7 +3,7 @@ module github.com/happytoolin/happycontext/adapter/zerolog
 go 1.24.0
 
 require (
-	github.com/happytoolin/happycontext v0.0.0
+	github.com/happytoolin/happycontext v0.0.0 // x-release-please-version
 	github.com/rs/zerolog v1.34.0
 )
 

--- a/integration/echo/go.mod
+++ b/integration/echo/go.mod
@@ -3,7 +3,7 @@ module github.com/happytoolin/happycontext/integration/echo
 go 1.24.0
 
 require (
-	github.com/happytoolin/happycontext v0.0.0
+	github.com/happytoolin/happycontext v0.0.0 // x-release-please-version
 	github.com/labstack/echo/v4 v4.15.0
 )
 

--- a/integration/fiber/go.mod
+++ b/integration/fiber/go.mod
@@ -4,7 +4,7 @@ go 1.24.0
 
 require (
 	github.com/gofiber/fiber/v2 v2.52.11
-	github.com/happytoolin/happycontext v0.0.0
+	github.com/happytoolin/happycontext v0.0.0 // x-release-please-version
 )
 
 require (

--- a/integration/fiberv3/go.mod
+++ b/integration/fiberv3/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/gofiber/fiber/v3 v3.0.0-rc.3
-	github.com/happytoolin/happycontext v0.0.0
+	github.com/happytoolin/happycontext v0.0.0 // x-release-please-version
 )
 
 require (

--- a/integration/gin/go.mod
+++ b/integration/gin/go.mod
@@ -4,7 +4,7 @@ go 1.24.0
 
 require (
 	github.com/gin-gonic/gin v1.11.0
-	github.com/happytoolin/happycontext v0.0.0
+	github.com/happytoolin/happycontext v0.0.0 // x-release-please-version
 )
 
 require (

--- a/integration/std/go.mod
+++ b/integration/std/go.mod
@@ -2,7 +2,7 @@ module github.com/happytoolin/happycontext/integration/std
 
 go 1.24
 
-require github.com/happytoolin/happycontext v0.0.0
+require github.com/happytoolin/happycontext v0.0.0 // x-release-please-version
 
 require github.com/felixge/httpsnoop v1.0.4
 

--- a/scripts/backfill-go-tags.sh
+++ b/scripts/backfill-go-tags.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: ./scripts/backfill-go-tags.sh [--push] [--remote <name>] [version ...]
+
+Creates the Go-compatible tags that should exist alongside legacy
+happycontext-vX.Y.Z tags:
+
+  vX.Y.Z
+  adapter/slog/vX.Y.Z
+  adapter/zap/vX.Y.Z
+  adapter/zerolog/vX.Y.Z
+  integration/echo/vX.Y.Z
+  integration/fiber/vX.Y.Z
+  integration/fiberv3/vX.Y.Z
+  integration/gin/vX.Y.Z
+  integration/std/vX.Y.Z
+
+Examples:
+  ./scripts/backfill-go-tags.sh
+  ./scripts/backfill-go-tags.sh v0.2.0
+  ./scripts/backfill-go-tags.sh happycontext-v0.2.0 --push
+EOF
+}
+
+remote=origin
+push_tags=false
+declare -a requested_versions=()
+declare -a module_paths=()
+
+while (($# > 0)); do
+  case "$1" in
+    --push)
+      push_tags=true
+      shift
+      ;;
+    --remote)
+      if (($# < 2)); then
+        echo "--remote requires a value" >&2
+        exit 1
+      fi
+      remote="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      requested_versions+=("$1")
+      shift
+      ;;
+  esac
+done
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+map_legacy_tag() {
+  local value="$1"
+  if [[ "$value" == happycontext-v* ]]; then
+    printf '%s\n' "$value"
+    return
+  fi
+  if [[ "$value" == v* ]]; then
+    printf 'happycontext-%s\n' "$value"
+    return
+  fi
+  printf 'happycontext-v%s\n' "$value"
+}
+
+publishable_modules() {
+  git ls-files 'adapter/*/go.mod' 'integration/*/go.mod' | sed 's#/go\.mod$##' | sort
+}
+
+declare -a legacy_tags=()
+
+if ((${#requested_versions[@]} > 0)); then
+  for version in "${requested_versions[@]}"; do
+    legacy_tag="$(map_legacy_tag "$version")"
+    if ! git rev-parse -q --verify "refs/tags/$legacy_tag" >/dev/null; then
+      echo "missing legacy tag: $legacy_tag" >&2
+      exit 1
+    fi
+    legacy_tags+=("$legacy_tag")
+  done
+else
+  while IFS= read -r tag; do
+    legacy_tags+=("$tag")
+  done < <(git tag --list 'happycontext-v*' | sort -V)
+fi
+
+if ((${#legacy_tags[@]} == 0)); then
+  echo "no legacy happycontext-v* tags found"
+  exit 0
+fi
+
+declare -a created_tags=()
+
+create_tag_if_missing() {
+  local tag_name="$1"
+  local target="$2"
+  local message="$3"
+
+  if git rev-parse -q --verify "refs/tags/$tag_name" >/dev/null; then
+    echo "exists: $tag_name"
+    return
+  fi
+
+  git tag -a "$tag_name" "$target" -m "$message"
+  created_tags+=("$tag_name")
+  echo "created: $tag_name -> $target"
+}
+
+while IFS= read -r module_path; do
+  module_paths+=("$module_path")
+done < <(publishable_modules)
+
+for legacy_tag in "${legacy_tags[@]}"; do
+  version="${legacy_tag#happycontext-}"
+  target="$(git rev-list -n1 "$legacy_tag")"
+
+  create_tag_if_missing "$version" "$target" "Release $version"
+
+  for module_path in "${module_paths[@]}"; do
+    if git cat-file -e "$target:$module_path/go.mod" 2>/dev/null; then
+      create_tag_if_missing \
+        "$module_path/$version" \
+        "$target" \
+        "Release $module_path/$version"
+    fi
+  done
+done
+
+if ((${#created_tags[@]} == 0)); then
+  echo "no tags created"
+  exit 0
+fi
+
+if [[ "$push_tags" == true ]]; then
+  git push "$remote" "${created_tags[@]}"
+fi


### PR DESCRIPTION
This fixes the repository release flow so Go can discover root and submodule versions correctly.\n\nIt also adds a backfill helper for the previously mis-tagged releases.\n\nThis commit includes a Release-As footer so merging it should cause Release Please to open the v0.2.1 release PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated release process documentation with tag format requirements for root and nested module releases.

* **Chores**
  * Configured support for publishing multiple adapter and integration modules as independent packages.
  * Added utility script for backfilling historical release tags from legacy tag format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->