### PR TITLE
perf: reduce hot-path allocations in core, slog adapter, and middleware

### DIFF
--- a/adapter/slog/sink.go
+++ b/adapter/slog/sink.go
@@ -9,8 +9,6 @@ import (
 	"github.com/happytoolin/happycontext"
 )
 
-// ponytail: retain buffers through the tested 100-field case; raise the limit
-// only if larger events are common enough to justify the retained memory.
 const (
 	slogPoolCapacity    = 32
 	slogPoolMaxCapacity = 160

--- a/adapter/slog/sink.go
+++ b/adapter/slog/sink.go
@@ -9,9 +9,9 @@ import (
 	"github.com/happytoolin/happycontext"
 )
 
-var slogAnyPool = sync.Pool{
+var slogAttrPool = sync.Pool{
 	New: func() any {
-		buf := make([]any, 0, 32)
+		buf := make([]slog.Attr, 0, 32)
 		return &buf
 	},
 }
@@ -65,18 +65,18 @@ func (s *Sink) Write(level hc.Level, message string, fields map[string]any) {
 		slogLevel = slog.LevelError
 	}
 
-	bufPtr := slogAnyPool.Get().(*[]any)
+	bufPtr := slogAttrPool.Get().(*[]slog.Attr)
 	attrs := (*bufPtr)[:0]
 	defer func() {
 		*bufPtr = attrs[:0]
-		slogAnyPool.Put(bufPtr)
+		slogAttrPool.Put(bufPtr)
 	}()
 
 	if !s.deterministicOrder {
 		for k, v := range fields {
 			attrs = append(attrs, slog.Any(k, v))
 		}
-		s.logger.Log(context.Background(), slogLevel, message, attrs...)
+		s.logger.LogAttrs(context.Background(), slogLevel, message, attrs...)
 		return
 	}
 	keysPtr := slogKeyPool.Get().(*[]string)
@@ -93,7 +93,7 @@ func (s *Sink) Write(level hc.Level, message string, fields map[string]any) {
 	for _, k := range keys {
 		attrs = append(attrs, slog.Any(k, fields[k]))
 	}
-	s.logger.Log(context.Background(), slogLevel, message, attrs...)
+	s.logger.LogAttrs(context.Background(), slogLevel, message, attrs...)
 }
 
 var _ hc.Sink = (*Sink)(nil)

--- a/adapter/slog/sink.go
+++ b/adapter/slog/sink.go
@@ -9,18 +9,34 @@ import (
 	"github.com/happytoolin/happycontext"
 )
 
+// ponytail: retain buffers through the tested 100-field case; raise the limit
+// only if larger events are common enough to justify the retained memory.
+const (
+	slogPoolCapacity    = 32
+	slogPoolMaxCapacity = 160
+)
+
 var slogAttrPool = sync.Pool{
 	New: func() any {
-		buf := make([]slog.Attr, 0, 32)
+		buf := make([]slog.Attr, 0, slogPoolCapacity)
 		return &buf
 	},
 }
 
 var slogKeyPool = sync.Pool{
 	New: func() any {
-		buf := make([]string, 0, 32)
+		buf := make([]string, 0, slogPoolCapacity)
 		return &buf
 	},
+}
+
+func recycleSlice[T any](pool *sync.Pool, bufPtr *[]T, buf []T) {
+	if cap(buf) > slogPoolMaxCapacity {
+		return
+	}
+	clear(buf)
+	*bufPtr = buf[:0]
+	pool.Put(bufPtr)
 }
 
 // SinkOptions controls slog adapter behavior.
@@ -68,8 +84,7 @@ func (s *Sink) Write(level hc.Level, message string, fields map[string]any) {
 	bufPtr := slogAttrPool.Get().(*[]slog.Attr)
 	attrs := (*bufPtr)[:0]
 	defer func() {
-		*bufPtr = attrs[:0]
-		slogAttrPool.Put(bufPtr)
+		recycleSlice(&slogAttrPool, bufPtr, attrs)
 	}()
 
 	if !s.deterministicOrder {
@@ -82,8 +97,7 @@ func (s *Sink) Write(level hc.Level, message string, fields map[string]any) {
 	keysPtr := slogKeyPool.Get().(*[]string)
 	keys := (*keysPtr)[:0]
 	defer func() {
-		*keysPtr = keys[:0]
-		slogKeyPool.Put(keysPtr)
+		recycleSlice(&slogKeyPool, keysPtr, keys)
 	}()
 	for k := range fields {
 		keys = append(keys, k)

--- a/adapter/slog/sink_concurrency_test.go
+++ b/adapter/slog/sink_concurrency_test.go
@@ -1,0 +1,191 @@
+package slogadapter
+
+import (
+	"context"
+	"log/slog"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/happytoolin/happycontext"
+)
+
+// retainingHandler keeps every record it receives (deliberately without
+// cloning) and the test validates them only after Write has returned, so any
+// aliasing of the sink's pooled buffers shows up as corrupted or
+// cross-contaminated attributes.
+type retainingHandler struct {
+	mu      sync.Mutex
+	records []slog.Record
+}
+
+func (h *retainingHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h *retainingHandler) Handle(_ context.Context, r slog.Record) error {
+	h.mu.Lock()
+	h.records = append(h.records, r)
+	h.mu.Unlock()
+	return nil
+}
+
+func (h *retainingHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h *retainingHandler) WithGroup(string) slog.Handler      { return h }
+
+func TestSinkPooledAttrsSurviveRetainingHandler(t *testing.T) {
+	h := &retainingHandler{}
+	sink := New(slog.New(h))
+
+	fields := map[string]any{"a": 1, "b": "two", "c": true}
+	for i := 0; i < 100; i++ {
+		sink.Write(hc.LevelInfo, "m", fields)
+	}
+
+	if len(h.records) != 100 {
+		t.Fatalf("got %d records, want 100", len(h.records))
+	}
+	for i, r := range h.records {
+		if r.Message != "m" {
+			t.Fatalf("record %d: message = %q", i, r.Message)
+		}
+		count := 0
+		r.Attrs(func(a slog.Attr) bool {
+			count++
+			switch a.Key {
+			case "a":
+				if a.Value.Int64() != 1 {
+					t.Fatalf("record %d: a = %v", i, a.Value)
+				}
+			case "b":
+				if a.Value.String() != "two" {
+					t.Fatalf("record %d: b = %v", i, a.Value)
+				}
+			case "c":
+				if a.Value.Bool() != true {
+					t.Fatalf("record %d: c = %v", i, a.Value)
+				}
+			default:
+				t.Fatalf("record %d: unexpected attr %q", i, a.Key)
+			}
+			return true
+		})
+		if count != 3 {
+			t.Fatalf("record %d: %d attrs, want 3", i, count)
+		}
+	}
+}
+
+func TestSinkConcurrentWritesLargeMaps(t *testing.T) {
+	h := &retainingHandler{}
+	sink := New(slog.New(h))
+	sinkDeterministic := NewWithOptions(slog.New(h), SinkOptions{DeterministicOrder: true})
+
+	// 100 fields exceeds the pooled buffer capacity (32) and forces growth;
+	// grown buffers must be returned to the pool without corrupting reuse.
+	bigFields := func(tag string) map[string]any {
+		m := make(map[string]any, 100)
+		for i := 0; i < 100; i++ {
+			m["k"+strconv.Itoa(i)] = tag + ":" + strconv.Itoa(i)
+		}
+		return m
+	}
+
+	const writers = 8
+	const writes = 50
+
+	var wg sync.WaitGroup
+	for w := 0; w < writers; w++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			tag := "w" + strconv.Itoa(w)
+			for i := 0; i < writes; i++ {
+				sink.Write(hc.LevelInfo, tag, bigFields(tag))
+				sinkDeterministic.Write(hc.LevelInfo, tag, bigFields(tag))
+			}
+		}(w)
+	}
+	wg.Wait()
+
+	total := writers * writes * 2
+	if len(h.records) != total {
+		t.Fatalf("got %d records, want %d", len(h.records), total)
+	}
+	for i, r := range h.records {
+		if len(r.Message) == 0 || !strings.HasPrefix(r.Message, "w") {
+			t.Fatalf("record %d: corrupted message %q", i, r.Message)
+		}
+		tag := r.Message
+		count := 0
+		r.Attrs(func(a slog.Attr) bool {
+			want := tag + ":" + strings.TrimPrefix(a.Key, "k")
+			if a.Value.String() != want {
+				t.Fatalf("record %d (%s): attr %s = %q, want %q (cross-writer contamination)",
+					i, tag, a.Key, a.Value.String(), want)
+			}
+			count++
+			return true
+		})
+		if count != 100 {
+			t.Fatalf("record %d: %d attrs, want 100", i, count)
+		}
+	}
+}
+
+func TestSinkNilFieldsAndOddValues(t *testing.T) {
+	h := &retainingHandler{}
+	sink := New(slog.New(h))
+
+	sink.Write(hc.LevelInfo, "nil_fields", nil)
+	sink.Write(hc.LevelInfo, "nil_value", map[string]any{"x": nil})
+	sink.Write(hc.LevelInfo, "", map[string]any{"empty_msg": 1})
+
+	if len(h.records) != 3 {
+		t.Fatalf("got %d records, want 3", len(h.records))
+	}
+	if r := h.records[0]; r.Message != "nil_fields" {
+		t.Fatalf("record 0 message = %q", r.Message)
+	}
+	if r := h.records[1]; r.NumAttrs() != 1 {
+		t.Fatalf("record 1: %d attrs, want 1", r.NumAttrs())
+	}
+	if r := h.records[2]; r.Message != hc.DefaultMessage {
+		t.Fatalf("empty message should fall back to %q, got %q", hc.DefaultMessage, r.Message)
+	}
+}
+
+// TestSinkRecoverableAfterHandlerPanic verifies the pool is returned to a
+// consistent state when a handler panics mid-write.
+func TestSinkRecoverableAfterHandlerPanic(t *testing.T) {
+	var calls int
+	boom := slog.New(panicHandler{calls: &calls})
+	sink := New(boom)
+
+	for i := 0; i < 3; i++ {
+		func() {
+			defer func() { _ = recover() }()
+			sink.Write(hc.LevelInfo, "boom", map[string]any{"i": i})
+		}()
+	}
+	if calls != 3 {
+		t.Fatalf("handler called %d times, want 3", calls)
+	}
+
+	// The sink must still work after the panics.
+	h := &retainingHandler{}
+	ok := New(slog.New(h))
+	ok.Write(hc.LevelInfo, "after", map[string]any{"k": "v"})
+	if len(h.records) != 1 || h.records[0].Message != "after" {
+		t.Fatalf("sink unusable after handler panic: %v", h.records)
+	}
+}
+
+type panicHandler struct{ calls *int }
+
+func (p panicHandler) Enabled(context.Context, slog.Level) bool { return true }
+func (p panicHandler) Handle(_ context.Context, _ slog.Record) error {
+	*p.calls++
+	panic("boom")
+}
+func (p panicHandler) WithAttrs([]slog.Attr) slog.Handler { return p }
+func (p panicHandler) WithGroup(string) slog.Handler      { return p }

--- a/adapter/slog/sink_concurrency_test.go
+++ b/adapter/slog/sink_concurrency_test.go
@@ -180,6 +180,39 @@ func TestSinkRecoverableAfterHandlerPanic(t *testing.T) {
 	}
 }
 
+func TestRecycleSliceClearsAndCaps(t *testing.T) {
+	var pool sync.Pool
+
+	small := make([]any, 1, slogPoolCapacity)
+	small[0] = new(int)
+	recycleSlice(&pool, &small, small)
+	if len(small) != 0 || small[:cap(small)][0] != nil {
+		t.Fatalf("small buffer was not cleared and recycled: len=%d first=%v", len(small), small[:cap(small)][0])
+	}
+
+	attrs := make([]slog.Attr, 0, slogPoolCapacity)
+	for range 100 {
+		attrs = append(attrs, slog.Attr{})
+	}
+	if cap(attrs) > slogPoolMaxCapacity {
+		t.Fatalf("100-field buffer exceeds pool limit: cap=%d limit=%d", cap(attrs), slogPoolMaxCapacity)
+	}
+	attrs[0] = slog.Any("retained", new(int))
+	var attrPool sync.Pool
+	recycleSlice(&attrPool, &attrs, attrs)
+	first := attrs[:cap(attrs)][0]
+	if len(attrs) != 0 || first.Key != "" || first.Value.Any() != nil {
+		t.Fatalf("grown attr buffer was not cleared and recycled: len=%d first=%v", len(attrs), first)
+	}
+
+	oversized := make([]any, slogPoolMaxCapacity+1)
+	oversized[0] = new(int)
+	recycleSlice(&pool, &oversized, oversized)
+	if len(oversized) != slogPoolMaxCapacity+1 {
+		t.Fatalf("oversized buffer was retained: len=%d", len(oversized))
+	}
+}
+
 type panicHandler struct{ calls *int }
 
 func (p panicHandler) Enabled(context.Context, slog.Level) bool { return true }

--- a/adapter/slog/sink_concurrency_test.go
+++ b/adapter/slog/sink_concurrency_test.go
@@ -11,10 +11,6 @@ import (
 	"github.com/happytoolin/happycontext"
 )
 
-// retainingHandler keeps every record it receives (deliberately without
-// cloning) and the test validates them only after Write has returned, so any
-// aliasing of the sink's pooled buffers shows up as corrupted or
-// cross-contaminated attributes.
 type retainingHandler struct {
 	mu      sync.Mutex
 	records []slog.Record
@@ -80,8 +76,6 @@ func TestSinkConcurrentWritesLargeMaps(t *testing.T) {
 	sink := New(slog.New(h))
 	sinkDeterministic := NewWithOptions(slog.New(h), SinkOptions{DeterministicOrder: true})
 
-	// 100 fields exceeds the pooled buffer capacity (32) and forces growth;
-	// grown buffers must be returned to the pool without corrupting reuse.
 	bigFields := func(tag string) map[string]any {
 		m := make(map[string]any, 100)
 		for i := 0; i < 100; i++ {
@@ -154,8 +148,6 @@ func TestSinkNilFieldsAndOddValues(t *testing.T) {
 	}
 }
 
-// TestSinkRecoverableAfterHandlerPanic verifies the pool is returned to a
-// consistent state when a handler panics mid-write.
 func TestSinkRecoverableAfterHandlerPanic(t *testing.T) {
 	var calls int
 	boom := slog.New(panicHandler{calls: &calls})
@@ -171,7 +163,6 @@ func TestSinkRecoverableAfterHandlerPanic(t *testing.T) {
 		t.Fatalf("handler called %d times, want 3", calls)
 	}
 
-	// The sink must still work after the panics.
 	h := &retainingHandler{}
 	ok := New(slog.New(h))
 	ok.Write(hc.LevelInfo, "after", map[string]any{"k": "v"})

--- a/adapter/slog/stress_test.go
+++ b/adapter/slog/stress_test.go
@@ -1,0 +1,88 @@
+package slogadapter
+
+import (
+	"io"
+	"log/slog"
+	"strconv"
+	"sync"
+	"testing"
+
+	hc "github.com/happytoolin/happycontext"
+)
+
+// BenchmarkStressParallelWrite drives the pooled attrs path from all cores
+// through a real JSON handler, the closest analogue to production load.
+func BenchmarkStressParallelWrite(b *testing.B) {
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	sink := New(logger)
+	fields := func() map[string]any {
+		m := make(map[string]any, 15)
+		for i := 0; i < 15; i++ {
+			m["k"+strconv.Itoa(i)] = i
+		}
+		m["http.status"] = 200
+		m["feature"] = "checkout"
+		return m
+	}()
+
+	b.ReportAllocs()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			sink.Write(hc.LevelInfo, "request_completed", fields)
+		}
+	})
+}
+
+func BenchmarkStressParallelDeterministic(b *testing.B) {
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	sink := NewWithOptions(logger, SinkOptions{DeterministicOrder: true})
+	fields := func() map[string]any {
+		m := make(map[string]any, 15)
+		for i := 0; i < 15; i++ {
+			m["k"+strconv.Itoa(i)] = i
+		}
+		return m
+	}()
+
+	b.ReportAllocs()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			sink.Write(hc.LevelInfo, "request_completed", fields)
+		}
+	})
+}
+
+// TestStressSlogSustainedCorrectness soaks the sink under sustained parallel
+// load and verifies every record survived intact (retained, not cloned).
+func TestStressSlogSustainedCorrectness(t *testing.T) {
+	h := &retainingHandler{}
+	sink := New(slog.New(h))
+	fields := map[string]any{"a": 1, "b": "two", "c": true, "d": nil}
+
+	const goroutines = 8
+	const writes = 20_000
+
+	var wg sync.WaitGroup
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < writes; i++ {
+				sink.Write(hc.LevelInfo, "stress", fields)
+			}
+		}()
+	}
+	wg.Wait()
+
+	total := goroutines * writes
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if len(h.records) != total {
+		t.Fatalf("retained %d records, want %d", len(h.records), total)
+	}
+	for i, r := range h.records {
+		if r.NumAttrs() != 4 {
+			t.Fatalf("record %d: %d attrs, want 4", i, r.NumAttrs())
+		}
+	}
+}

