### PR TITLE
docs: freeze main at 0.5.0, point at the v2 release line

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # happycontext
 
+> **Development and releases have moved to the [`v2` branch`](https://github.com/happytoolin/happycontext/tree/v2).**
+> This branch is frozen at v0.5.0 and kept only as the home of the 0.x
+> tags; the 0.x line remains installable via
+> `go get github.com/happytoolin/happycontext@v0.5.0`. New work —
+> starting with v0.6.0 — ships from `v2`.
+
 ![happycontext banner](./assets/og-image.svg)
 
 [![CI](https://github.com/happytoolin/happycontext/actions/workflows/ci.yml/badge.svg)](https://github.com/happytoolin/happycontext/actions/workflows/ci.yml)


### PR DESCRIPTION
## What

Banner on frozen `main`: development and releases moved to the [`v2` branch](https://github.com/happytoolin/happycontext/tree/v2) (owner decision 2026-08-31, zero users — see #26 for the release-line switch). This branch stays at v0.5.0 as the home of the 0.x tags.

`docs:` only. Merge after #26 (which retargets CI/release workflows to v2) — order between this and #23/#24 doesn't matter otherwise. `main` never sees another release; its CI still runs (gating this PR) but nothing else should land here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a notice explaining that ongoing development and releases have moved to the `v2` branch.
  - Clarified that the current branch remains frozen at version 0.5.0 and is still available for installation.
  - Noted that future releases beginning with version 0.6.0 will come from `v2`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->