### PR TITLE
refactor!: remove DeterministicOrder sorting from adapters

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -9,12 +9,13 @@ set shell := ["zsh", "-cu"]
 default:
   @just --list
 
-# Maintain clean dependencies.
+# Maintain clean dependencies across all modules.
 tidy:
-  go fmt ./...
-  go fix ./...
-  go mod tidy
-  gofumpt -l -w .
+  while IFS= read -r modfile; do \
+    moddir="$(dirname "$modfile")"; \
+    echo "== tidying $moddir =="; \
+    (cd "$moddir" && go fmt ./... && go fix ./... && go mod tidy && gofumpt -l -w .); \
+  done < <(printf '%s\n' go.mod && git ls-files '**/go.mod')
 
 
 lint:

--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ func runJob(cfg hc.Config) (err error) {
 - `adapter/zap`
 - `adapter/zerolog`
 
-All adapters expose `NewWithOptions` plus `SinkOptions{DeterministicOrder: true}` when you need stable field ordering.
+All adapters expose `NewWithOptions` plus a `SinkOptions` value reserved for future options. Adapters do not sort fields: field order follows Go's map iteration and is unspecified. Deterministic, insertion-ordered output arrives structurally with the upcoming record-based core.
 
 ## More Examples
 

--- a/adapter/slog/sink.go
+++ b/adapter/slog/sink.go
@@ -3,7 +3,6 @@ package slogadapter
 import (
 	"context"
 	"log/slog"
-	"sort"
 	"sync"
 
 	"github.com/happytoolin/happycontext"
@@ -21,13 +20,6 @@ var slogAttrPool = sync.Pool{
 	},
 }
 
-var slogKeyPool = sync.Pool{
-	New: func() any {
-		buf := make([]string, 0, slogPoolCapacity)
-		return &buf
-	},
-}
-
 func recycleSlice[T any](pool *sync.Pool, bufPtr *[]T, buf []T) {
 	if cap(buf) > slogPoolMaxCapacity {
 		return
@@ -38,15 +30,17 @@ func recycleSlice[T any](pool *sync.Pool, bufPtr *[]T, buf []T) {
 }
 
 // SinkOptions controls slog adapter behavior.
-type SinkOptions struct {
-	// DeterministicOrder sorts keys before writing attributes.
-	DeterministicOrder bool
-}
+//
+// It is currently empty and reserved for future options. The previous
+// DeterministicOrder option was removed: adapters no longer sort fields,
+// because the map-based sink contract cannot carry insertion order and
+// sorting on top of it only masked that. Deterministic field order
+// arrives structurally with the v2 record core.
+type SinkOptions struct{}
 
 // Sink writes happycontext events to slog.
 type Sink struct {
-	logger             *slog.Logger
-	deterministicOrder bool
+	logger *slog.Logger
 }
 
 // New creates a slog-backed sink with default options.
@@ -56,7 +50,7 @@ func New(l *slog.Logger) *Sink {
 
 // NewWithOptions creates a slog-backed sink with options.
 func NewWithOptions(l *slog.Logger, opts SinkOptions) *Sink {
-	return &Sink{logger: l, deterministicOrder: opts.DeterministicOrder}
+	return &Sink{logger: l}
 }
 
 // Write implements hc.Sink.
@@ -93,25 +87,8 @@ func (s *Sink) Write(level hc.Level, message string, fields map[string]any) {
 		recycleSlice(&slogAttrPool, bufPtr, attrs)
 	}()
 
-	if !s.deterministicOrder {
-		for k, v := range fields {
-			attrs = append(attrs, slog.Any(k, v))
-		}
-		s.logger.LogAttrs(ctx, slogLevel, message, attrs...)
-		return
-	}
-	keysPtr := slogKeyPool.Get().(*[]string)
-	keys := (*keysPtr)[:0]
-	defer func() {
-		recycleSlice(&slogKeyPool, keysPtr, keys)
-	}()
-	for k := range fields {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-
-	for _, k := range keys {
-		attrs = append(attrs, slog.Any(k, fields[k]))
+	for k, v := range fields {
+		attrs = append(attrs, slog.Any(k, v))
 	}
 	s.logger.LogAttrs(ctx, slogLevel, message, attrs...)
 }

--- a/adapter/slog/sink_concurrency_test.go
+++ b/adapter/slog/sink_concurrency_test.go
@@ -33,7 +33,7 @@ func TestSinkPooledAttrsSurviveRetainingHandler(t *testing.T) {
 	sink := New(slog.New(h))
 
 	fields := map[string]any{"a": 1, "b": "two", "c": true}
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		sink.Write(hc.LevelInfo, "m", fields)
 	}
 
@@ -77,7 +77,7 @@ func TestSinkConcurrentWritesLargeMaps(t *testing.T) {
 
 	bigFields := func(tag string) map[string]any {
 		m := make(map[string]any, 100)
-		for i := 0; i < 100; i++ {
+		for i := range 100 {
 			m["k"+strconv.Itoa(i)] = tag + ":" + strconv.Itoa(i)
 		}
 		return m
@@ -87,12 +87,12 @@ func TestSinkConcurrentWritesLargeMaps(t *testing.T) {
 	const writes = 50
 
 	var wg sync.WaitGroup
-	for w := 0; w < writers; w++ {
+	for w := range writers {
 		wg.Add(1)
 		go func(w int) {
 			defer wg.Done()
 			tag := "w" + strconv.Itoa(w)
-			for i := 0; i < writes; i++ {
+			for range writes {
 				sink.Write(hc.LevelInfo, tag, bigFields(tag))
 			}
 		}(w)
@@ -151,7 +151,7 @@ func TestSinkRecoverableAfterHandlerPanic(t *testing.T) {
 	boom := slog.New(panicHandler{calls: &calls})
 	sink := New(boom)
 
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		func() {
 			defer func() { _ = recover() }()
 			sink.Write(hc.LevelInfo, "boom", map[string]any{"i": i})

--- a/adapter/slog/sink_concurrency_test.go
+++ b/adapter/slog/sink_concurrency_test.go
@@ -74,7 +74,6 @@ func TestSinkPooledAttrsSurviveRetainingHandler(t *testing.T) {
 func TestSinkConcurrentWritesLargeMaps(t *testing.T) {
 	h := &retainingHandler{}
 	sink := New(slog.New(h))
-	sinkDeterministic := NewWithOptions(slog.New(h), SinkOptions{DeterministicOrder: true})
 
 	bigFields := func(tag string) map[string]any {
 		m := make(map[string]any, 100)
@@ -95,13 +94,12 @@ func TestSinkConcurrentWritesLargeMaps(t *testing.T) {
 			tag := "w" + strconv.Itoa(w)
 			for i := 0; i < writes; i++ {
 				sink.Write(hc.LevelInfo, tag, bigFields(tag))
-				sinkDeterministic.Write(hc.LevelInfo, tag, bigFields(tag))
 			}
 		}(w)
 	}
 	wg.Wait()
 
-	total := writers * writes * 2
+	total := writers * writes
 	if len(h.records) != total {
 		t.Fatalf("got %d records, want %d", len(h.records), total)
 	}
@@ -172,15 +170,6 @@ func TestSinkRecoverableAfterHandlerPanic(t *testing.T) {
 }
 
 func TestRecycleSliceClearsAndCaps(t *testing.T) {
-	var pool sync.Pool
-
-	small := make([]any, 1, slogPoolCapacity)
-	small[0] = new(int)
-	recycleSlice(&pool, &small, small)
-	if len(small) != 0 || small[:cap(small)][0] != nil {
-		t.Fatalf("small buffer was not cleared and recycled: len=%d first=%v", len(small), small[:cap(small)][0])
-	}
-
 	attrs := make([]slog.Attr, 0, slogPoolCapacity)
 	for range 100 {
 		attrs = append(attrs, slog.Attr{})
@@ -196,6 +185,7 @@ func TestRecycleSliceClearsAndCaps(t *testing.T) {
 		t.Fatalf("grown attr buffer was not cleared and recycled: len=%d first=%v", len(attrs), first)
 	}
 
+	var pool sync.Pool
 	oversized := make([]any, slogPoolMaxCapacity+1)
 	oversized[0] = new(int)
 	recycleSlice(&pool, &oversized, oversized)

--- a/adapter/slog/sink_test.go
+++ b/adapter/slog/sink_test.go
@@ -3,7 +3,6 @@ package slogadapter
 import (
 	"context"
 	"log/slog"
-	"slices"
 	"testing"
 
 	"github.com/happytoolin/happycontext"
@@ -29,26 +28,6 @@ func TestSinkWriteMapsLevelAndDefaultsMessage(t *testing.T) {
 	}
 	if h.records[0].Attrs["user_id"] != "u_1" {
 		t.Fatalf("missing user_id attr")
-	}
-}
-
-func TestSinkDeterministicOrderSortsKeys(t *testing.T) {
-	h := &captureSlogHandler{}
-	logger := slog.New(h)
-	sink := NewWithOptions(logger, SinkOptions{DeterministicOrder: true})
-
-	sink.Write("INFO", "done", map[string]any{
-		"z": 1,
-		"a": 2,
-		"m": 3,
-	})
-
-	if len(h.records) != 1 {
-		t.Fatalf("expected 1 record, got %d", len(h.records))
-	}
-	expectedOrder := []string{"a", "m", "z"}
-	if !slices.Equal(h.records[0].Order, expectedOrder) {
-		t.Fatalf("expected sorted attrs order %v, got %v", expectedOrder, h.records[0].Order)
 	}
 }
 

--- a/adapter/slog/stress_test.go
+++ b/adapter/slog/stress_test.go
@@ -17,11 +17,11 @@ func TestStressSlogSustainedCorrectness(t *testing.T) {
 	const writes = 20_000
 
 	var wg sync.WaitGroup
-	for g := 0; g < goroutines; g++ {
+	for range goroutines {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			for i := 0; i < writes; i++ {
+			for range writes {
 				sink.Write(hc.LevelInfo, "stress", fields)
 			}
 		}()

--- a/adapter/zap/sink.go
+++ b/adapter/zap/sink.go
@@ -1,7 +1,6 @@
 package zapadapter
 
 import (
-	"sort"
 	"sync"
 
 	"github.com/happytoolin/happycontext"
@@ -21,13 +20,6 @@ var zapFieldPool = sync.Pool{
 	},
 }
 
-var zapKeyPool = sync.Pool{
-	New: func() any {
-		buf := make([]string, 0, zapPoolCapacity)
-		return &buf
-	},
-}
-
 func recycleSlice[T any](pool *sync.Pool, bufPtr *[]T, buf []T) {
 	if cap(buf) > zapPoolMaxCapacity {
 		return
@@ -38,15 +30,17 @@ func recycleSlice[T any](pool *sync.Pool, bufPtr *[]T, buf []T) {
 }
 
 // SinkOptions controls zap adapter behavior.
-type SinkOptions struct {
-	// DeterministicOrder sorts keys before writing fields.
-	DeterministicOrder bool
-}
+//
+// It is currently empty and reserved for future options. The previous
+// DeterministicOrder option was removed: adapters no longer sort fields,
+// because the map-based sink contract cannot carry insertion order and
+// sorting on top of it only masked that. Deterministic field order
+// arrives structurally with the v2 record core.
+type SinkOptions struct{}
 
 // Sink writes happycontext events to zap.
 type Sink struct {
-	logger             *zap.Logger
-	deterministicOrder bool
+	logger *zap.Logger
 }
 
 // New creates a zap-backed sink.
@@ -56,7 +50,7 @@ func New(l *zap.Logger) *Sink {
 
 // NewWithOptions creates a zap-backed sink with options.
 func NewWithOptions(l *zap.Logger, opts SinkOptions) *Sink {
-	return &Sink{logger: l, deterministicOrder: opts.DeterministicOrder}
+	return &Sink{logger: l}
 }
 
 // Write implements hc.Sink.
@@ -82,28 +76,9 @@ func (z *Sink) Write(level hc.Level, message string, fields map[string]any) {
 		recycleSlice(&zapFieldPool, bufPtr, zapFields)
 	}()
 
-	if !z.deterministicOrder {
-		for k, v := range fields {
-			zapFields = append(zapFields, zap.Any(k, v))
-		}
-		checked.Write(zapFields...)
-		return
+	for k, v := range fields {
+		zapFields = append(zapFields, zap.Any(k, v))
 	}
-
-	keysPtr := zapKeyPool.Get().(*[]string)
-	keys := (*keysPtr)[:0]
-	defer func() {
-		recycleSlice(&zapKeyPool, keysPtr, keys)
-	}()
-
-	for k := range fields {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	for _, k := range keys {
-		zapFields = append(zapFields, zap.Any(k, fields[k]))
-	}
-
 	checked.Write(zapFields...)
 }
 

--- a/adapter/zap/sink_test.go
+++ b/adapter/zap/sink_test.go
@@ -1,8 +1,6 @@
 package zapadapter
 
 import (
-	"bytes"
-	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -77,30 +75,6 @@ func TestSinkWriteMapsAllKnownLevels(t *testing.T) {
 	}
 }
 
-func TestSinkDeterministicOrderSortsKeys(t *testing.T) {
-	var buf bytes.Buffer
-	encoderCfg := zap.NewProductionEncoderConfig()
-	core := zapcore.NewCore(zapcore.NewJSONEncoder(encoderCfg), zapcore.AddSync(&buf), zapcore.DebugLevel)
-	sink := NewWithOptions(zap.New(core), SinkOptions{DeterministicOrder: true})
-
-	sink.Write(hc.LevelInfo, "done", map[string]any{
-		"z": 1,
-		"a": 2,
-		"m": 3,
-	})
-
-	output := buf.String()
-	aIdx := strings.Index(output, `"a":2`)
-	mIdx := strings.Index(output, `"m":3`)
-	zIdx := strings.Index(output, `"z":1`)
-	if aIdx == -1 || mIdx == -1 || zIdx == -1 {
-		t.Fatalf("expected ordered keys in output, got %q", output)
-	}
-	if aIdx >= mIdx || mIdx >= zIdx {
-		t.Fatalf("expected key order a,m,z in output, got %q", output)
-	}
-}
-
 func TestSinkWriteNilSafety(t *testing.T) {
 	var nilSink *Sink
 	nilSink.Write(hc.LevelInfo, "x", map[string]any{"k": 1})
@@ -162,13 +136,6 @@ func TestRecycleSliceClearsAndCaps(t *testing.T) {
 	first := fields[:cap(fields)][0]
 	if len(fields) != 0 || first.Key != "" || first.Interface != nil {
 		t.Fatalf("field buffer was not cleared and recycled: len=%d first=%v", len(fields), first)
-	}
-
-	keys := []string{"retained"}
-	var keyPool sync.Pool
-	recycleSlice(&keyPool, &keys, keys)
-	if len(keys) != 0 || keys[:cap(keys)][0] != "" {
-		t.Fatalf("key buffer was not cleared and recycled: len=%d first=%q", len(keys), keys[:cap(keys)][0])
 	}
 
 	oversized := make([]zap.Field, zapPoolMaxCapacity+1)

--- a/adapter/zerolog/sink.go
+++ b/adapter/zerolog/sink.go
@@ -1,45 +1,24 @@
 package zerologadapter
 
 import (
-	"sort"
-	"sync"
 	"time"
 
 	"github.com/happytoolin/happycontext"
 	"github.com/rs/zerolog"
 )
 
-const (
-	zerologPoolCapacity    = 32
-	zerologPoolMaxCapacity = 160
-)
-
-var zerologKeyPool = sync.Pool{
-	New: func() any {
-		buf := make([]string, 0, zerologPoolCapacity)
-		return &buf
-	},
-}
-
-func recycleKeys(bufPtr *[]string, keys []string) {
-	if cap(keys) > zerologPoolMaxCapacity {
-		return
-	}
-	clear(keys)
-	*bufPtr = keys[:0]
-	zerologKeyPool.Put(bufPtr)
-}
-
 // SinkOptions controls zerolog adapter behavior.
-type SinkOptions struct {
-	// DeterministicOrder sorts keys before writing fields.
-	DeterministicOrder bool
-}
+//
+// It is currently empty and reserved for future options. The previous
+// DeterministicOrder option was removed: adapters no longer sort fields,
+// because the map-based sink contract cannot carry insertion order and
+// sorting on top of it only masked that. Deterministic field order
+// arrives structurally with the v2 record core.
+type SinkOptions struct{}
 
 // Sink writes happycontext events to zerolog.
 type Sink struct {
-	logger             *zerolog.Logger
-	deterministicOrder bool
+	logger *zerolog.Logger
 }
 
 // New creates a zerolog-backed sink.
@@ -49,7 +28,7 @@ func New(l *zerolog.Logger) *Sink {
 
 // NewWithOptions creates a zerolog-backed sink with options.
 func NewWithOptions(l *zerolog.Logger, opts SinkOptions) *Sink {
-	return &Sink{logger: l, deterministicOrder: opts.DeterministicOrder}
+	return &Sink{logger: l}
 }
 
 // Write implements hc.Sink.
@@ -80,26 +59,8 @@ func (z *Sink) Write(level hc.Level, message string, fields map[string]any) {
 		return
 	}
 
-	if !z.deterministicOrder {
-		for k, v := range fields {
-			event = appendField(event, k, v)
-		}
-		event.Msg(message)
-		return
-	}
-
-	keysPtr := zerologKeyPool.Get().(*[]string)
-	keys := (*keysPtr)[:0]
-	defer func() {
-		recycleKeys(keysPtr, keys)
-	}()
-
-	for k := range fields {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	for _, k := range keys {
-		event = appendField(event, k, fields[k])
+	for k, v := range fields {
+		event = appendField(event, k, v)
 	}
 	event.Msg(message)
 }

--- a/adapter/zerolog/sink_test.go
+++ b/adapter/zerolog/sink_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"strings"
 	"testing"
 	"time"
 
@@ -117,29 +116,6 @@ func TestSinkWriteMapsAllLevelsAndMessageBehavior(t *testing.T) {
 	}
 }
 
-func TestSinkDeterministicOrderSortsKeys(t *testing.T) {
-	var buf bytes.Buffer
-	logger := zerolog.New(&buf)
-	sink := NewWithOptions(&logger, SinkOptions{DeterministicOrder: true})
-
-	sink.Write(hc.LevelInfo, "done", map[string]any{
-		"z": 1,
-		"a": 2,
-		"m": 3,
-	})
-
-	output := buf.String()
-	aIdx := strings.Index(output, `"a":2`)
-	mIdx := strings.Index(output, `"m":3`)
-	zIdx := strings.Index(output, `"z":1`)
-	if aIdx == -1 || mIdx == -1 || zIdx == -1 {
-		t.Fatalf("expected ordered keys in output, got %q", output)
-	}
-	if aIdx >= mIdx || mIdx >= zIdx {
-		t.Fatalf("expected key order a,m,z in output, got %q", output)
-	}
-}
-
 func TestSinkWriteNilSafety(t *testing.T) {
 	var nilSink *Sink
 	nilSink.Write(hc.LevelInfo, "x", map[string]any{"k": 1})
@@ -182,25 +158,5 @@ func TestSinkSkipsDisabledEvent(t *testing.T) {
 
 	if buf.Len() != 0 {
 		t.Fatalf("disabled debug produced output: %q", buf.String())
-	}
-}
-
-func TestRecycleKeysClearsAndCaps(t *testing.T) {
-	keys := make([]string, 0, zerologPoolCapacity)
-	for range 100 {
-		keys = append(keys, "retained")
-	}
-	if cap(keys) > zerologPoolMaxCapacity {
-		t.Fatalf("100-field buffer exceeds pool limit: cap=%d limit=%d", cap(keys), zerologPoolMaxCapacity)
-	}
-	recycleKeys(&keys, keys)
-	if len(keys) != 0 || keys[:cap(keys)][0] != "" {
-		t.Fatalf("key buffer was not cleared and recycled: len=%d first=%q", len(keys), keys[:cap(keys)][0])
-	}
-
-	oversized := make([]string, zerologPoolMaxCapacity+1)
-	recycleKeys(&oversized, oversized)
-	if len(oversized) != zerologPoolMaxCapacity+1 {
-		t.Fatalf("oversized buffer was retained: len=%d", len(oversized))
 	}
 }

--- a/benches/adapters_benchmark_test.go
+++ b/benches/adapters_benchmark_test.go
@@ -33,7 +33,6 @@ func adapterFieldsMedium() map[string]any {
 func BenchmarkAdapterSlog(b *testing.B) {
 	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
 	sink := slogadapter.New(logger)
-	deterministicSink := slogadapter.NewWithOptions(logger, slogadapter.SinkOptions{DeterministicOrder: true})
 	medium := adapterFieldsMedium()
 
 	b.Run("write_empty", func(b *testing.B) {
@@ -52,12 +51,6 @@ func BenchmarkAdapterSlog(b *testing.B) {
 		b.ReportAllocs()
 		for b.Loop() {
 			sink.Write(hc.LevelInfo, "request_completed", medium)
-		}
-	})
-	b.Run("write_medium_deterministic", func(b *testing.B) {
-		b.ReportAllocs()
-		for b.Loop() {
-			deterministicSink.Write(hc.LevelInfo, "request_completed", medium)
 		}
 	})
 	b.Run("write_disabled_medium", func(b *testing.B) {
@@ -145,21 +138,6 @@ func BenchmarkAdapterZerolog(b *testing.B) {
 func BenchmarkAdapterSlogParallel(b *testing.B) {
 	sink := slogadapter.New(slog.New(slog.NewJSONHandler(io.Discard, nil)))
 	fields := adapterFieldsMedium()
-
-	b.ReportAllocs()
-	b.RunParallel(func(pb *testing.PB) {
-		for pb.Next() {
-			sink.Write(hc.LevelInfo, "request_completed", fields)
-		}
-	})
-}
-
-func BenchmarkAdapterSlogParallelDeterministic(b *testing.B) {
-	sink := slogadapter.NewWithOptions(
-		slog.New(slog.NewJSONHandler(io.Discard, nil)),
-		slogadapter.SinkOptions{DeterministicOrder: true},
-	)
-	fields := buildBenchmarkFields(15)
 
 	b.ReportAllocs()
 	b.RunParallel(func(pb *testing.PB) {

--- a/benches/stress_test.go
+++ b/benches/stress_test.go
@@ -105,7 +105,7 @@ func TestStressHeapStable(t *testing.T) {
 
 	// Warm up pools/maps so their one-time growth does not count as a leak.
 	var err error
-	for i := 0; i < 100_000; i++ {
+	for range 100_000 {
 		op := hc.StartOperation(context.Background(), hc.OperationStart{Domain: hc.DomainJob, Name: "warmup"})
 		op.End(cfg, &err)
 	}
@@ -116,7 +116,7 @@ func TestStressHeapStable(t *testing.T) {
 	runtime.ReadMemStats(&before)
 
 	const ops = 2_000_000
-	for i := 0; i < ops; i++ {
+	for range ops {
 		op := hc.StartOperation(context.Background(), hc.OperationStart{
 			Domain:  hc.DomainJob,
 			Name:    "cleanup",
@@ -147,11 +147,11 @@ func TestStressConcurrentMixedAccess(t *testing.T) {
 	const iterations = 20_000
 
 	var wg sync.WaitGroup
-	for g := 0; g < goroutines; g++ {
+	for g := range goroutines {
 		wg.Add(1)
 		go func(g int) {
 			defer wg.Done()
-			for i := 0; i < iterations; i++ {
+			for i := range iterations {
 				hc.Add(sharedCtx, "g", g, "i", i, "note", "x")
 				hc.SetLevel(sharedCtx, hc.LevelWarn)
 				hc.SetMessage(sharedCtx, "mixed")
@@ -189,9 +189,7 @@ func TestStressSamplerUnderContention(t *testing.T) {
 			var kept atomic.Int64
 			var wg sync.WaitGroup
 			for range goroutines {
-				wg.Add(1)
-				go func() {
-					defer wg.Done()
+				wg.Go(func() {
 					local := int64(0)
 					for range iterations {
 						if sampler(hc.SampleInput{Outcome: hc.OutcomeSuccess}) {
@@ -199,7 +197,7 @@ func TestStressSamplerUnderContention(t *testing.T) {
 						}
 					}
 					kept.Add(local)
-				}()
+				})
 			}
 			wg.Wait()
 

--- a/config_equivalence_test.go
+++ b/config_equivalence_test.go
@@ -259,13 +259,13 @@ func TestNormalizeConfigRandomizedMatchesReference(t *testing.T) {
 
 	randomLevel := func() Level { return levels[rng.Intn(len(levels))] }
 
-	for i := 0; i < 2000; i++ {
+	for i := range 2000 {
 		cfg := Config{SamplingRate: rates[rng.Intn(len(rates))]}
 
 		if rng.Intn(2) == 0 {
 			n := rng.Intn(4)
 			m := make(map[Level]float64, n)
-			for j := 0; j < n; j++ {
+			for range n {
 				m[randomLevel()] = rates[rng.Intn(len(rates))]
 			}
 			if rng.Intn(4) == 0 {
@@ -277,7 +277,7 @@ func TestNormalizeConfigRandomizedMatchesReference(t *testing.T) {
 		if rng.Intn(2) == 0 {
 			n := rng.Intn(3)
 			m := make(map[Domain]OperationPolicy, n)
-			for j := 0; j < n; j++ {
+			for range n {
 				policy := OperationPolicy{
 					SuccessLevel: randomLevel(),
 					FailureLevel: randomLevel(),
@@ -286,7 +286,7 @@ func TestNormalizeConfigRandomizedMatchesReference(t *testing.T) {
 				if rng.Intn(2) == 0 {
 					n := rng.Intn(3)
 					ol := make(map[Outcome]Level, n)
-					for k := 0; k < n; k++ {
+					for range n {
 						ol[outcomes[rng.Intn(len(outcomes))]] = randomLevel()
 					}
 					policy.OutcomeLevels = ol

--- a/integration/std/middleware_test.go
+++ b/integration/std/middleware_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"errors"
 	"io"
+	"maps"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -362,9 +363,7 @@ func (s *memorySink) Write(level hc.Level, message string, fields map[string]any
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	cp := make(map[string]any, len(fields))
-	for k, v := range fields {
-		cp[k] = v
-	}
+	maps.Copy(cp, fields)
 	s.events = append(s.events, memoryEvent{
 		Level:   level,
 		Message: message,

--- a/prebox_test.go
+++ b/prebox_test.go
@@ -30,12 +30,12 @@ func TestDomainAnyProducesPlainStrings(t *testing.T) {
 
 func TestOutcomeAnyProducesPlainStrings(t *testing.T) {
 	cases := map[Outcome]string{
-		OutcomeSuccess:  "success",
-		OutcomeFailure:  "failure",
-		OutcomePanic:    "panic",
-		OutcomeCanceled: "canceled",
-		OutcomeTimeout:  "timeout",
-		OutcomeRetry:    "retry",
+		OutcomeSuccess:   "success",
+		OutcomeFailure:   "failure",
+		OutcomePanic:     "panic",
+		OutcomeCanceled:  "canceled",
+		OutcomeTimeout:   "timeout",
+		OutcomeRetry:     "retry",
 		Outcome("weird"): "weird",
 	}
 	for outcome, want := range cases {

--- a/sampling.go
+++ b/sampling.go
@@ -2,6 +2,7 @@ package hc
 
 import (
 	"math/rand/v2"
+	"slices"
 	"strings"
 	"time"
 )
@@ -38,11 +39,11 @@ func ChainSampler(base Sampler, middlewares ...SamplerMiddleware) Sampler {
 		base = NeverSampler()
 	}
 	chained := base
-	for i := len(middlewares) - 1; i >= 0; i-- {
-		if middlewares[i] == nil {
+	for _, middleware := range slices.Backward(middlewares) {
+		if middleware == nil {
 			continue
 		}
-		chained = middlewares[i](chained)
+		chained = middleware(chained)
 	}
 	return chained
 }


### PR DESCRIPTION
## What

Removes `SinkOptions.DeterministicOrder` and the pooled-key sort machinery from all three adapters (slog, zap, zerolog): **−253 lines, +36**.

## Why

The option existed to compensate for the map-based sink contract, which cannot carry insertion order — sorting on top only masked that:

- **+22% write cost** on slog medium fields (1,699 → 2,079 ns in `BENCHMARK_REPORT.md`) when enabled
- **~90 lines** of key-pool/sort/recycle code replicated across three modules
- Go randomizes map iteration order by design, so without the option the output was nondeterministic anyway — the default was already random order

Adapters should not sort: no host logger (zap/slog/zerolog) offers sorting, and the map has already erased order by the time a host logger sees a field. Deterministic, insertion-ordered output arrives structurally with the v2 record core (see `V2_PLAN.md` §3a/§6).

## Compatibility

- **Default output bytes: unchanged** — the option was off by default
- Opt-in users get a **compile error** on the removed `SinkOptions` field (loud, not silent)
- Migration for stable-byte assertions: `hc.TestSink` (order-free map comparison) or pin the v0.4 adapter modules — they remain compatible because the `Sink` interface is unchanged
- `SinkOptions` is kept as an empty struct reserved for future options

## Testing

- All modules pass (`.`, 3 adapters, 8 integrations, `cmd/examples`, `benches`)
- `-race` clean on all three adapters
- Removed: per-adapter `TestSinkDeterministicOrderSortsKeys`, zerolog key-pool recycle test, key-pool half of zap/slog recycle tests, deterministic benchmark cases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed deterministic field-ordering support from the slog, zap, and zerolog adapters.
  * Adapter options remain available for future configuration, but no longer provide a stable ordering option.
  * Field output order is now unspecified and follows map iteration behavior.
  * Updated documentation to clarify current ordering behavior and note that deterministic insertion ordering is planned for a future record-based core.
  * Updated tests and benchmarks to reflect the changed behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->