### PR TITLE
docs: prior-art appendix — wide-event and canonical-log-line libraries

### DIFF
--- a/V2_PLAN.md
+++ b/V2_PLAN.md
@@ -943,3 +943,65 @@ table plus dual-write window during the preview.
   (counted) rather than block producers.
 - **RawJSON** — field kind holding pre-encoded JSON appended verbatim;
   escape scan skipped.
+
+## 11. Prior art: wide-event and canonical-log-line libraries
+
+Research pass 2026-08-31 (sources cloned and read at file:line level;
+beeline-go micro-benchmarks measured locally on the M4, everything else
+as claimed by the projects). Question: what public libraries implement
+the "one wide event per request" model, and how do their performance,
+error handling, and sampling compare to ours?
+
+### The primary sources
+
+- **Stripe — canonical log lines (internal, blog-published).** One line
+  per request per service, emitted in a Ruby `ensure` block (fires even
+  while the middleware stack unwinds on an exception) with the logging
+  statement itself wrapped in a nested `rescue` — building a canonical
+  line can never fail a request. Field names are a formal **protobuf
+  contract**; schema changes are breaking changes. Lines ship
+  asynchronously Kafka → S3 → Presto/Redshift and power the Developer
+  Dashboard and incident queries — logs in place of a metrics pipeline.
+  (stripe.com/blog/canonical-log-lines)
+- **Honeycomb — "wide events."** Coined the term; their archived
+  **beeline** SDKs (Go/Node/Python/Ruby/Java) are the closest public
+  analog to hc: middleware opens a request span, fields accumulate,
+  one enriched event per request. Sun-setted in favor of OTel, but the
+  design DNA is ours.
+
+### The public libraries, compared
+
+| Library | Language | Field accumulation | Performance | Error capture | Sampling |
+| --- | --- | --- | --- | --- | --- |
+| beeline-go (archived 2025-08) | Go | ctx span + mutexed map; map copied at send | **measured, M4**: `AddField` 39–49 ns; `CreateSpan` 488 ns / 7 al; `SendSpan` 345 ns / 8 al; async batched transport (50/batch, 100 ms, 10k queue, drop-on-overflow) | 5xx → status field; **no `recover()`** — panics propagate, event sent sans status via deferred Send; drops are silent | SHA-1(traceID) deterministic whole-trace; field-based hook; no salt |
+| pino-http | Node | pino child-logger bindings — **no mutable event** | their stale autocannon (2013 MBP): 21.5k req/s vs 46.1k no-logger | real err on socket errors; 5xx → **synthetic** Error, no stack; aborted-request path known-broken (own skipped test) | none (level-silent trick + `ignore` predicate) |
+| evlog (HugoRCD; audited §7) | TS | closure over one mutable object, in-place merge, stringify once at emit | their published suite: ~2.7 µs/req lifecycle; `emit` 400 ns; wide-event 7.7× pino | full error objects + rethrow; drain failures swallowed; **circular values can crash emit's stringify** | head Math.random per level (errors 100%) + tail keep-rules; not deterministic |
+| lograge | Ruby | ActiveSupport notifications → one KV line | no benchmarks; sync string building | exception → status via ExceptionWrapper; **no rescue around its own emission** — formatter bug breaks requests | none (binary include/exclude) |
+| Serilog.AspNetCore `UseSerilogRequestLogging` | C# | middleware + DiagnosticContext collector | qualitative claim only ("fewer events constructed/transmitted/stored") | exceptions & ≥500 → Error; **4xx stays Information**; logger exceptions propagate | none |
+
+### What it says about our design
+
+1. **The 12-field gate (293 ns / 0 al) is a different class.** It beats
+   beeline-go's span *creation* alone (488 ns / 7 al) before any send;
+   nobody else has pooled-buffer + single-`Write` on the hot path.
+2. **Error-bypass-sampling is unique.** Zero OSS implementations have
+   "always emit errors, sample successes" (amendment 4 is a real
+   differentiator). The only kindred philosophy is Stripe's
+   ensure+rescue: observability must be most reliable when things are
+   worst.
+3. **Sealing (amendment 20) is validated** — evlog's post-emit warning
+   path is exactly the use-after-emit bug class sealing prevents.
+4. **BufferedSink (W11) would be a library-level first.** Every OSS
+   implementation punts buffering to downstream infrastructure (Kafka,
+   Serilog.Sinks.Async, SonicBoom); Stripe does it in infra, not the
+   library.
+5. **Worth stealing: schema discipline.** Stripe's protobuf field
+   contract built org-wide "muscle memory" for querying logs. A short
+   README policy note — `op.*`/`http.*` names are stable, renames are
+   breaking — is the cheap version of that.
+
+Sources: github.com/honeycombio/beeline-go@cb95e4b, github.com/pinojs/
+pino-http, github.com/HugoRCD/evlog, github.com/roidrage/lograge,
+github.com/serilog/serilog-aspnetcore, stripe.com/blog/canonical-log-
+lines, docs.honeycomb.io. Full research notes with file:line citations
+in the PR that added this section.


### PR DESCRIPTION
## What

Adds **V2_PLAN.md §11 — Prior art: wide-event and canonical-log-line libraries** (62 lines): the research pass from today's investigation, distilled into the plan archive.

Contents:
- **Primary sources**: Stripe's canonical log lines (`ensure` + nested `rescue`, protobuf field contract, Kafka→S3→Presto aggregation) and Honeycomb's wide-events/beeline lineage.
- **Comparison table** over beeline-go, pino-http, evlog, lograge, and Serilog.AspNetCore request logging: field accumulation model, performance evidence, error capture, sampling.
- **Five conclusions for our design**: the 293 ns/0-al gate is a different class (beeline-go's span *creation* alone measures 488 ns/7 al on the same M4); error-bypass-sampling is unique in OSS (only Stripe's ensure/rescue shares the philosophy); evlog's post-emit warnings validate our sealing spec (amendment 20); BufferedSink would be a library-level first; and Stripe's protobuf schema discipline suggests a cheap README policy note for `op.*`/`http.*` stability.

Methodology notes: beeline-go figures were measured locally in a cloned tree (micro-benchmarks on this M4); all other numbers are the projects' own claims (several stale — pino-http's autocannon suite dates to a 2013 MBP), marked as such in the text.

Research provenance (full notes from the session, not committed): sources cloned to /tmp and read at file:line level by two independent reviewers (deepseek-v4-pro, qwen3.7-max) — beeline-go@cb95e4b, pinojs/pino-http, HugoRCD/evlog, roidrage/lograge, serilog/serilog-aspnetcore, plus the Stripe blog post and Honeycomb docs.

`docs:` only — no code, no release-please impact. Targets `v2` (the plan archive lives there; §9 port-back lane).