--- a/adapter/slog/stress_test.go
+++ b/adapter/slog/stress_test.go
@@ -10,8 +10,6 @@ import (
 	hc "github.com/happytoolin/happycontext"
 )
 
-// BenchmarkStressParallelWrite drives the pooled attrs path from all cores
-// through a real JSON handler, the closest analogue to production load.
 func BenchmarkStressParallelWrite(b *testing.B) {
 	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
 	sink := New(logger)
@@ -52,8 +50,6 @@ func BenchmarkStressParallelDeterministic(b *testing.B) {
 	})
 }
 
-// TestStressSlogSustainedCorrectness soaks the sink under sustained parallel
-// load and verifies every record survived intact (retained, not cloned).
 func TestStressSlogSustainedCorrectness(t *testing.T) {
 	h := &retainingHandler{}
 	sink := New(slog.New(h))

--- a/adapter/zap/sink.go
+++ b/adapter/zap/sink.go
@@ -8,8 +8,6 @@ import (
 	"go.uber.org/zap"
 )
 
-// ponytail: retain buffers through the tested 100-field case; raise the limit
-// only if larger events are common enough to justify the retained memory.
 const (
 	zapPoolCapacity    = 32
 	zapPoolMaxCapacity = 160

--- a/adapter/zap/sink.go
+++ b/adapter/zap/sink.go
@@ -8,18 +8,34 @@ import (
 	"go.uber.org/zap"
 )
 
+// ponytail: retain buffers through the tested 100-field case; raise the limit
+// only if larger events are common enough to justify the retained memory.
+const (
+	zapPoolCapacity    = 32
+	zapPoolMaxCapacity = 160
+)
+
 var zapFieldPool = sync.Pool{
 	New: func() any {
-		buf := make([]zap.Field, 0, 32)
+		buf := make([]zap.Field, 0, zapPoolCapacity)
 		return &buf
 	},
 }
 
 var zapKeyPool = sync.Pool{
 	New: func() any {
-		buf := make([]string, 0, 32)
+		buf := make([]string, 0, zapPoolCapacity)
 		return &buf
 	},
+}
+
+func recycleSlice[T any](pool *sync.Pool, bufPtr *[]T, buf []T) {
+	if cap(buf) > zapPoolMaxCapacity {
+		return
+	}
+	clear(buf)
+	*bufPtr = buf[:0]
+	pool.Put(bufPtr)
 }
 
 // SinkOptions controls zap adapter behavior.
@@ -56,8 +72,7 @@ func (z *Sink) Write(level hc.Level, message string, fields map[string]any) {
 	bufPtr := zapFieldPool.Get().(*[]zap.Field)
 	zapFields := (*bufPtr)[:0]
 	defer func() {
-		*bufPtr = zapFields[:0]
-		zapFieldPool.Put(bufPtr)
+		recycleSlice(&zapFieldPool, bufPtr, zapFields)
 	}()
 
 	if !z.deterministicOrder {
@@ -71,8 +86,7 @@ func (z *Sink) Write(level hc.Level, message string, fields map[string]any) {
 	keysPtr := zapKeyPool.Get().(*[]string)
 	keys := (*keysPtr)[:0]
 	defer func() {
-		*keysPtr = keys[:0]
-		zapKeyPool.Put(keysPtr)
+		recycleSlice(&zapKeyPool, keysPtr, keys)
 	}()
 
 	for k := range fields {

--- a/adapter/zap/sink_test.go
+++ b/adapter/zap/sink_test.go
@@ -3,6 +3,7 @@ package zapadapter
 import (
 	"bytes"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/happytoolin/happycontext"
@@ -105,4 +106,34 @@ func TestSinkWriteNilSafety(t *testing.T) {
 
 	sink := New(nil)
 	sink.Write(hc.LevelInfo, "x", map[string]any{"k": 1})
+}
+
+func TestRecycleSliceClearsAndCaps(t *testing.T) {
+	fields := make([]zap.Field, 0, zapPoolCapacity)
+	for range 100 {
+		fields = append(fields, zap.Field{})
+	}
+	if cap(fields) > zapPoolMaxCapacity {
+		t.Fatalf("100-field buffer exceeds pool limit: cap=%d limit=%d", cap(fields), zapPoolMaxCapacity)
+	}
+	fields[0] = zap.Any("retained", new(int))
+	var fieldPool sync.Pool
+	recycleSlice(&fieldPool, &fields, fields)
+	first := fields[:cap(fields)][0]
+	if len(fields) != 0 || first.Key != "" || first.Interface != nil {
+		t.Fatalf("field buffer was not cleared and recycled: len=%d first=%v", len(fields), first)
+	}
+
+	keys := []string{"retained"}
+	var keyPool sync.Pool
+	recycleSlice(&keyPool, &keys, keys)
+	if len(keys) != 0 || keys[:cap(keys)][0] != "" {
+		t.Fatalf("key buffer was not cleared and recycled: len=%d first=%q", len(keys), keys[:cap(keys)][0])
+	}
+
+	oversized := make([]zap.Field, zapPoolMaxCapacity+1)
+	recycleSlice(&fieldPool, &oversized, oversized)
+	if len(oversized) != zapPoolMaxCapacity+1 {
+		t.Fatalf("oversized buffer was retained: len=%d", len(oversized))
+	}
 }

--- a/adapter/zerolog/sink.go
+++ b/adapter/zerolog/sink.go
@@ -9,11 +9,27 @@ import (
 	"github.com/rs/zerolog"
 )
 
+// ponytail: retain buffers through the tested 100-field case; raise the limit
+// only if larger events are common enough to justify the retained memory.
+const (
+	zerologPoolCapacity    = 32
+	zerologPoolMaxCapacity = 160
+)
+
 var zerologKeyPool = sync.Pool{
 	New: func() any {
-		buf := make([]string, 0, 32)
+		buf := make([]string, 0, zerologPoolCapacity)
 		return &buf
 	},
+}
+
+func recycleKeys(bufPtr *[]string, keys []string) {
+	if cap(keys) > zerologPoolMaxCapacity {
+		return
+	}
+	clear(keys)
+	*bufPtr = keys[:0]
+	zerologKeyPool.Put(bufPtr)
 }
 
 // SinkOptions controls zerolog adapter behavior.
@@ -68,8 +84,7 @@ func (z *Sink) Write(level hc.Level, message string, fields map[string]any) {
 	keysPtr := zerologKeyPool.Get().(*[]string)
 	keys := (*keysPtr)[:0]
 	defer func() {
-		*keysPtr = keys[:0]
-		zerologKeyPool.Put(keysPtr)
+		recycleKeys(keysPtr, keys)
 	}()
 
 	for k := range fields {

--- a/adapter/zerolog/sink.go
+++ b/adapter/zerolog/sink.go
@@ -9,8 +9,6 @@ import (
 	"github.com/rs/zerolog"
 )
 
-// ponytail: retain buffers through the tested 100-field case; raise the limit
-// only if larger events are common enough to justify the retained memory.
 const (
 	zerologPoolCapacity    = 32
 	zerologPoolMaxCapacity = 160

--- a/adapter/zerolog/sink_test.go
+++ b/adapter/zerolog/sink_test.go
@@ -147,3 +147,23 @@ func TestSinkWriteNilSafety(t *testing.T) {
 	sink := New(nil)
 	sink.Write(hc.LevelInfo, "x", map[string]any{"k": 1})
 }
+
+func TestRecycleKeysClearsAndCaps(t *testing.T) {
+	keys := make([]string, 0, zerologPoolCapacity)
+	for range 100 {
+		keys = append(keys, "retained")
+	}
+	if cap(keys) > zerologPoolMaxCapacity {
+		t.Fatalf("100-field buffer exceeds pool limit: cap=%d limit=%d", cap(keys), zerologPoolMaxCapacity)
+	}
+	recycleKeys(&keys, keys)
+	if len(keys) != 0 || keys[:cap(keys)][0] != "" {
+		t.Fatalf("key buffer was not cleared and recycled: len=%d first=%q", len(keys), keys[:cap(keys)][0])
+	}
+
+	oversized := make([]string, zerologPoolMaxCapacity+1)
+	recycleKeys(&oversized, oversized)
+	if len(oversized) != zerologPoolMaxCapacity+1 {
+		t.Fatalf("oversized buffer was retained: len=%d", len(oversized))
+	}
+}

--- a/bench/stress_test.go
+++ b/bench/stress_test.go
@@ -42,8 +42,6 @@ func stressPolicyConfig(sink hc.Sink) hc.Config {
 	})
 }
 
-// BenchmarkStressParallelLifecycle runs full operation lifecycles across all
-// cores with a policy-bearing config, the hottest per-request path.
 func BenchmarkStressParallelLifecycle(b *testing.B) {
 	cfg := stressPolicyConfig(discardSink{})
 	b.ReportAllocs()
@@ -62,8 +60,6 @@ func BenchmarkStressParallelLifecycle(b *testing.B) {
 	})
 }
 
-// BenchmarkStressSustainedLifecycle measures single-goroutine sustained
-// throughput; run with a long -benchtime for soak-style measurement.
 func BenchmarkStressSustainedLifecycle(b *testing.B) {
 	cfg := stressPolicyConfig(discardSink{})
 	b.ReportAllocs()
@@ -80,8 +76,6 @@ func BenchmarkStressSustainedLifecycle(b *testing.B) {
 	}
 }
 
-// BenchmarkStressParallelStdMiddleware drives the std HTTP middleware (no
-// network) from all cores.
 func BenchmarkStressParallelStdMiddleware(b *testing.B) {
 	cfg := stressPolicyConfig(discardSink{})
 	handler := stdhc.Middleware(cfg)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -98,8 +92,6 @@ func BenchmarkStressParallelStdMiddleware(b *testing.B) {
 	})
 }
 
-// nopResponseWriter is a minimal http.ResponseWriter; the middleware only
-// records the status code and never touches the header map in this path.
 type nopResponseWriter struct{}
 
 func (nopResponseWriter) Header() http.Header       { return nopHeader }
@@ -108,9 +100,6 @@ func (nopResponseWriter) WriteHeader(int)             {}
 
 var nopHeader = http.Header{}
 
-// TestStressHeapStable runs millions of operation lifecycles and verifies the
-// heap returns to its baseline size afterwards: nothing per-event may be
-// retained.
 func TestStressHeapStable(t *testing.T) {
 	cfg := stressPolicyConfig(discardSink{})
 
@@ -150,10 +139,6 @@ func TestStressHeapStable(t *testing.T) {
 	t.Logf("heap growth after %d ops: %d bytes (%.2f bytes/op)", ops, grew, float64(grew)/ops)
 }
 
-// TestStressConcurrentMixedAccess hammers the event API from many goroutines:
-// a shared event for the Add/Set* storm, and per-goroutine operation finishes
-// sharing one config (the sharing fast path must be race-free read-only).
-// Run with -race.
 func TestStressConcurrentMixedAccess(t *testing.T) {
 	cfg := stressPolicyConfig(discardSink{})
 	sharedCtx, _ := hc.NewContext(context.Background())
@@ -167,14 +152,12 @@ func TestStressConcurrentMixedAccess(t *testing.T) {
 		go func(g int) {
 			defer wg.Done()
 			for i := 0; i < iterations; i++ {
-				// Storm the shared event.
 				hc.Add(sharedCtx, "g", g, "i", i, "note", "x")
 				hc.SetLevel(sharedCtx, hc.LevelWarn)
 				hc.SetMessage(sharedCtx, "mixed")
 				hc.Error(sharedCtx, errors.New("boom"))
 				hc.EventFields(hc.FromContext(sharedCtx))
 
-				// Independent lifecycle against the shared config.
 				var err error
 				op := hc.StartOperation(context.Background(), hc.OperationStart{
 					Domain: hc.DomainJob, Name: "stress", ID: "id", Attempt: 1,
@@ -187,8 +170,6 @@ func TestStressConcurrentMixedAccess(t *testing.T) {
 	wg.Wait()
 }
 
-// TestStressSamplerUnderContention verifies RateSampler stays statistically
-// sound while all cores hammer the shared PRNG state.
 func TestStressSamplerUnderContention(t *testing.T) {
 	sampler := hc.RateSampler(0.5)
 

--- a/bench/stress_test.go
+++ b/bench/stress_test.go
@@ -1,0 +1,221 @@
+package bench_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	hc "github.com/happytoolin/happycontext"
+	stdhc "github.com/happytoolin/happycontext/integration/std"
+)
+
+func stressPolicyConfig(sink hc.Sink) hc.Config {
+	return hc.NormalizeConfig(hc.Config{
+		Sink:         sink,
+		SamplingRate: 1,
+		LevelSamplingRates: map[hc.Level]float64{
+			hc.LevelDebug: 0.1,
+			hc.LevelInfo:  1,
+			hc.LevelWarn:  1,
+			hc.LevelError: 1,
+		},
+		OperationPolicies: map[hc.Domain]hc.OperationPolicy{
+			hc.DomainJob: {
+				SuccessLevel: hc.LevelInfo,
+				FailureLevel: hc.LevelError,
+				PanicLevel:   hc.LevelError,
+				OutcomeLevels: map[hc.Outcome]hc.Level{
+					hc.OutcomeTimeout: hc.LevelWarn,
+				},
+			},
+			hc.DomainHTTP: {
+				SuccessLevel: hc.LevelInfo,
+				FailureLevel: hc.LevelError,
+				PanicLevel:   hc.LevelError,
+			},
+		},
+	})
+}
+
+// BenchmarkStressParallelLifecycle runs full operation lifecycles across all
+// cores with a policy-bearing config, the hottest per-request path.
+func BenchmarkStressParallelLifecycle(b *testing.B) {
+	cfg := stressPolicyConfig(discardSink{})
+	b.ReportAllocs()
+	b.RunParallel(func(pb *testing.PB) {
+		var err error
+		for pb.Next() {
+			op := hc.StartOperation(context.Background(), hc.OperationStart{
+				Domain:  hc.DomainJob,
+				Name:    "cleanup",
+				ID:      "job_1",
+				Attempt: 1,
+			})
+			hc.Add(op.Context(), "worker", "payments", "tenant", "enterprise")
+			op.End(cfg, &err)
+		}
+	})
+}
+
+// BenchmarkStressSustainedLifecycle measures single-goroutine sustained
+// throughput; run with a long -benchtime for soak-style measurement.
+func BenchmarkStressSustainedLifecycle(b *testing.B) {
+	cfg := stressPolicyConfig(discardSink{})
+	b.ReportAllocs()
+	var err error
+	for b.Loop() {
+		op := hc.StartOperation(context.Background(), hc.OperationStart{
+			Domain:  hc.DomainJob,
+			Name:    "cleanup",
+			ID:      "job_1",
+			Attempt: 1,
+		})
+		hc.Add(op.Context(), "worker", "payments", "tenant", "enterprise")
+		op.End(cfg, &err)
+	}
+}
+
+// BenchmarkStressParallelStdMiddleware drives the std HTTP middleware (no
+// network) from all cores.
+func BenchmarkStressParallelStdMiddleware(b *testing.B) {
+	cfg := stressPolicyConfig(discardSink{})
+	handler := stdhc.Middleware(cfg)(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	req := httptest.NewRequest(http.MethodGet, "/orders", nil)
+
+	b.ReportAllocs()
+	b.RunParallel(func(pb *testing.PB) {
+		rw := nopResponseWriter{}
+		for pb.Next() {
+			handler.ServeHTTP(rw, req)
+		}
+	})
+}
+
+// nopResponseWriter is a minimal http.ResponseWriter; the middleware only
+// records the status code and never touches the header map in this path.
+type nopResponseWriter struct{}
+
+func (nopResponseWriter) Header() http.Header       { return nopHeader }
+func (nopResponseWriter) Write(p []byte) (int, error) { return len(p), nil }
+func (nopResponseWriter) WriteHeader(int)             {}
+
+var nopHeader = http.Header{}
+
+// TestStressHeapStable runs millions of operation lifecycles and verifies the
+// heap returns to its baseline size afterwards: nothing per-event may be
+// retained.
+func TestStressHeapStable(t *testing.T) {
+	cfg := stressPolicyConfig(discardSink{})
+
+	// Warm up pools/maps so their one-time growth does not count as a leak.
+	var err error
+	for i := 0; i < 100_000; i++ {
+		op := hc.StartOperation(context.Background(), hc.OperationStart{Domain: hc.DomainJob, Name: "warmup"})
+		op.End(cfg, &err)
+	}
+
+	runtime.GC()
+	runtime.GC()
+	var before runtime.MemStats
+	runtime.ReadMemStats(&before)
+
+	const ops = 2_000_000
+	for i := 0; i < ops; i++ {
+		op := hc.StartOperation(context.Background(), hc.OperationStart{
+			Domain:  hc.DomainJob,
+			Name:    "cleanup",
+			ID:      "job_1",
+			Attempt: 1,
+		})
+		hc.Add(op.Context(), "worker", "payments")
+		op.End(cfg, &err)
+	}
+
+	runtime.GC()
+	runtime.GC()
+	var after runtime.MemStats
+	runtime.ReadMemStats(&after)
+
+	grew := int64(after.HeapInuse) - int64(before.HeapInuse)
+	if grew > 32<<20 {
+		t.Fatalf("heap grew by %d bytes after %d ops; suspected retention", grew, ops)
+	}
+	t.Logf("heap growth after %d ops: %d bytes (%.2f bytes/op)", ops, grew, float64(grew)/ops)
+}
+
+// TestStressConcurrentMixedAccess hammers the event API from many goroutines:
+// a shared event for the Add/Set* storm, and per-goroutine operation finishes
+// sharing one config (the sharing fast path must be race-free read-only).
+// Run with -race.
+func TestStressConcurrentMixedAccess(t *testing.T) {
+	cfg := stressPolicyConfig(discardSink{})
+	sharedCtx, _ := hc.NewContext(context.Background())
+
+	const goroutines = 32
+	const iterations = 20_000
+
+	var wg sync.WaitGroup
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				// Storm the shared event.
+				hc.Add(sharedCtx, "g", g, "i", i, "note", "x")
+				hc.SetLevel(sharedCtx, hc.LevelWarn)
+				hc.SetMessage(sharedCtx, "mixed")
+				hc.Error(sharedCtx, errors.New("boom"))
+				hc.EventFields(hc.FromContext(sharedCtx))
+
+				// Independent lifecycle against the shared config.
+				var err error
+				op := hc.StartOperation(context.Background(), hc.OperationStart{
+					Domain: hc.DomainJob, Name: "stress", ID: "id", Attempt: 1,
+				})
+				hc.Add(op.Context(), "worker", "payments")
+				op.End(cfg, &err)
+			}
+		}(g)
+	}
+	wg.Wait()
+}
+
+// TestStressSamplerUnderContention verifies RateSampler stays statistically
+// sound while all cores hammer the shared PRNG state.
+func TestStressSamplerUnderContention(t *testing.T) {
+	sampler := hc.RateSampler(0.5)
+
+	const goroutines = 16
+	const iterations = 100_000
+
+	var kept atomic.Int64
+	var wg sync.WaitGroup
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			local := int64(0)
+			for i := 0; i < iterations; i++ {
+				if sampler(hc.SampleInput{Outcome: hc.OutcomeSuccess}) {
+					local++
+				}
+			}
+			kept.Add(local)
+		}()
+	}
+	wg.Wait()
+
+	total := int64(goroutines * iterations)
+	ratio := float64(kept.Load()) / float64(total)
+	if ratio < 0.45 || ratio > 0.55 {
+		t.Fatalf("sampled ratio = %.4f, want within [0.45, 0.55]", ratio)
+	}
+	t.Logf("kept %d/%d = %.4f", kept.Load(), total, ratio)
+}

--- a/config.go
+++ b/config.go
@@ -1,10 +1,41 @@
 package hc
 
+import "maps"
+
 // NormalizeConfig clamps config values and normalizes policy maps.
+//
+// The returned config shares no mutable state with cfg: mutating cfg or its
+// maps afterwards never affects the normalized result.
 func NormalizeConfig(cfg Config) Config {
+	cfg = normalizeConfigShared(cfg)
+
+	if cfg.LevelSamplingRates != nil {
+		cfg.LevelSamplingRates = maps.Clone(cfg.LevelSamplingRates)
+	}
+	if cfg.OperationPolicies != nil {
+		policies := make(map[Domain]OperationPolicy, len(cfg.OperationPolicies))
+		for domain, policy := range cfg.OperationPolicies {
+			if policy.OutcomeLevels != nil {
+				policy.OutcomeLevels = maps.Clone(policy.OutcomeLevels)
+			}
+			if policy.SamplingRate != nil {
+				rate := *policy.SamplingRate
+				policy.SamplingRate = &rate
+			}
+			policies[domain] = policy
+		}
+		cfg.OperationPolicies = policies
+	}
+	return cfg
+}
+
+// normalizeConfigShared normalizes like NormalizeConfig but may share maps
+// with cfg when they are already normalized. It is safe for internal
+// per-request use, where the config is trusted to be read-only.
+func normalizeConfigShared(cfg Config) Config {
 	cfg.SamplingRate = clampRate(cfg.SamplingRate)
 
-	if len(cfg.LevelSamplingRates) > 0 {
+	if len(cfg.LevelSamplingRates) > 0 && levelRatesNeedNormalization(cfg.LevelSamplingRates) {
 		clamped := make(map[Level]float64, len(cfg.LevelSamplingRates))
 		for level, rate := range cfg.LevelSamplingRates {
 			if !IsValidLevel(level) {
@@ -15,7 +46,7 @@ func NormalizeConfig(cfg Config) Config {
 		cfg.LevelSamplingRates = clamped
 	}
 
-	if len(cfg.OperationPolicies) > 0 {
+	if len(cfg.OperationPolicies) > 0 && operationPoliciesNeedNormalization(cfg.OperationPolicies) {
 		normalized := make(map[Domain]OperationPolicy, len(cfg.OperationPolicies))
 		for domain, policy := range cfg.OperationPolicies {
 			if domain == "" {
@@ -32,6 +63,42 @@ func NormalizeConfig(cfg Config) Config {
 	}
 
 	return cfg
+}
+
+func levelRatesNeedNormalization(rates map[Level]float64) bool {
+	for level, rate := range rates {
+		if !IsValidLevel(level) || rate < 0 || rate > 1 {
+			return true
+		}
+	}
+	return false
+}
+
+func operationPoliciesNeedNormalization(policies map[Domain]OperationPolicy) bool {
+	for domain, policy := range policies {
+		if domain == "" {
+			return true
+		}
+		if operationPolicyNeedsNormalization(policy) {
+			return true
+		}
+	}
+	return false
+}
+
+func operationPolicyNeedsNormalization(policy OperationPolicy) bool {
+	if !IsValidLevel(policy.SuccessLevel) || !IsValidLevel(policy.FailureLevel) || !IsValidLevel(policy.PanicLevel) {
+		return true
+	}
+	for outcome, level := range policy.OutcomeLevels {
+		if !IsValidOutcome(outcome) || !IsValidLevel(level) {
+			return true
+		}
+	}
+	if policy.SamplingRate != nil && (*policy.SamplingRate < 0 || *policy.SamplingRate > 1) {
+		return true
+	}
+	return false
 }
 
 func normalizeOperationPolicy(policy OperationPolicy) OperationPolicy {

--- a/config_bench_test.go
+++ b/config_bench_test.go
@@ -1,0 +1,48 @@
+package hc
+
+import (
+	"context"
+	"testing"
+)
+
+type benchDiscardSink struct{}
+
+func (benchDiscardSink) Write(Level, string, map[string]any) {}
+
+// BenchmarkFinishOperationWithPolicies exercises the per-request finish path
+// with a config carrying policies and level sampling rates, normalized once
+// up front the way middleware constructors do.
+func BenchmarkFinishOperationWithPolicies(b *testing.B) {
+	cfg := NormalizeConfig(Config{
+		Sink:         benchDiscardSink{},
+		SamplingRate: 1,
+		LevelSamplingRates: map[Level]float64{
+			LevelDebug: 0.1,
+			LevelInfo:  1,
+			LevelWarn:  1,
+			LevelError: 1,
+		},
+		OperationPolicies: map[Domain]OperationPolicy{
+			DomainJob: {
+				SuccessLevel: LevelInfo,
+				FailureLevel: LevelError,
+				PanicLevel:   LevelError,
+				OutcomeLevels: map[Outcome]Level{
+					OutcomeTimeout: LevelWarn,
+				},
+			},
+		},
+	})
+
+	b.ReportAllocs()
+	for b.Loop() {
+		op := StartOperation(context.Background(), OperationStart{
+			Domain:  DomainJob,
+			Name:    "cleanup",
+			ID:      "job_1",
+			Attempt: 1,
+		})
+		var err error
+		op.End(cfg, &err)
+	}
+}

--- a/config_bench_test.go
+++ b/config_bench_test.go
@@ -9,9 +9,6 @@ type benchDiscardSink struct{}
 
 func (benchDiscardSink) Write(Level, string, map[string]any) {}
 
-// BenchmarkFinishOperationWithPolicies exercises the per-request finish path
-// with a config carrying policies and level sampling rates, normalized once
-// up front the way middleware constructors do.
 func BenchmarkFinishOperationWithPolicies(b *testing.B) {
 	cfg := NormalizeConfig(Config{
 		Sink:         benchDiscardSink{},

--- a/config_equivalence_test.go
+++ b/config_equivalence_test.go
@@ -275,9 +275,6 @@ func TestNormalizeConfigRandomizedMatchesReference(t *testing.T) {
 	}
 }
 
-// TestNormalizeConfigIsolatesCallerMaps pins the historical contract that the
-// returned config shares no mutable state with the caller's input: mutating
-// the input after normalization must not affect the normalized result.
 func TestNormalizeConfigIsolatesCallerMaps(t *testing.T) {
 	rate := 0.5
 	rates := map[Level]float64{LevelInfo: 0.5}

--- a/config_equivalence_test.go
+++ b/config_equivalence_test.go
@@ -1,0 +1,325 @@
+package hc
+
+import (
+	"math"
+	"math/rand"
+	"testing"
+)
+
+// referenceNormalizeConfig is the pre-fast-path implementation, kept verbatim
+// as an oracle: NormalizeConfig must produce identical output for every input.
+func referenceNormalizeConfig(cfg Config) Config {
+	cfg.SamplingRate = clampRate(cfg.SamplingRate)
+
+	if len(cfg.LevelSamplingRates) > 0 {
+		clamped := make(map[Level]float64, len(cfg.LevelSamplingRates))
+		for level, rate := range cfg.LevelSamplingRates {
+			if !IsValidLevel(level) {
+				continue
+			}
+			clamped[level] = clampRate(rate)
+		}
+		cfg.LevelSamplingRates = clamped
+	}
+
+	if len(cfg.OperationPolicies) > 0 {
+		normalized := make(map[Domain]OperationPolicy, len(cfg.OperationPolicies))
+		for domain, policy := range cfg.OperationPolicies {
+			if domain == "" {
+				continue
+			}
+			normalized[domain] = referenceNormalizeOperationPolicy(policy)
+		}
+		if aliasPolicy, ok := cfg.OperationPolicies[""]; ok {
+			if _, exists := normalized[defaultDomainValue]; !exists {
+				normalized[defaultDomainValue] = referenceNormalizeOperationPolicy(aliasPolicy)
+			}
+		}
+		cfg.OperationPolicies = normalized
+	}
+
+	return cfg
+}
+
+func referenceNormalizeOperationPolicy(policy OperationPolicy) OperationPolicy {
+	if !IsValidLevel(policy.SuccessLevel) {
+		policy.SuccessLevel = LevelInfo
+	}
+	if !IsValidLevel(policy.FailureLevel) {
+		policy.FailureLevel = LevelError
+	}
+	if !IsValidLevel(policy.PanicLevel) {
+		policy.PanicLevel = LevelError
+	}
+
+	if len(policy.OutcomeLevels) > 0 {
+		outcomeLevels := make(map[Outcome]Level, len(policy.OutcomeLevels))
+		for outcome, level := range policy.OutcomeLevels {
+			if !IsValidOutcome(outcome) || !IsValidLevel(level) {
+				continue
+			}
+			outcomeLevels[outcome] = level
+		}
+		policy.OutcomeLevels = outcomeLevels
+	}
+
+	if policy.SamplingRate != nil {
+		rate := clampRate(*policy.SamplingRate)
+		policy.SamplingRate = &rate
+	}
+
+	return policy
+}
+
+func nastyConfigs() []Config {
+	rateOutOfRange := 2.5
+	rateNaN := math.NaN()
+	rateNegInf := math.Inf(-1)
+	ratePosInf := math.Inf(1)
+	rateFine := 0.5
+
+	return []Config{
+		{}, // zero config
+		{SamplingRate: math.NaN()},
+		{SamplingRate: math.Inf(1)},
+		{SamplingRate: math.Inf(-1)},
+		{SamplingRate: -0.0},
+		{LevelSamplingRates: map[Level]float64{}}, // non-nil, empty
+		{LevelSamplingRates: map[Level]float64{
+			LevelDebug: 1.25,
+			LevelWarn:  -0.5,
+			Level("invalid"): 0.7,
+			LevelError:       math.NaN(),
+			LevelInfo:        math.Inf(1),
+		}},
+		{LevelSamplingRates: map[Level]float64{LevelInfo: 0.5}}, // already valid
+		{OperationPolicies: map[Domain]OperationPolicy{}},       // non-nil, empty
+		{OperationPolicies: map[Domain]OperationPolicy{
+			"": {
+				SuccessLevel: Level("invalid"),
+				FailureLevel: LevelDebug,
+				PanicLevel:   Level("invalid"),
+				OutcomeLevels: map[Outcome]Level{
+					OutcomeRetry:   LevelWarn,
+					Outcome("bad"): LevelError,
+					OutcomeFailure: Level("trace"),
+				},
+				SamplingRate: &rateOutOfRange,
+			},
+		}},
+		{OperationPolicies: map[Domain]OperationPolicy{
+			"api": {SuccessLevel: LevelWarn, FailureLevel: LevelError, PanicLevel: LevelError},
+		}}, // already valid, no alias
+		{OperationPolicies: map[Domain]OperationPolicy{
+			"":    {SuccessLevel: LevelDebug, SamplingRate: &rateFine},
+			"api": {SuccessLevel: LevelWarn, SamplingRate: &rateNaN},
+		}},
+		{OperationPolicies: map[Domain]OperationPolicy{
+			"":                {SuccessLevel: LevelDebug},
+			defaultDomainValue: {SuccessLevel: LevelWarn}, // canonical must beat alias
+		}},
+		{OperationPolicies: map[Domain]OperationPolicy{
+			"api": {
+				SuccessLevel:  LevelDebug,
+				FailureLevel:  LevelWarn,
+				PanicLevel:    LevelError,
+				OutcomeLevels: map[Outcome]Level{OutcomeRetry: LevelWarn},
+				SamplingRate:  &rateNegInf,
+			},
+			"job": {OutcomeLevels: map[Outcome]Level{}}, // empty outcome map
+		}},
+		{OperationPolicies: map[Domain]OperationPolicy{
+			"api": {SamplingRate: &ratePosInf},
+		}},
+		{OperationPolicies: map[Domain]OperationPolicy{
+			"api": {
+				SuccessLevel:  LevelInfo,
+				FailureLevel:  LevelError,
+				PanicLevel:    LevelError,
+				OutcomeLevels: map[Outcome]Level{OutcomeRetry: LevelWarn},
+				SamplingRate:  &rateFine, // fully valid policy
+			},
+		}},
+	}
+}
+
+// configsEqual compares configs structurally. Unlike reflect.DeepEqual it
+// tolerates NaN, and unlike %#v it dereferences sampling-rate pointers
+// instead of comparing their addresses.
+func configsEqual(a, b Config) bool {
+	if !floatEqual(a.SamplingRate, b.SamplingRate) || a.Message != b.Message {
+		return false
+	}
+	if (a.Sink == nil) != (b.Sink == nil) || (a.Sampler == nil) != (b.Sampler == nil) {
+		return false
+	}
+	if len(a.LevelSamplingRates) != len(b.LevelSamplingRates) {
+		return false
+	}
+	for level, ra := range a.LevelSamplingRates {
+		rb, ok := b.LevelSamplingRates[level]
+		if !ok || !floatEqual(ra, rb) {
+			return false
+		}
+	}
+	if len(a.OperationPolicies) != len(b.OperationPolicies) {
+		return false
+	}
+	for domain, pa := range a.OperationPolicies {
+		pb, ok := b.OperationPolicies[domain]
+		if !ok || !policiesEqual(pa, pb) {
+			return false
+		}
+	}
+	return true
+}
+
+func policiesEqual(a, b OperationPolicy) bool {
+	if a.SuccessLevel != b.SuccessLevel || a.FailureLevel != b.FailureLevel || a.PanicLevel != b.PanicLevel {
+		return false
+	}
+	if (a.SamplingRate == nil) != (b.SamplingRate == nil) {
+		return false
+	}
+	if a.SamplingRate != nil && !floatEqual(*a.SamplingRate, *b.SamplingRate) {
+		return false
+	}
+	if len(a.OutcomeLevels) != len(b.OutcomeLevels) {
+		return false
+	}
+	for outcome, la := range a.OutcomeLevels {
+		lb, ok := b.OutcomeLevels[outcome]
+		if !ok || la != lb {
+			return false
+		}
+	}
+	return true
+}
+
+func floatEqual(a, b float64) bool {
+	return a == b || (math.IsNaN(a) && math.IsNaN(b))
+}
+
+func TestNormalizeConfigMatchesReference(t *testing.T) {
+	for i, cfg := range nastyConfigs() {
+		got := NormalizeConfig(cfg)
+		want := referenceNormalizeConfig(cfg)
+		if !configsEqual(got, want) {
+			t.Fatalf("case %d: NormalizeConfig mismatch\ngot:  %#v\nwant: %#v", i, got, want)
+		}
+		if got2 := NormalizeConfig(NormalizeConfig(cfg)); !configsEqual(got2, got) {
+			t.Fatalf("case %d: NormalizeConfig not idempotent\ngot:  %#v\nwant: %#v", i, got2, got)
+		}
+	}
+}
+
+func TestNormalizeConfigRandomizedMatchesReference(t *testing.T) {
+	rng := rand.New(rand.NewSource(1))
+	levels := []Level{"", LevelDebug, LevelInfo, LevelWarn, LevelError, Level("bogus")}
+	outcomes := []Outcome{"", OutcomeSuccess, OutcomeFailure, OutcomePanic, OutcomeCanceled, OutcomeTimeout, OutcomeRetry, Outcome("weird")}
+	rates := []float64{0, 1, -1, 2, 0.5, math.NaN(), math.Inf(1), math.Inf(-1), -0.0, 1e-300}
+	domains := []Domain{"", "http", "job", defaultDomainValue, Domain("")}
+
+	randomLevel := func() Level { return levels[rng.Intn(len(levels))] }
+	hasPtr := rng.Intn(2) == 0
+
+	for i := 0; i < 2000; i++ {
+		cfg := Config{SamplingRate: rates[rng.Intn(len(rates))]}
+
+		if rng.Intn(2) == 0 {
+			m := make(map[Level]float64, rng.Intn(4))
+			for j := 0; j < rng.Intn(4); j++ {
+				m[randomLevel()] = rates[rng.Intn(len(rates))]
+			}
+			if rng.Intn(4) == 0 {
+				m = nil
+			}
+			cfg.LevelSamplingRates = m
+		}
+
+		if rng.Intn(2) == 0 {
+			m := make(map[Domain]OperationPolicy, rng.Intn(3))
+			for j := 0; j < rng.Intn(3); j++ {
+				policy := OperationPolicy{
+					SuccessLevel: randomLevel(),
+					FailureLevel: randomLevel(),
+					PanicLevel:   randomLevel(),
+				}
+				if rng.Intn(2) == 0 {
+					ol := make(map[Outcome]Level, rng.Intn(3))
+					for k := 0; k < rng.Intn(3); k++ {
+						ol[outcomes[rng.Intn(len(outcomes))]] = randomLevel()
+					}
+					policy.OutcomeLevels = ol
+				}
+				if hasPtr && rng.Intn(2) == 0 {
+					r := rates[rng.Intn(len(rates))]
+					policy.SamplingRate = &r
+				}
+				m[domains[rng.Intn(len(domains))]] = policy
+			}
+			if rng.Intn(4) == 0 {
+				m = nil
+			}
+			cfg.OperationPolicies = m
+		}
+
+		got := NormalizeConfig(cfg)
+		want := referenceNormalizeConfig(cfg)
+		if !configsEqual(got, want) {
+			t.Fatalf("iteration %d: mismatch\ncfg:  %#v\ngot:  %#v\nwant: %#v", i, cfg, got, want)
+		}
+	}
+}
+
+// TestNormalizeConfigIsolatesCallerMaps pins the historical contract that the
+// returned config shares no mutable state with the caller's input: mutating
+// the input after normalization must not affect the normalized result.
+func TestNormalizeConfigIsolatesCallerMaps(t *testing.T) {
+	rate := 0.5
+	rates := map[Level]float64{LevelInfo: 0.5}
+	policies := map[Domain]OperationPolicy{
+		"api": {
+			SuccessLevel:  LevelInfo,
+			FailureLevel:  LevelError,
+			PanicLevel:    LevelError,
+			OutcomeLevels: map[Outcome]Level{OutcomeRetry: LevelWarn},
+			SamplingRate:  &rate,
+		},
+	}
+
+	cfg := NormalizeConfig(Config{LevelSamplingRates: rates, OperationPolicies: policies})
+
+	// Caller mutates everything it still holds references to.
+	rates[LevelInfo] = 0.9
+	rates[LevelDebug] = 0.1
+	mutated := policies["api"]
+	mutated.FailureLevel = LevelDebug
+	policies["api"] = mutated
+	policies["extra"] = OperationPolicy{}
+	policies["api"].OutcomeLevels[OutcomeRetry] = LevelError
+	policies["api"].OutcomeLevels[Outcome("new")] = LevelDebug
+	rate = 0.99
+
+	if cfg.LevelSamplingRates[LevelInfo] != 0.5 {
+		t.Fatalf("normalized level rate changed after caller mutation: %v", cfg.LevelSamplingRates[LevelInfo])
+	}
+	if _, ok := cfg.LevelSamplingRates[LevelDebug]; ok {
+		t.Fatal("caller-added level rate leaked into normalized config")
+	}
+	if cfg.OperationPolicies["api"].FailureLevel != LevelError {
+		t.Fatalf("normalized policy mutated via caller map: %v", cfg.OperationPolicies["api"].FailureLevel)
+	}
+	if _, ok := cfg.OperationPolicies["extra"]; ok {
+		t.Fatal("caller-added policy leaked into normalized config")
+	}
+	if cfg.OperationPolicies["api"].OutcomeLevels[OutcomeRetry] != LevelWarn {
+		t.Fatalf("normalized outcome level mutated via caller map: %v", cfg.OperationPolicies["api"].OutcomeLevels[OutcomeRetry])
+	}
+	if len(cfg.OperationPolicies["api"].OutcomeLevels) != 1 {
+		t.Fatalf("caller-added outcome level leaked into normalized config: %d entries", len(cfg.OperationPolicies["api"].OutcomeLevels))
+	}
+	if cfg.OperationPolicies["api"].SamplingRate == nil || *cfg.OperationPolicies["api"].SamplingRate != 0.5 {
+		t.Fatalf("normalized sampling rate changed via caller pointer: %v", cfg.OperationPolicies["api"].SamplingRate)
+	}
+}

--- a/config_equivalence_test.go
+++ b/config_equivalence_test.go
@@ -76,6 +76,7 @@ func nastyConfigs() []Config {
 	rateNaN := math.NaN()
 	rateNegInf := math.Inf(-1)
 	ratePosInf := math.Inf(1)
+	rateNegZero := math.Copysign(0, -1)
 	rateFine := 0.5
 
 	return []Config{
@@ -83,11 +84,11 @@ func nastyConfigs() []Config {
 		{SamplingRate: math.NaN()},
 		{SamplingRate: math.Inf(1)},
 		{SamplingRate: math.Inf(-1)},
-		{SamplingRate: -0.0},
+		{SamplingRate: rateNegZero},
 		{LevelSamplingRates: map[Level]float64{}}, // non-nil, empty
 		{LevelSamplingRates: map[Level]float64{
-			LevelDebug: 1.25,
-			LevelWarn:  -0.5,
+			LevelDebug:       1.25,
+			LevelWarn:        -0.5,
 			Level("invalid"): 0.7,
 			LevelError:       math.NaN(),
 			LevelInfo:        math.Inf(1),
@@ -115,7 +116,7 @@ func nastyConfigs() []Config {
 			"api": {SuccessLevel: LevelWarn, SamplingRate: &rateNaN},
 		}},
 		{OperationPolicies: map[Domain]OperationPolicy{
-			"":                {SuccessLevel: LevelDebug},
+			"":                 {SuccessLevel: LevelDebug},
 			defaultDomainValue: {SuccessLevel: LevelWarn}, // canonical must beat alias
 		}},
 		{OperationPolicies: map[Domain]OperationPolicy{
@@ -137,7 +138,7 @@ func nastyConfigs() []Config {
 				FailureLevel:  LevelError,
 				PanicLevel:    LevelError,
 				OutcomeLevels: map[Outcome]Level{OutcomeRetry: LevelWarn},
-				SamplingRate:  &rateFine, // fully valid policy
+				SamplingRate:  &rateNegZero, // fully valid policy
 			},
 		}},
 	}
@@ -153,7 +154,7 @@ func configsEqual(a, b Config) bool {
 	if (a.Sink == nil) != (b.Sink == nil) || (a.Sampler == nil) != (b.Sampler == nil) {
 		return false
 	}
-	if len(a.LevelSamplingRates) != len(b.LevelSamplingRates) {
+	if (a.LevelSamplingRates == nil) != (b.LevelSamplingRates == nil) || len(a.LevelSamplingRates) != len(b.LevelSamplingRates) {
 		return false
 	}
 	for level, ra := range a.LevelSamplingRates {
@@ -162,7 +163,7 @@ func configsEqual(a, b Config) bool {
 			return false
 		}
 	}
-	if len(a.OperationPolicies) != len(b.OperationPolicies) {
+	if (a.OperationPolicies == nil) != (b.OperationPolicies == nil) || len(a.OperationPolicies) != len(b.OperationPolicies) {
 		return false
 	}
 	for domain, pa := range a.OperationPolicies {
@@ -184,7 +185,7 @@ func policiesEqual(a, b OperationPolicy) bool {
 	if a.SamplingRate != nil && !floatEqual(*a.SamplingRate, *b.SamplingRate) {
 		return false
 	}
-	if len(a.OutcomeLevels) != len(b.OutcomeLevels) {
+	if (a.OutcomeLevels == nil) != (b.OutcomeLevels == nil) || len(a.OutcomeLevels) != len(b.OutcomeLevels) {
 		return false
 	}
 	for outcome, la := range a.OutcomeLevels {
@@ -197,7 +198,7 @@ func policiesEqual(a, b OperationPolicy) bool {
 }
 
 func floatEqual(a, b float64) bool {
-	return a == b || (math.IsNaN(a) && math.IsNaN(b))
+	return math.Float64bits(a) == math.Float64bits(b) || (math.IsNaN(a) && math.IsNaN(b))
 }
 
 func TestNormalizeConfigMatchesReference(t *testing.T) {
@@ -217,18 +218,18 @@ func TestNormalizeConfigRandomizedMatchesReference(t *testing.T) {
 	rng := rand.New(rand.NewSource(1))
 	levels := []Level{"", LevelDebug, LevelInfo, LevelWarn, LevelError, Level("bogus")}
 	outcomes := []Outcome{"", OutcomeSuccess, OutcomeFailure, OutcomePanic, OutcomeCanceled, OutcomeTimeout, OutcomeRetry, Outcome("weird")}
-	rates := []float64{0, 1, -1, 2, 0.5, math.NaN(), math.Inf(1), math.Inf(-1), -0.0, 1e-300}
+	rates := []float64{0, 1, -1, 2, 0.5, math.NaN(), math.Inf(1), math.Inf(-1), math.Copysign(0, -1), 1e-300}
 	domains := []Domain{"", "http", "job", defaultDomainValue, Domain("")}
 
 	randomLevel := func() Level { return levels[rng.Intn(len(levels))] }
-	hasPtr := rng.Intn(2) == 0
 
 	for i := 0; i < 2000; i++ {
 		cfg := Config{SamplingRate: rates[rng.Intn(len(rates))]}
 
 		if rng.Intn(2) == 0 {
-			m := make(map[Level]float64, rng.Intn(4))
-			for j := 0; j < rng.Intn(4); j++ {
+			n := rng.Intn(4)
+			m := make(map[Level]float64, n)
+			for j := 0; j < n; j++ {
 				m[randomLevel()] = rates[rng.Intn(len(rates))]
 			}
 			if rng.Intn(4) == 0 {
@@ -238,21 +239,23 @@ func TestNormalizeConfigRandomizedMatchesReference(t *testing.T) {
 		}
 
 		if rng.Intn(2) == 0 {
-			m := make(map[Domain]OperationPolicy, rng.Intn(3))
-			for j := 0; j < rng.Intn(3); j++ {
+			n := rng.Intn(3)
+			m := make(map[Domain]OperationPolicy, n)
+			for j := 0; j < n; j++ {
 				policy := OperationPolicy{
 					SuccessLevel: randomLevel(),
 					FailureLevel: randomLevel(),
 					PanicLevel:   randomLevel(),
 				}
 				if rng.Intn(2) == 0 {
-					ol := make(map[Outcome]Level, rng.Intn(3))
-					for k := 0; k < rng.Intn(3); k++ {
+					n := rng.Intn(3)
+					ol := make(map[Outcome]Level, n)
+					for k := 0; k < n; k++ {
 						ol[outcomes[rng.Intn(len(outcomes))]] = randomLevel()
 					}
 					policy.OutcomeLevels = ol
 				}
-				if hasPtr && rng.Intn(2) == 0 {
+				if rng.Intn(2) == 0 {
 					r := rates[rng.Intn(len(rates))]
 					policy.SamplingRate = &r
 				}

--- a/integration/common/lifecycle.go
+++ b/integration/common/lifecycle.go
@@ -7,6 +7,120 @@ import (
 	hc "github.com/happytoolin/happycontext"
 )
 
+// Pre-boxed values for fixed HTTP strings and common status codes. Boxing an
+// int >= 256 or any string into the event's map[string]any allocates, so the
+// fixed set is boxed once here.
+var (
+	methodGetAny     = any(http.MethodGet)
+	methodHeadAny    = any(http.MethodHead)
+	methodPostAny    = any(http.MethodPost)
+	methodPutAny     = any(http.MethodPut)
+	methodPatchAny   = any(http.MethodPatch)
+	methodDeleteAny  = any(http.MethodDelete)
+	methodConnectAny = any(http.MethodConnect)
+	methodOptionsAny = any(http.MethodOptions)
+	methodTraceAny   = any(http.MethodTrace)
+
+	status300Any = any(300)
+	status301Any = any(301)
+	status302Any = any(302)
+	status303Any = any(303)
+	status304Any = any(304)
+	status307Any = any(307)
+	status308Any = any(308)
+	status400Any = any(400)
+	status401Any = any(401)
+	status403Any = any(403)
+	status404Any = any(404)
+	status405Any = any(405)
+	status409Any = any(409)
+	status410Any = any(410)
+	status418Any = any(418)
+	status422Any = any(422)
+	status429Any = any(429)
+	status500Any = any(500)
+	status501Any = any(501)
+	status502Any = any(502)
+	status503Any = any(503)
+	status504Any = any(504)
+)
+
+func methodAny(method string) any {
+	switch method {
+	case http.MethodGet:
+		return methodGetAny
+	case http.MethodHead:
+		return methodHeadAny
+	case http.MethodPost:
+		return methodPostAny
+	case http.MethodPut:
+		return methodPutAny
+	case http.MethodPatch:
+		return methodPatchAny
+	case http.MethodDelete:
+		return methodDeleteAny
+	case http.MethodConnect:
+		return methodConnectAny
+	case http.MethodOptions:
+		return methodOptionsAny
+	case http.MethodTrace:
+		return methodTraceAny
+	default:
+		return method
+	}
+}
+
+func statusAny(code int) any {
+	switch code {
+	case 300:
+		return status300Any
+	case 301:
+		return status301Any
+	case 302:
+		return status302Any
+	case 303:
+		return status303Any
+	case 304:
+		return status304Any
+	case 307:
+		return status307Any
+	case 308:
+		return status308Any
+	case 400:
+		return status400Any
+	case 401:
+		return status401Any
+	case 403:
+		return status403Any
+	case 404:
+		return status404Any
+	case 405:
+		return status405Any
+	case 409:
+		return status409Any
+	case 410:
+		return status410Any
+	case 418:
+		return status418Any
+	case 422:
+		return status422Any
+	case 429:
+		return status429Any
+	case 500:
+		return status500Any
+	case 501:
+		return status501Any
+	case 502:
+		return status502Any
+	case 503:
+		return status503Any
+	case 504:
+		return status504Any
+	default:
+		return code
+	}
+}
+
 // FinalizeInput contains request data required for finalization.
 type FinalizeInput struct {
 	Ctx        context.Context
@@ -23,7 +137,7 @@ func StartRequest(baseCtx context.Context, method, path string) (context.Context
 		Domain: hc.DomainHTTP,
 		Name:   "request",
 	})
-	hc.Add(ctx, "http.method", method, "http.path", path)
+	hc.Add(ctx, "http.method", methodAny(method), "http.path", path)
 	return ctx, event
 }
 
@@ -32,7 +146,7 @@ func FinalizeRequest(cfg hc.Config, in FinalizeInput) {
 	if in.Route != "" {
 		hc.SetRoute(in.Ctx, in.Route)
 	}
-	hc.Add(in.Ctx, "http.status", in.StatusCode)
+	hc.Add(in.Ctx, "http.status", statusAny(in.StatusCode))
 
 	name := "request"
 	if in.Route != "" {

--- a/integration/common/lifecycle_prebox_test.go
+++ b/integration/common/lifecycle_prebox_test.go
@@ -32,9 +32,6 @@ func TestStatusAnyProducesPlainInts(t *testing.T) {
 	}
 }
 
-// TestFinalizeRequestFieldsRemainPlainValues checks the middleware path end
-// to end: fields written via the pre-boxed helpers must be indistinguishable
-// from plain literals to consumers.
 func TestFinalizeRequestFieldsRemainPlainValues(t *testing.T) {
 	// 404 is a client error: the operation outcome stays "success"
 	// (resolveOutcome only classifies >= 500 as failure).

--- a/integration/common/lifecycle_prebox_test.go
+++ b/integration/common/lifecycle_prebox_test.go
@@ -1,0 +1,95 @@
+package common
+
+import (
+	"context"
+	"testing"
+
+	hc "github.com/happytoolin/happycontext"
+)
+
+func TestMethodAnyProducesPlainStrings(t *testing.T) {
+	for _, method := range []string{"GET", "HEAD", "POST", "PUT", "PATCH", "DELETE", "CONNECT", "OPTIONS", "TRACE", "PROPFIND", ""} {
+		got := methodAny(method)
+		if _, ok := got.(string); !ok {
+			t.Fatalf("methodAny(%q) dynamic type = %T, want string", method, got)
+		}
+		if got != any(method) {
+			t.Fatalf("methodAny(%q) = %#v", method, got)
+		}
+	}
+}
+
+func TestStatusAnyProducesPlainInts(t *testing.T) {
+	for _, code := range []int{200, 204, 300, 301, 404, 418, 429, 500, 503, 599, 0, 9999} {
+		got := statusAny(code)
+		v, ok := got.(int)
+		if !ok {
+			t.Fatalf("statusAny(%d) dynamic type = %T, want int", code, got)
+		}
+		if v != code {
+			t.Fatalf("statusAny(%d) = %d", code, v)
+		}
+	}
+}
+
+// TestFinalizeRequestFieldsRemainPlainValues checks the middleware path end
+// to end: fields written via the pre-boxed helpers must be indistinguishable
+// from plain literals to consumers.
+func TestFinalizeRequestFieldsRemainPlainValues(t *testing.T) {
+	// 404 is a client error: the operation outcome stays "success"
+	// (resolveOutcome only classifies >= 500 as failure).
+	sink := hc.NewTestSink()
+	cfg := hc.Config{Sink: sink, SamplingRate: 1}
+
+	ctx, event := StartRequest(context.Background(), "GET", "/orders")
+	FinalizeRequest(cfg, FinalizeInput{
+		Ctx:        ctx,
+		Event:      event,
+		StatusCode: 404,
+	})
+
+	events := sink.Events()
+	if len(events) != 1 {
+		t.Fatalf("captured %d events, want 1", len(events))
+	}
+	fields := events[0].Fields
+
+	for key, want := range map[string]any{
+		"http.method": "GET",
+		"http.path":   "/orders",
+		"http.status": 404,
+		"op.domain":   "http",
+		"op.outcome":  "success",
+	} {
+		got, ok := fields[key]
+		if !ok {
+			t.Fatalf("missing field %q", key)
+		}
+		if got != want {
+			t.Fatalf("field %q = %#v (%T), want %#v", key, got, got, want)
+		}
+		if _, isStr := got.(string); isStr == (want == 404) {
+			t.Fatalf("field %q dynamic type = %T", key, got)
+		}
+	}
+
+	// 5xx does map to the failure outcome; still plain strings.
+	sink2 := hc.NewTestSink()
+	cfg2 := hc.Config{Sink: sink2, SamplingRate: 1}
+	ctx2, event2 := StartRequest(context.Background(), "POST", "/pay")
+	FinalizeRequest(cfg2, FinalizeInput{
+		Ctx:        ctx2,
+		Event:      event2,
+		StatusCode: 503,
+	})
+	events2 := sink2.Events()
+	if len(events2) != 1 {
+		t.Fatalf("captured %d events, want 1", len(events2))
+	}
+	if got := events2[0].Fields["op.outcome"]; got != any("failure") {
+		t.Fatalf("op.outcome = %#v, want \"failure\"", got)
+	}
+	if got := events2[0].Fields["http.status"]; got != any(503) {
+		t.Fatalf("http.status = %#v, want 503", got)
+	}
+}

--- a/operation_lifecycle.go
+++ b/operation_lifecycle.go
@@ -89,7 +89,7 @@ func FinishOperation(cfg Config, in OperationFinish) bool {
 }
 
 func finishOperation(cfg Config, ctx context.Context, event *Event, start OperationStart, result operationResult) bool {
-	cfg = NormalizeConfig(cfg)
+	cfg = normalizeConfigShared(cfg)
 	if cfg.Sink == nil || event == nil || ctx == nil {
 		return false
 	}
@@ -115,6 +115,59 @@ func finishOperation(cfg Config, ctx context.Context, event *Event, start Operat
 
 	cfg.Sink.Write(level, resolveEventMessage(cfg.Message, start.Domain, snap.message), snap.fields)
 	return true
+}
+
+// Pre-boxed field values for the library's fixed strings. Storing these in
+// map[string]any avoids a heap allocation per write; dynamic values fall back
+// to a fresh conversion.
+var (
+	domainHTTPAny      = any(string(DomainHTTP))
+	domainJobAny       = any(string(DomainJob))
+	domainMessageAny   = any(string(DomainMessage))
+	domainCLIAny       = any(string(DomainCLI))
+	domainDefaultAny   = any(string(defaultDomainValue))
+	outcomeSuccessAny  = any(string(OutcomeSuccess))
+	outcomeFailureAny  = any(string(OutcomeFailure))
+	outcomePanicAny    = any(string(OutcomePanic))
+	outcomeCanceledAny = any(string(OutcomeCanceled))
+	outcomeTimeoutAny  = any(string(OutcomeTimeout))
+	outcomeRetryAny    = any(string(OutcomeRetry))
+)
+
+func domainAny(domain Domain) any {
+	switch domain {
+	case DomainHTTP:
+		return domainHTTPAny
+	case DomainJob:
+		return domainJobAny
+	case DomainMessage:
+		return domainMessageAny
+	case DomainCLI:
+		return domainCLIAny
+	case defaultDomainValue:
+		return domainDefaultAny
+	default:
+		return string(domain)
+	}
+}
+
+func outcomeAny(outcome Outcome) any {
+	switch outcome {
+	case OutcomeSuccess:
+		return outcomeSuccessAny
+	case OutcomeFailure:
+		return outcomeFailureAny
+	case OutcomePanic:
+		return outcomePanicAny
+	case OutcomeCanceled:
+		return outcomeCanceledAny
+	case OutcomeTimeout:
+		return outcomeTimeoutAny
+	case OutcomeRetry:
+		return outcomeRetryAny
+	default:
+		return string(outcome)
+	}
 }
 
 func applyOperationStartFields(ctx context.Context, start OperationStart) {
@@ -149,7 +202,7 @@ func applyOperationStartFieldsToEvent(event *Event, start OperationStart) {
 	if event.fields == nil {
 		event.fields = make(map[string]any, max(capHint, 8))
 	}
-	event.fields["op.domain"] = string(start.Domain)
+	event.fields["op.domain"] = domainAny(start.Domain)
 	event.fields["op.name"] = start.Name
 	if start.ID != "" {
 		event.fields["op.id"] = start.ID
@@ -249,7 +302,7 @@ func annotateOperationCompletion(event *Event, duration time.Duration, code int,
 	}
 	event.fields["duration_ms"] = duration.Milliseconds()
 	event.fields["op.code"] = code
-	event.fields["op.outcome"] = string(outcome)
+	event.fields["op.outcome"] = outcomeAny(outcome)
 	event.mu.Unlock()
 }
 

--- a/prebox_test.go
+++ b/prebox_test.go
@@ -1,0 +1,127 @@
+package hc
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+)
+
+// The pre-boxed field values must be indistinguishable from freshly
+// converted strings at the interface level: same dynamic type, same ==,
+// same JSON output. These tests pin that contract.
+
+func TestDomainAnyProducesPlainStrings(t *testing.T) {
+	cases := map[Domain]string{
+		DomainHTTP:         "http",
+		DomainJob:          "job",
+		DomainMessage:      "msg",
+		DomainCLI:          "cli",
+		defaultDomainValue: "operation",
+		"custom":           "custom",
+		"":                 "", // fast path never sees "" (normalized first), but must not panic
+	}
+	for domain, want := range cases {
+		got := domainAny(domain)
+		if _, ok := got.(string); !ok {
+			t.Fatalf("domainAny(%q) dynamic type = %T, want string", domain, got)
+		}
+		if got != any(want) {
+			t.Fatalf("domainAny(%q) = %#v, want %q", domain, got, want)
+		}
+	}
+}
+
+func TestOutcomeAnyProducesPlainStrings(t *testing.T) {
+	cases := map[Outcome]string{
+		OutcomeSuccess:  "success",
+		OutcomeFailure:  "failure",
+		OutcomePanic:    "panic",
+		OutcomeCanceled: "canceled",
+		OutcomeTimeout:  "timeout",
+		OutcomeRetry:    "retry",
+		Outcome("weird"): "weird",
+	}
+	for outcome, want := range cases {
+		got := outcomeAny(outcome)
+		if _, ok := got.(string); !ok {
+			t.Fatalf("outcomeAny(%q) dynamic type = %T, want string", outcome, got)
+		}
+		if got != any(want) {
+			t.Fatalf("outcomeAny(%q) = %#v, want %q", outcome, got, want)
+		}
+	}
+}
+
+// TestOperationFieldsRemainPlainValues runs the full lifecycle and verifies
+// the library-written fields from the outside: type assertions, equality,
+// fmt rendering, and JSON marshaling.
+func TestOperationFieldsRemainPlainValues(t *testing.T) {
+	sink := NewTestSink()
+	cfg := Config{Sink: sink, SamplingRate: 1}
+
+	op := StartOperation(context.Background(), OperationStart{
+		Domain:      DomainJob,
+		Name:        "cleanup",
+		ID:          "job_1",
+		Source:      "batch",
+		Attempt:     1,
+		MaxAttempts: 3,
+	})
+	var err error
+	op.End(cfg, &err)
+
+	events := sink.Events()
+	if len(events) != 1 {
+		t.Fatalf("captured %d events, want 1", len(events))
+	}
+	fields := events[0].Fields
+
+	assertions := []struct {
+		key  string
+		want any
+	}{
+		{"op.domain", "job"},
+		{"op.outcome", "success"},
+		{"op.name", "cleanup"},
+		{"op.id", "job_1"},
+		{"op.source", "batch"},
+		{"op.attempt", 1},
+		{"op.max_attempts", 3},
+	}
+	for _, a := range assertions {
+		got, ok := fields[a.key]
+		if !ok {
+			t.Fatalf("missing field %q", a.key)
+		}
+		if got != a.want {
+			t.Fatalf("field %q = %#v, want %#v", a.key, got, a.want)
+		}
+		// The dynamic type must stay string/int, not Domain/Outcome.
+		switch a.want.(type) {
+		case string:
+			if _, ok := got.(string); !ok {
+				t.Fatalf("field %q dynamic type = %T, want string", a.key, got)
+			}
+		}
+	}
+
+	// Rendering and JSON encoding must be unaffected by boxing.
+	if s := fmt.Sprint(fields["op.outcome"]); s != "success" {
+		t.Fatalf("fmt.Sprint(op.outcome) = %q", s)
+	}
+	b, err := json.Marshal(fields)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(b, &decoded); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if decoded["op.domain"] != "job" {
+		t.Fatalf("json op.domain = %#v, want \"job\"", decoded["op.domain"])
+	}
+	if decoded["op.outcome"] != "success" {
+		t.Fatalf("json op.outcome = %#v, want \"success\"", decoded["op.outcome"])
+	}
+}

--- a/prebox_test.go
+++ b/prebox_test.go
@@ -7,10 +7,6 @@ import (
 	"testing"
 )
 
-// The pre-boxed field values must be indistinguishable from freshly
-// converted strings at the interface level: same dynamic type, same ==,
-// same JSON output. These tests pin that contract.
-
 func TestDomainAnyProducesPlainStrings(t *testing.T) {
 	cases := map[Domain]string{
 		DomainHTTP:         "http",
@@ -53,9 +49,6 @@ func TestOutcomeAnyProducesPlainStrings(t *testing.T) {
 	}
 }
 
-// TestOperationFieldsRemainPlainValues runs the full lifecycle and verifies
-// the library-written fields from the outside: type assertions, equality,
-// fmt rendering, and JSON marshaling.
 func TestOperationFieldsRemainPlainValues(t *testing.T) {
 	sink := NewTestSink()
 	cfg := Config{Sink: sink, SamplingRate: 1}
@@ -97,7 +90,6 @@ func TestOperationFieldsRemainPlainValues(t *testing.T) {
 		if got != a.want {
 			t.Fatalf("field %q = %#v, want %#v", a.key, got, a.want)
 		}
-		// The dynamic type must stay string/int, not Domain/Outcome.
 		switch a.want.(type) {
 		case string:
 			if _, ok := got.(string); !ok {
@@ -106,7 +98,6 @@ func TestOperationFieldsRemainPlainValues(t *testing.T) {
 		}
 	}
 
-	// Rendering and JSON encoding must be unaffected by boxing.
 	if s := fmt.Sprint(fields["op.outcome"]); s != "success" {
 		t.Fatalf("fmt.Sprint(op.outcome) = %q", s)
 	}


### PR DESCRIPTION
## Summary

Profiling (pprof alloc attribution on the existing benchmark suite) showed that most per-event allocations come from the `map[string]any` field model itself, not from logging: **every string value written into the map is boxed into an `any` (16B heap alloc)**, the slog adapter boxed each `slog.Attr` into a `[]any`, and `finishOperation` re-cloned config maps on every request even though middleware normalizes once at construction.

Three changes:

1. **slog adapter** (`adapter/slog/sink.go`): use `Logger.LogAttrs` with a pooled `[]slog.Attr` instead of appending `slog.Attr` structs into a `[]any`. Each boxed Attr was one allocation.
2. **Config fast path** (`config.go`): new unexported `normalizeConfigShared` validates maps first and only rebuilds them when something actually needs fixing; the per-request finish path uses it and stays allocation-free for already-normalized configs. The public `NormalizeConfig` keeps the historical always-isolated-copy contract (see below).
3. **Pre-boxed values** (`operation_lifecycle.go`, `integration/common/lifecycle.go`): package-level boxed `any` values for the library's fixed strings and common HTTP values (`op.domain`, `op.outcome`, HTTP methods, 3xx–5xx statuses). Dynamic values fall back to fresh conversions. Stored dynamic types remain plain `string`/`int`, so consumer type assertions, `==`, and JSON output are unchanged — pinned by tests.

## Sequential benchmarks (Apple M4, go1.26.2, same-machine before/after, median of 3)

| Benchmark | Before | After | Δ time | Δ allocs | Δ bytes |
|---|---|---|---|---|---|
| slog adapter, small write | 1079 ns, 7 allocs, 336 B | 628 ns, 1 alloc, 48 B | **−41.8%** | **−85.7%** | −85.7% |
| slog adapter, medium write | 2153 ns, 18 allocs, 1297 B | 1246 ns, 1 alloc, 480 B | **−42.1%** | **−94.4%** | −63.0% |
| `OperationLifecycle` | 809 ns, 17 allocs, 1968 B | 717 ns, 15 allocs, 1936 B | −11.3% | −11.8% | −1.6% |
| Finish with policies (new bench) | 881 ns, 17 allocs, 2352 B | 597 ns, 9 allocs, 976 B | **−32.2%** | **−47.1%** | **−58.5%** |
| std router middleware e2e (HTTP roundtrip) | 1088 ns, 29 allocs | 1026 ns, 26 allocs | −5.7% | −10.3% | −1.8% |

## Stress testing (added in this PR: `bench/stress_test.go`, `adapter/slog/stress_test.go`)

Medians of 5 runs; parallel = `RunParallel` across all 10 cores. Baseline = `main` in a separate worktree, same machine.

| Stress benchmark | Before | After | Δ time | Δ throughput | Δ allocs | Δ bytes |
|---|---|---|---|---|---|---|
| Parallel operation lifecycle (policies cfg) | 853 ns, 22 allocs, 3296 B | 557 ns, 14 allocs, 1920 B | **−34.7%** | **+53.2%** | **−36.4%** | **−41.7%** |
| Sustained single-core lifecycle | 1148 ns, 22 allocs, 3296 B | 804 ns, 14 allocs, 1920 B | **−30.0%** | **+42.8%** | **−36.4%** | **−41.7%** |
| Parallel std middleware (direct `ServeHTTP`) | 826 ns, 26 allocs, 2800 B | 472 ns, 17 allocs, 1408 B | **−42.9%** | **+75.2%** | **−34.6%** | **−49.7%** |
| Parallel slog JSON write | 667 ns, 18 allocs, 1299 B | 437 ns, 1 alloc, 481 B | **−34.4%** | **+52.5%** | **−94.4%** | −63.0% |
| Parallel slog deterministic write | 712 ns, 16 allocs, 1139 B | 503 ns, 1 alloc, 417 B | **−29.5%** | **+41.8%** | **−93.8%** | −63.4% |

Note the middleware harnesses differ: the e2e row above includes the httptest HTTP client roundtrip (diluting the delta); the stress row calls `ServeHTTP` directly and isolates the middleware itself.

### Stress correctness results (all passing)

- **Heap stability**: 2M full operation lifecycles → heap growth 319,488 B = **0.16 B/op retained** (no leaks).
- **Race**: 32 goroutines × 20k mixed API calls (`Add`/`SetLevel`/`SetMessage`/`Error` storm on a shared event + concurrent finishes sharing one config, exercising the sharing fast path) — clean under `-race`.
- **Sampler under contention**: 16 goroutines × 100k decisions through `RateSampler(0.5)` → kept ratio **0.4994**.
- **slog sustained correctness**: 160k parallel writes with a retaining (non-cloning) handler → all 160k records intact, 4 attrs each.

## Regression caught during adversarial testing (and fixed)

An earlier version of the fast path made the public `NormalizeConfig` share the caller's maps when already valid. The new isolation test proved a caller mutating their config maps after normalizing would retroactively change the normalized config — breaking the historical contract (cf. the existing "should not mutate caller sampling pointer" test). `NormalizeConfig` now always returns isolated deep copies (`maps.Clone` on both map levels, fresh rate pointers); only the internal, read-only finish path uses the sharing variant.

## New test coverage

- `config_equivalence_test.go`: equivalence against the previous implementation kept as a reference oracle — nasty table (invalid levels, NaN/±Inf/−0 rates, `""` domain alias, canonical-beats-alias, out-of-range pointers) + 2000 randomized configs + idempotency + caller-map isolation.
- `adapter/slog/sink_concurrency_test.go` + `stress_test.go`: pooled-buffer aliasing probe (handler retains records without cloning), 8 concurrent writers with 100-field maps (forces pool growth past capacity), nil fields/values, handler panic recovery, pool consistency after panics, 160k-write sustained correctness.
- `prebox_test.go` / `lifecycle_prebox_test.go`: pre-boxed values stay plain `string`/`int` (`==`, type assertion, `fmt`, JSON), fixed and dynamic fallbacks, full lifecycle and middleware paths.
- `bench/stress_test.go`: stress benchmarks + heap/race/sampler stress tests above.
- `config_bench_test.go`: benchmark for the finish path with policies configured.

## Caveats / notes

- `normalizeConfigShared` *shares* maps with its input. Safe today because nothing in the finish path writes to config maps; documented on the function. If config mutation is ever added to the finish path, this must be revisited.
- Verified behavior detail while testing: HTTP 4xx maps to outcome `success` (only `>= 500` is `failure`), consistent with `KeepErrors` — now pinned by a test.
- No public API changes; all stored field values keep their dynamic types.

## Test plan

- [x] `go test ./...` in all 10 modules (root + adapters + integrations)
- [x] `go test -race` + `go vet` across all modules
- [x] Stress: heap stability (2M ops), 32-goroutine mixed-access race run, sampler contention, slog sustained correctness
- [x] Same-machine before/after: sequential benchmarks, parallel/sustained stress benchmarks (baseline in separate worktree)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved concurrent logging reliability and prevented attribute data from being corrupted or shared between records.
  * Configuration normalization now isolates caller-provided settings from unexpected changes.
  * Preserved consistent plain values for HTTP, domain, outcome, and status fields.

* **Performance**
  * Reduced memory allocations and improved buffer reuse across logging adapters and operation processing.
  * Prevented oversized temporary buffers from being retained unnecessarily.
  * Improved efficiency when processing normalized operation policies and sampling settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->