### PR TITLE
chore: point release-please at the v2 branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,10 @@ jobs:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
           config-file: .release-please-config.json
           manifest-file: .release-please-manifest.json
+          # v2 is the release line (§9 amendment): the action's default
+          # branch input is the repo default (main), which made it scan
+          # frozen main and find nothing releasable.
+          branch: v2
 
       - name: Checkout
         if: ${{ steps.release.outputs.releases_created == 'true' }}


### PR DESCRIPTION
## What

One-line fix for the release line switch (#26, my miss): release-please's v4 action defaults its `branch` input to the **repo default branch (main)**, not the triggering branch. After #26 retargeted the workflow trigger to v2, the action ran on v2 pushes but computed against frozen main — the run logs show `targetBranch: main`, 2 docs-only commits since v0.5.0, and `No user facing commits found - skipping`. No v0.6.0 release PR was ever opened.

This passes `branch: v2` explicitly (with a comment explaining why). After merging, the next v2 push (or a re-run) should open **`chore(release): 0.6.0`** — verify it computes 0.5.0 → 0.6.0 (feat: from #23) before merging it, then lockstep tags the nested modules.
