### PR TITLE
chore: v2 becomes the single release line

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: ci
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, v2]
   push:
-    branches: [main]
+    branches: [main, v2]
 
 permissions:
   contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,7 @@ jobs:
             cmd/examples/go.mod
 
           git commit -m "chore: sync lockstep modules for ${RELEASE_TAG}"
-          git push origin HEAD:main
+          git push origin HEAD:v2
 
       - name: Publish lockstep module releases
         if: ${{ steps.release.outputs.release_created == 'true' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,10 @@
 name: release
 
+# v2 is the release line (V2_DESIGN.md §9 amendment, 2026-08-31).
+# Exactly one branch may run release-please; main is frozen at v0.5.0.
 on:
   push:
-    branches: [main]
+    branches: [v2]
 
 permissions:
   contents: write

--- a/V2_DESIGN.md
+++ b/V2_DESIGN.md
@@ -401,38 +401,37 @@ Every question raised during design, and its final answer.
 | Destination adapters | bridges (slog/zap/zerolog) = formats, shipped at 1.0; `adapter/otlp` = the only first-party destination, post-1.0; per-vendor drains rejected — the Sink interface plus a documented recipe covers custom destinations |
 | Timeline / watchdog | off by default; arm-on-stall; `t_ms` only when armed |
 | Disk-backed WAL | rejected — shipper territory |
-| Compatibility window | old 0.x bridges keep compiling against 0.x core via module versioning; no dual-write in core (mapping table only) |
+| Compatibility window | none needed — zero users; `v2` is the only release line (owner, 2026-08-31), main frozen at v0.5.0; port-back lane retired |
 
 ## 9. Branching and release choreography
 
-`v2` is a long-lived branch off main carrying this spec. Main remains
-the classic-API line until cutover.
+> **Amended 2026-08-31 (owner decision): the dual-line choreography is
+> retired.** With zero external users, the 0.x compatibility window it
+> protected doesn't exist. `v2` is the single development and release
+> line; `main` is frozen at v0.5.0 behind a pointer banner. Version
+> mechanics are unchanged — `feat:` on v2 releases 0.6.0, and the
+> record-core `feat!:` computes 1.0.0 through the same release-please
+> flow, just aimed at v2. The port-back lane is dead: nothing flows to
+> main anymore.
 
-1. **v0.6.0 ships from main** — W1 encoder fork + W2 `NewJSONSink` are
-   additive; they release on the old API (plus the Go-version policy:
-   floor 1.25, CI matrix 1.25/1.26/1.27). After release, main merges
-   into `v2`.
-2. **The break develops on `v2`** — sequenced PRs targeting the `v2`
-   branch: core first (W3 typed WAL with sealing and arming), then
-   W5 Compile/Runtime, W4 Record/Sink, W7 lifecycle, W6 sampler, then
-   W8 bridges, W9 dedupe, integrations, `MIGRATION.md`, runnable
-   examples. Every PR carries the full matrix, `-race`, and benchstat
-   evidence against the §4 gates.
-3. **Port-backs flow v2 → main** whenever compatible: encoder and SWAR
-   improvements, property/fuzz test suites, benchmark harness, small
-   cuts, docs, CI. Never the API-shape work (W3–W9) or pool-dependent
-   internals (sealing, timeline, watchdog).
-4. **Final classic release from main** — feature freeze after the last
-   v0.6.x; fixes only; README banner announcing the classic line's end
-   and pointing at `MIGRATION.md`.
-5. **Cutover** — one PR merging `v2` into main titled
-   `feat!: v2 record core (W3–W9)`. Release-please computes the major
-   bump from the breaking marker: **0.6.x → 1.0.0** — the same
-   mechanism that misfired on v0.5.0 now works for us. Lockstep
-   scripts tag all nested modules 1.0.0; README and docs swap; the
-   classic line lives on as installable 0.x tags.
-6. **Post-cutover**: v1.1.0 (W11 BufferedSink, W12 watchdog, `adapter/
-   otlp` evaluation) proceeds on main, trunk-based.
+1. **v0.6.0 ships from v2** — W1 encoder fork + W2 `NewJSONSink` plus
+   the Go-floor/CI PR merge into v2; release-please opens the release
+   PR there (the release workflow triggers on v2 pushes; CI gates v2
+   PRs).
+2. **The break develops on v2** — sequenced PRs targeting the `v2`
+   branch: core first (W3 typed WAL with sealing and arming), then W5
+   Compile/Runtime, W4 Record/Sink, W7 lifecycle, W6 sampler, then W8
+   bridges, W9 dedupe, integrations, `MIGRATION.md`, runnable examples.
+   Every PR carries the full matrix, `-race`, and benchstat evidence
+   against the §4 gates.
+3. **v1.0.0 releases from v2** — when the S-series merges, release-
+   please computes 0.6.x → 1.0.0 from the breaking marker and lockstep
+   scripts tag all nested modules 1.0.0. No cutover merge, no feature
+   freeze, no classic-line retirement PR.
+4. **main** — frozen at v0.5.0 with a README banner pointing at the v2
+   line; the 0.x tags keep a home. Afterwards, either switch the
+   default branch to v2 or fast-forward main to v2 (a plain merge —
+   main never releases again).
 
 ## 10. What would reopen this design
 

--- a/V2_DESIGN.md
+++ b/V2_DESIGN.md
@@ -12,14 +12,14 @@ behind us.
 | --- | --- | --- | --- |
 | **v0.5.0** — shipped | adapter sort removal, `just tidy` all-modules | soft (done) | — |
 | **v0.6.0** | W1: `internal/hcjson` encoder fork (SWAR hybrid, zerolog-table property test, fuzz 1M, golden vs current zerolog adapter) · W2: `hc.NewJSONSink(io.Writer)` on the *current* Sink interface · jsontext fallback backend behind the internal encoder interface | none | golden output ≡ zerolog adapter (modulo ordering); fuzz clean; soak in `benches` |
-| **v1.0.0** — the break, one PR | W3 typed Event (request-WAL) · W4 `Record`/`Sink` · W5 `Compile`/`Runtime` · W6 sampler `Lookup` · W7 single lifecycle · W8 bridges on `[]Field` · W9 field dedupe · `MIGRATION.md` | yes, lockstep (root + all nested modules) | performance gates §4; full matrix green under `-race`; migration guide published *before* merge |
+| **v1.0.0** — the break (S-series) | W3 typed Event (request-WAL) · W4 `Record`/`Sink` · W5 `Compile`/`Runtime` · W6 sampler `Lookup` · W7 single lifecycle · W8 bridges on `[]Field` · W9 field dedupe · `MIGRATION.md` | yes, lockstep (root + all nested modules) | performance gates §4; full matrix green under `-race`; migration guide published *before* merge |
 | **v1.1.0** | W11 `BufferedSink` (async drain, writev batches) · W12 stall watchdog + in-flight records + timeline arming · encode-once multi-sink reuse | none | buffered append ≤ 100 ns; watchdog emits within 1 s of threshold under load |
 | **later, data-gated** | W10 `hc/log` mini logger · console writer | none | only if post-1.0 profiles justify |
 
 The v0.6 encoder exists so the highest-risk component earns production
 trust on the old core before anything breaks. Nothing else ships
-between v0.6 and the 1.0 core PR — the break is coordinated, atomic,
-and never partially merged.
+between v0.6 and 1.0.0 — the break lands as the coordinated S-series on
+v2 (§9) and releases only when complete.
 
 ## 2. The public API
 

--- a/V2_PLAN.md
+++ b/V2_PLAN.md
@@ -582,6 +582,11 @@ Decision needed: the literal version number.
 Either way: v0.5.0 ships W1 + W2 (first-party sink, non-breaking) first,
 so the encoder gets production soak time before the break.
 
+> Amended 2026-08-31: the non-breaking encoder release is **v0.6.0**, and
+> per the V2_DESIGN §9 amendment everything ships from the `v2` branch —
+> one release line, main frozen at v0.5.0. The 1.0.0 computation is
+> unchanged.
+
 Migration support:
 
 - A `MIGRATION.md` with a before/after table for every removed or changed

--- a/openspec/changes/add-first-party-json-sink/proposal.md
+++ b/openspec/changes/add-first-party-json-sink/proposal.md
@@ -18,7 +18,8 @@ amendment 10.
 - Add the jsontext comparator in `benches/` behind a `go1.27` build tag.
 - Harmonize Go floors to 1.25 across all modules; CI matrix 1.25/1.26/1.27
   with `-race` and a gofmt gate.
-- Release v0.6.0 from main via release-please (`feat:` → minor).
+- Release v0.6.0 from v2 via release-please (`feat:` → minor); v2 is
+  the single release line (§9 amendment, 2026-08-31).
 
 ## Non-goals
 

--- a/openspec/changes/add-first-party-json-sink/tasks.md
+++ b/openspec/changes/add-first-party-json-sink/tasks.md
@@ -1,8 +1,10 @@
 # Tasks: add-first-party-json-sink
 
-Two PRs to main, sequential (not stacked), then release. Stack depth: 0.
+Two PRs, sequential (not stacked), then release. Retargeted to `v2`
+(§9 amendment, 2026-08-31): v2 is the single release line; main stays
+frozen at v0.5.0. Stack depth: 0.
 
-## 1. PR-A `feat: add first-party JSON sink with SWAR encoder` (target: main)
+## 1. PR-A `feat: add first-party JSON sink with SWAR encoder` (target: v2)
 
 - [ ] Vendor `internal/hcjson` from zerolog v1.34.0 `internal/json`
       (types/string/time/bytes/base), MIT notice + attribution file
@@ -20,7 +22,7 @@ Two PRs to main, sequential (not stacked), then release. Stack depth: 0.
 - [ ] Verify: full module matrix green, `-race` on root, benchstat vs the
       §4 gate (≤ 400 ns / ≤ 2 allocs for 12 fields), property test passing
 
-## 2. PR-B `chore: go 1.25 floor, CI matrix with race and format gates` (target: main)
+## 2. PR-B `chore: go 1.25 floor, CI matrix with race and format gates` (target: v2)
 
 - [ ] Harmonize all `go.mod` directives to `go 1.25` (fiberv3 already there)
 - [ ] CI: matrix {1.25.x, 1.26.x, 1.27.x}; add `-race` pass and `gofmt -l`
@@ -29,6 +31,8 @@ Two PRs to main, sequential (not stacked), then release. Stack depth: 0.
 
 ## 3. Release
 
-- [ ] Merge PR-A, PR-B; let release-please open the v0.6.0 release PR
-      (`feat:` → minor from 0.5.0; no breaking markers in scope)
-- [ ] After release: merge main into `v2` so the branch carries the encoder
+- [ ] Merge PR-A, PR-B into v2; let release-please open the v0.6.0
+      release PR on v2 (`feat:` → minor from 0.5.0; no breaking markers
+      in scope)
+- [ ] After release: nothing to sync — v2 is the release line (the old
+      "merge main into v2" step is retired with the §9 amendment)

--- a/openspec/changes/v2-cutover/proposal.md
+++ b/openspec/changes/v2-cutover/proposal.md
@@ -1,33 +1,36 @@
-# v2 cutover — final classic release, then publish v1.0.0
+# v2 single-line release — publish v1.0.0 from v2
 
 ## Why
 
-The classic line must end deliberately (with the migration guide already
-published) and the v2 architecture must publish as **v1.0.0** — reserving
-`/v2` module-path churn and making the stability promise at the moment
-the new API lands. Choreography: `V2_DESIGN.md` §9.
+Zero external users means the dual-line choreography (classic main line,
+port-back lane, cutover merge) protects a compatibility window that does
+not exist. Owner decision 2026-08-31: `v2` becomes the single
+development and release line; `main` freezes at v0.5.0 behind a pointer
+banner. `V2_DESIGN.md` §9 is amended accordingly.
 
 ## What Changes
 
-- Feature-freeze main after the last v0.6.x; final classic release with a
-  README banner pointing to `MIGRATION.md`.
-- One cutover PR merges `v2` into main as `feat!: v2 record core (W3–W9)`.
-  Release-please computes **0.6.x → 1.0.0** from the breaking marker — the
-  same mechanism hand-corrected at v0.5.0, now working for us.
-- Lockstep scripts strip branch-local `replace` directives, tag root
-  `v1.0.0` and every nested module `<path>/v1.0.0`.
-- README/docs swap to v2; the classic line remains installable as 0.x tags.
+- Release workflow triggers on `v2` pushes only (exactly one branch may
+  run release-please); CI gates PRs against `v2` as well as `main`.
+- v0.6.0 (`add-first-party-json-sink`) releases **from v2**: PR-A/PR-B
+  retarget to v2, release-please computes 0.5.0 → 0.6.0 there.
+- The v1.0.0 path is unchanged in mechanism: the record-core breaking
+  markers compute 0.6.x → 1.0.0 on v2; lockstep scripts tag all nested
+  modules; no cutover merge, no classic-line retirement PR.
+- `main` keeps the 0.x tags and a banner; afterwards the default branch
+  moves to v2 (or main is fast-forwarded once — a plain merge).
 
 ## Non-goals
 
 - v1.1 features (BufferedSink, watchdog, `adapter/otlp` evaluation) —
-  trunk-based after cutover.
-- Renaming the module or moving to `/v2` paths.
+  sequenced after 1.0.0 as fresh changes.
+- Renaming the module or moving to `/v2` import paths.
+- Any change to the record-core work itself (`v2-record-core` is
+  unaffected: it already targets `v2`).
 
 ## Impact
 
-- Affected specs: `release-process` (new capability).
-- Affected code: none beyond merges — all code landed via `v2-record-core`.
+- Affected specs: `release-process` (branch references retargeted).
+- Affected code: CI/release workflows only.
 - Risk: release automation surprises — mitigated by verifying the v0.6.0
-  release flow end-to-end first and watching the cutover workflow's
-  `RELEASE_TAG`.
+  release end-to-end on v2 before any breaking work lands.

--- a/openspec/changes/v2-cutover/specs/release-process/spec.md
+++ b/openspec/changes/v2-cutover/specs/release-process/spec.md
@@ -5,10 +5,11 @@
 ### Requirement: Breaking releases compute the major
 A release PR containing a breaking conventional-commit marker SHALL
 compute a major version bump via release-please; maintainers SHALL
-verify the computed version before merging any release PR.
+verify the computed version before merging any release PR. The release
+branch is `v2` (§9 amendment); release-please runs on v2 pushes only.
 
-#### Scenario: Cutover bump
-- GIVEN main at 0.6.x and a cutover commit titled `feat!: v2 record core`
+#### Scenario: Record-core bump
+- GIVEN v2 at 0.6.x and a record-core commit titled `feat!: v2 record core`
 - WHEN release-please runs
 - THEN the release PR proposes `1.0.0`
 

--- a/openspec/changes/v2-cutover/tasks.md
+++ b/openspec/changes/v2-cutover/tasks.md
@@ -1,32 +1,37 @@
 # Tasks: v2-cutover
 
-Sequential PRs on main, no stacking. Prerequisite: `v2-record-core` fully
-merged on the `v2` branch.
+Single release line on `v2` (V2_DESIGN.md §9 amendment, 2026-08-31).
+No cutover merge and no classic-line freeze: `main` is frozen at v0.5.0
+behind a pointer banner. Prerequisite: `add-first-party-json-sink`
+merged on `v2` and v0.6.0 released there.
 
-## 1. PR-F1 `docs: announce classic line end` (target: main)
+## 1. Release line switch (target: v2)
 
-- [ ] After the final planned v0.6.x port-back release, freeze features
-- [ ] README banner: final classic release; v1.0.0 (v2 record core) next;
-      link `MIGRATION.md` (published from the v2 branch's PR-S4)
-- [ ] Release the final classic version via release-please and verify tags
+- [ ] Choreography PR: release workflow triggers on v2 only; CI gates
+      v2 PRs; V2_DESIGN §9 + ledger amended; main banner PR open
+- [ ] Merge PR-A/PR-B (retargeted to v2); release v0.6.0 via
+      release-please on v2; verify the release PR computes 0.5.0 →
+      0.6.0 and the lockstep workflow tags nested modules v0.6.0 (the
+      v0.5.0 lesson: never merge a release PR with a surprising
+      version)
 
-## 2. PR-F2 `feat!: v2 record core (W3–W9)` (target: main, from `v2`)
+## 2. v1.0.0 (target: v2, after `v2-record-core`)
 
-- [ ] Pre-flight: v2 branch green on full matrix + `-race`; §4 gates
-      evidenced in the PR body; `MIGRATION.md` reviewed
-- [ ] Merge `v2` into main with the breaking-marker title
-- [ ] Confirm release-please opens `chore(main): release 1.0.0` — if it
-      computes anything else, stop and reconcile the manifest before merge
-      (the v0.5.0 lesson)
-- [ ] Verify the lockstep workflow: `RELEASE_TAG=v1.0.0`, nested module
-      tags created, branch-local replaces stripped
-- [ ] Verify `go list -m -versions` picks up root + nested 1.0.0; smoke
-      `go get github.com/happytoolin/happycontext@v1.0.0` in a scratch
-      module against the README quick start
+- [ ] Pre-flight: v2 green on full matrix + `-race`; §4 gates evidenced
+      in the final PR; `MIGRATION.md` reviewed
+- [ ] Merge the final `v2-record-core` PRs carrying breaking markers;
+      confirm release-please opens `chore(release): 1.0.0` — anything
+      else, stop and reconcile the manifest before merging
+- [ ] Verify lockstep: `RELEASE_TAG=v1.0.0`, nested module tags created,
+      branch-local replaces stripped; smoke `go get
+      github.com/happytoolin/happycontext@v1.0.0` in a scratch module
+      against the README quick start
 
-## 3. Post-cutover
+## 3. Post-1.0
 
 - [ ] Archive the three OpenSpec changes (`openspec archive …`) so main
       specs absorb the deltas
 - [ ] Open the v1.1.0 parking-lot review (BufferedSink, watchdog,
       `adapter/otlp`) as fresh changes — nothing starts without them
+- [ ] Owner decision: switch the GitHub default branch to v2, or fast
+      forward main to v2 once (plain merge; main never releases again)

--- a/openspec/changes/v2-record-core/proposal.md
+++ b/openspec/changes/v2-record-core/proposal.md
@@ -11,7 +11,8 @@ Full design, measurements, and the 21 amendments: `V2_DESIGN.md`.
 ## What Changes
 
 Delivered as **four stacked PRs to the `v2` branch** (stack depth 4 —
-deliberately shallow), then port-backs flow to main:
+deliberately shallow). Per the §9 amendment (2026-08-31) v2 is the only
+line — nothing flows to main:
 
 - **PR-S1 — core**: typed `Field`/record WAL (append-only, sealed after
   `End`, atomic arming protocol), pooled events, encode-time last-wins
@@ -32,7 +33,7 @@ deliberately shallow), then port-backs flow to main:
 
 - BufferedSink, stall watchdog, timeline (v1.1+; `v2_DESIGN.md` §8 ledger).
 - OTel correlation or any destination adapter (parking lot).
-- Any change to the classic line beyond port-backs of compatible work.
+- Any change to frozen main (retired with the port-back lane, §9 amendment).
 
 ## Impact
 

--- a/openspec/changes/v2-record-core/tasks.md
+++ b/openspec/changes/v2-record-core/tasks.md
@@ -1,8 +1,9 @@
 # Tasks: v2-record-core
 
-Four stacked PRs to `v2` (each rebased on its parent), plus an opportunistic
-port-back lane. Every PR ships with the full module matrix, `-race`, and
-benchstat evidence against the `V2_DESIGN.md` §4 gates.
+Four stacked PRs to `v2` (each rebased on its parent). Every PR ships
+with the full module matrix, `-race`, and benchstat evidence against the
+`V2_DESIGN.md` §4 gates. (The opportunistic port-back lane to main is
+retired with the §9 amendment, 2026-08-31 — v2 is the only line.)
 
 ## 1. PR-S1 `feat(core)!: typed WAL record core` (target: v2, stack base)
 
@@ -61,11 +62,3 @@ benchstat evidence against the `V2_DESIGN.md` §4 gates.
       outcome-precedence and field-rename callouts
 - [ ] README v2 rewrite (quick starts from the spec's §2 samples)
 - [ ] Verify: `go test` runs examples; docs build; full matrix final pass
-
-## 5. Port-back lane (target: main, opportunistic — never stacked)
-
-- [ ] After each PR-S merges: cherry-pick compatible items to main
-      (encoder/SWAR improvements, property+fuzz suites, bench harness,
-      docs, CI) as small `chore:`/`test:` PRs feeding the next v0.6.x
-- [ ] Never port: API-shape work (S1–S3) or pool-dependent internals
-      (sealing, arming, timeline, watchdog)

--- a/scripts/publish-lockstep-release.sh
+++ b/scripts/publish-lockstep-release.sh
@@ -13,7 +13,7 @@ provided.
 Examples:
   ./scripts/publish-lockstep-release.sh v0.2.3
   ./scripts/publish-lockstep-release.sh --push --github-releases v0.2.3
-  ./scripts/publish-lockstep-release.sh --push v0.2.3 origin/main
+  ./scripts/publish-lockstep-release.sh --push v0.2.3 origin/v2
 EOF
 }
 


### PR DESCRIPTION
## What

Owner decision 2026-08-31: **`v2` becomes the single development and release line**; `main` freezes at v0.5.0 behind a pointer banner (banner PR follows separately). Zero external users means the dual-line choreography — classic main line, port-back lane, cutover merge, feature freeze — protected a compatibility window that doesn't exist.

Mechanics in this PR:
- `release.yml`: triggers on `v2` pushes **only** — exactly one branch may run release-please, or versions fork between branches
- `ci.yml`: gates PRs against `v2` (and `main`, which still gets the banner PR)
- `V2_DESIGN.md` §9 rewritten as a dated owner amendment; decisions-ledger row updated; `V2_PLAN.md` §5 note
- openspec: `v2-cutover` retitled/retasked for single-line release (v0.6.0 from v2 → 1.0.0 from v2 → post-1.0 housekeeping; no cutover merge, no classic freeze); `add-first-party-json-sink` PRs retargeted to v2; `release-process` spec branch references updated. `openspec validate --changes --strict` green (3/3).

Version mechanics are **unchanged**: `feat:` on v2 → release-please computes 0.6.0; the record-core `feat!:` markers compute 1.0.0 — same flow, different branch. The v0.5.0 lesson (verify the computed version before merging any release PR) is now a spec scenario.

## Downstream (after this merges)

1. #23 and #24 are retargeted `main` → `v2` (branches already carry the merge; add/add on `openspec/.../tasks.md` resolved to the ticked, v2-targeted version)
2. Merge #23 → #24 → release-please opens `chore(release): 0.6.0` **on v2** → lockstep tags nested modules
3. `v2-record-core` proceeds exactly as specced (it already targeted v2)
4. Banner PR on main points at the v2 line

No code changes; no release-please impact from this PR itself (`chore:`).
