### PR TITLE
docs: examples, migration guide, README

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,131 @@
+# Migrating from v0.x to v1.0.0
+
+v1.0.0 is the v2 record core: the same one-canonical-event-per-request
+philosophy on a typed, insertion-ordered WAL instead of a map. This
+guide maps every removed or changed symbol. The
+[wire format](#wire-format-changes) section covers output differences.
+
+## The mental model
+
+- **v0**: configure per call sites (`hc.Config` handed to middleware or
+  `op.End`), fields in a `map[string]any` (random order), sinks receive
+  `(level, message, map)`.
+- **v1**: `hc.Compile`/`hc.MustCompile` once at startup → an immutable
+  `*Runtime` shared by everything; fields are typed `hc.Field` records
+  in insertion order; sinks receive `(ctx, *hc.Record)`.
+
+## Construction
+
+| v0 | v1 |
+|---|---|
+| `hc.Config{...}` passed to middleware / `op.End(cfg, &err)` | `rt := hc.MustCompile(hc.Config{...})` once; middleware takes `rt`; `op.End(&err)` |
+| `hc.NormalizeConfig(cfg)` | internal to `Compile`; invalid config is now a **construction-time error** (`ErrInvalidRate`, `ErrInvalidLevel`, `ErrInvalidOutcome`, wrapped with `%w`) |
+| — | `hc.Compile(cfg) (*Runtime, error)` for config from files/flags |
+
+```go
+// v0
+mw := stdhc.Middleware(hc.Config{Sink: sink, SamplingRate: 1})
+
+// v1
+rt := hc.MustCompile(hc.Config{Sink: sink, SamplingRate: 1})
+mw := stdhc.Middleware(rt)
+```
+
+## Lifecycle
+
+| v0 | v1 |
+|---|---|
+| `hc.BeginOperation(ctx, start)` → `(ctx, *Event)` | `op := hc.Start(ctx, rt, start)`; pass `op.Context()` down |
+| `hc.StartOperation(ctx, start)` → `*Operation` | `hc.Start(ctx, rt, start)` |
+| `op.End(cfg, &err)` | `op.End(&err)` — one-shot, returns *emitted* |
+| `hc.FinishOperation(cfg, OperationFinish{...})` | gone; integrations call `op.End` |
+| `hc.Commit(ctx, sink, level)` | gone; the event commits once at `op.End` |
+| `op.Event()` | gone; the WAL is request-confined (use the sampler view or sinks) |
+
+`End` must be **deferred directly** — `defer op.End(&err)`. The closure
+form (`defer func() { op.End(&err) }()`) compiles but silently disables
+panic capture.
+
+## Fields
+
+| v0 | v1 |
+|---|---|
+| `hc.Add(ctx, k, v)` returning `bool` | same call, returns nothing (silent no-op without an event — the `slog` helper idiom) |
+| `hc.EventFields(e)` / `EventMessage` / `EventHasMessage` / `EventHasError` / `EventStartTime` | gone; sinks receive `*hc.Record` (`Fields()`, `Lookup`, `Message()`, `Level()`); samplers receive `SampleInput.Fields()`/`Lookup` |
+| `hc.NewContext(ctx)` / `hc.FromContext(ctx)` | gone (internal) |
+| `hc.AddRaw(ctx, k, raw)` | `hc.AddRawJSON(ctx, k, raw)` |
+| — | `hc.SetLevel(ctx, level)` unchanged in shape; `GetLevel` removed |
+
+## Levels
+
+`hc.Level` is now int-backed with slog-compatible ranks
+(`LevelDebug = -4`, `LevelInfo = 0`, `LevelWarn = 4`, `LevelError = 8`).
+Source that references the constants compiles unchanged;
+`hc.LevelRank` and `hc.MergeLevelWithFloor` are gone (internal).
+
+## Sinks
+
+```go
+// v0
+type Sink interface {
+    Write(level hc.Level, message string, fields map[string]any)
+}
+
+// v1 — slog.Handler.Handle shape
+type Sink interface {
+    Write(ctx context.Context, rec *hc.Record)
+}
+```
+
+- `rec.Fields()` is the insertion-ordered typed slice; `rec.Lookup(key)`
+  resolves last-write-wins; `rec.Encoded()` is the canonical JSON line,
+  computed once (copy it if you retain it).
+- The Record is valid only inside `Write`; sinks must be safe for
+  concurrent use.
+
+## Bridges
+
+`NewWithOptions` and `SinkOptions` are removed from all three adapters
+(`adapter/slog`, `adapter/zap`, `adapter/zerolog`) — constructors are
+`New` only. Bridges iterate `rec.Fields()` in order with typed
+constructors.
+
+## Outcome precedence
+
+v0 resolved `explicit outcome > error > panic` in some paths; v1 is
+strictly **panic > error > explicit > 5xx > success**. Errors and
+panics also **bypass sampling structurally** — before any custom
+`Sampler` runs — so `NeverSampler()` can no longer hide failures.
+
+## Wire format changes
+
+- **Field order**: insertion order (deterministic), replacing Go's
+  random map order.
+- **`op.code`**: emitted only for non-HTTP operations (from the explicit
+  `op.code` field); HTTP events carry `http.status`.
+- **Worker `job.*` mirrors dropped**: `job.name`, `job.id`,
+  `job.queue`, `job.attempt`, `job.max_attempts` are gone — `op.name`,
+  `op.id`, `op.source`, `op.attempt`, `op.max_attempts` carry them.
+  `job.scheduled_at` remains.
+- **Duplicate keys**: last write wins (v0 maps did the same); encoding
+  emits each key once.
+- **Durations** through bridges render each host's native shape
+  (unchanged from v0 adapters); the first-party JSON sink renders float
+  milliseconds.
+- **Failure levels on default policies**: unchanged (INFO success,
+  ERROR failures/panics).
+
+## Removed symbols (complete list)
+
+`BeginOperation`, `FinishOperation`, `OperationFinish`, `StartOperation`,
+`Commit`, `GetLevel`, `LevelRank`, `MergeLevelWithFloor`, `EventFields`,
+`EventMessage`, `EventHasMessage`, `EventHasError`, `EventStartTime`,
+`NewContext`, `FromContext`, `NormalizeConfig`, `AddRaw`, plus the
+`Event` type itself, `SinkOptions`/`NewWithOptions` in the bridges, and
+`operation/common.NormalizeConfig`-style helpers that moved into
+`Compile`.
+
+## Nothing to configure?
+
+A `nil` `*Runtime` is a valid no-op: requests run, nothing emits — the
+v0 zero-config behavior, kept deliberately.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -92,7 +92,7 @@ constructors.
 
 ## Outcome precedence
 
-v0 resolved `explicit outcome > error > panic` in some paths; v1 is
+v0 resolved `explicit outcome > panic > error` in some paths; v1 is
 strictly **panic > error > explicit > 5xx > success**. Errors and
 panics also **bypass sampling structurally** — before any custom
 `Sampler` runs — so `NeverSampler()` can no longer hide failures.
@@ -112,6 +112,10 @@ panics also **bypass sampling structurally** — before any custom
 - **Durations** through bridges render each host's native shape
   (unchanged from v0 adapters); the first-party JSON sink renders float
   milliseconds.
+- **float32 values**: the JSON sink and the zap/zerolog bridges render
+  32-bit precision (`0.1`); the slog host widens on Go ≥ 1.24
+  (`slog.AnyValue` converts to `Float64Value`) — same as the v0
+  adapter.
 - **Failure levels on default policies**: unchanged (INFO success,
   ERROR failures/panics).
 

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ mw := stdhc.Middleware(hc.MustCompile(hc.Config{
 		hc.LevelWarn:  1.0, // keep all warns
 		hc.LevelDebug: 0.01,
 	},
-})
+}))
 ```
 
 Custom sampler (route/user/latency rules):
@@ -198,14 +198,11 @@ mw := stdhc.Middleware(hc.MustCompile(hc.Config{
 			return true
 		}
 		// Keep enterprise requests based on event fields.
-		fields := hc.EventFields(in.Event)
-		tier, _ := fields["user_tier"].(string)
+		tier, _ := in.Lookup("user_tier")
 		return tier == "enterprise"
 	},
-})
+}))
 ```
-
-`hc.EventFields` returns a shallow copy of top-level fields. Nested maps/slices are shared references.
 
 `hc.Add` accepts one or more key/value pairs:
 `hc.Add(ctx, "k1", v1, "k2", v2, "k3", v3)`.
@@ -224,7 +221,7 @@ mw := stdhc.Middleware(hc.MustCompile(hc.Config{
 		hc.KeepPathPrefix("/admin"), // always keep admin paths
 		hc.KeepSlowerThan(500*time.Millisecond),
 	),
-})))
+}))
 ```
 
 Sampler building blocks:
@@ -316,7 +313,7 @@ import (
 func main() {
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
 	sink := sloghc.New(logger)
-	mw := stdhc.Middleware(hc.MustCompile(hc.Config{Sink: sink, SamplingRate: 1})))
+	mw := stdhc.Middleware(hc.MustCompile(hc.Config{Sink: sink, SamplingRate: 1}))
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
@@ -480,7 +477,7 @@ import (
 func main() {
 	logger := zap.NewExample()
 	sink := zaphc.New(logger)
-	mw := stdhc.Middleware(hc.MustCompile(hc.Config{Sink: sink, SamplingRate: 1})))
+	mw := stdhc.Middleware(hc.MustCompile(hc.Config{Sink: sink, SamplingRate: 1}))
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
@@ -513,7 +510,7 @@ import (
 func main() {
 	logger := zerolog.New(os.Stdout).With().Timestamp().Logger()
 	sink := zerologhc.New(&logger)
-	mw := stdhc.Middleware(hc.MustCompile(hc.Config{Sink: sink, SamplingRate: 1})))
+	mw := stdhc.Middleware(hc.MustCompile(hc.Config{Sink: sink, SamplingRate: 1}))
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ func runImport(ctx context.Context, rt *hc.Runtime) (err error) {
 	})
 	defer op.End(&err) // captures errors AND panics; re-panics
 
-	hc.Add(ctx, "rows", 42, "source", "queue")
+	hc.Add(op.Context(), "rows", 42, "source", "queue")
 	return doImport(ctx)
 }
 ```
@@ -224,7 +224,7 @@ mw := stdhc.Middleware(hc.MustCompile(hc.Config{
 		hc.KeepPathPrefix("/admin"), // always keep admin paths
 		hc.KeepSlowerThan(500*time.Millisecond),
 	),
-}))
+})))
 ```
 
 Sampler building blocks:
@@ -293,7 +293,7 @@ sink := hc.NewJSONSink(os.Stdout)
 
 The wire format matches `zerolog.New(w).With().Timestamp().Logger()`
 through `adapter/zerolog`, so existing pipelines ingest it unchanged.
-Field order remains unspecified (map-based, same as the adapters).
+Field order is insertion order — deterministic by construction, identical across every sink.
 
 ## More Examples
 
@@ -316,7 +316,7 @@ import (
 func main() {
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
 	sink := sloghc.New(logger)
-	mw := stdhc.Middleware(hc.MustCompile(hc.Config{Sink: sink, SamplingRate: 1}))
+	mw := stdhc.Middleware(hc.MustCompile(hc.Config{Sink: sink, SamplingRate: 1})))
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
@@ -351,7 +351,7 @@ func main() {
 	sink := sloghc.New(logger)
 
 	r := gin.New()
-	r.Use(ginhc.Middleware(hc.MustCompile(hc.Config{Sink: sink, SamplingRate: 1}))
+	r.Use(ginhc.Middleware(hc.MustCompile(hc.Config{Sink: sink, SamplingRate: 1})))
 	r.GET("/users/:id", func(c *gin.Context) {
 		hc.Add(c.Request.Context(), "router", "gin")
 		c.Status(200)
@@ -384,7 +384,7 @@ func main() {
 	sink := sloghc.New(logger)
 
 	app := fiber.New()
-	app.Use(fiberhc.Middleware(hc.MustCompile(hc.Config{Sink: sink, SamplingRate: 1}))
+	app.Use(fiberhc.Middleware(hc.MustCompile(hc.Config{Sink: sink, SamplingRate: 1})))
 	app.Get("/users/:id", func(c *fiber.Ctx) error {
 		hc.Add(c.UserContext(), "router", "fiber-v2")
 		return c.SendStatus(200)
@@ -417,7 +417,7 @@ func main() {
 	sink := sloghc.New(logger)
 
 	app := fiber.New()
-	app.Use(fiberv3hc.Middleware(hc.MustCompile(hc.Config{Sink: sink, SamplingRate: 1}))
+	app.Use(fiberv3hc.Middleware(hc.MustCompile(hc.Config{Sink: sink, SamplingRate: 1})))
 	app.Get("/users/:id", func(c fiber.Ctx) error {
 		hc.Add(c.Context(), "router", "fiber-v3")
 		return c.SendStatus(200)
@@ -450,7 +450,7 @@ func main() {
 	sink := sloghc.New(logger)
 
 	e := echo.New()
-	e.Use(echohc.Middleware(hc.MustCompile(hc.Config{Sink: sink, SamplingRate: 1}))
+	e.Use(echohc.Middleware(hc.MustCompile(hc.Config{Sink: sink, SamplingRate: 1})))
 	e.GET("/users/:id", func(c echo.Context) error {
 		hc.Add(c.Request().Context(), "router", "echo")
 		return c.NoContent(200)
@@ -480,7 +480,7 @@ import (
 func main() {
 	logger := zap.NewExample()
 	sink := zaphc.New(logger)
-	mw := stdhc.Middleware(hc.MustCompile(hc.Config{Sink: sink, SamplingRate: 1}))
+	mw := stdhc.Middleware(hc.MustCompile(hc.Config{Sink: sink, SamplingRate: 1})))
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
@@ -513,7 +513,7 @@ import (
 func main() {
 	logger := zerolog.New(os.Stdout).With().Timestamp().Logger()
 	sink := zerologhc.New(&logger)
-	mw := stdhc.Middleware(hc.MustCompile(hc.Config{Sink: sink, SamplingRate: 1}))
+	mw := stdhc.Middleware(hc.MustCompile(hc.Config{Sink: sink, SamplingRate: 1})))
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![CI](https://github.com/happytoolin/happycontext/actions/workflows/ci.yml/badge.svg)](https://github.com/happytoolin/happycontext/actions/workflows/ci.yml)
 [![Release](https://github.com/happytoolin/happycontext/actions/workflows/release.yml/badge.svg)](https://github.com/happytoolin/happycontext/actions/workflows/release.yml)
 [![Go Reference](https://pkg.go.dev/badge/github.com/happytoolin/happycontext.svg)](https://pkg.go.dev/github.com/happytoolin/happycontext)
-[![Go Version](https://img.shields.io/badge/go-1.24%2B-00ADD8?logo=go)](https://go.dev/)
+[![Go Version](https://img.shields.io/badge/go-1.25%2B-00ADD8?logo=go)](https://go.dev/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
 
 Most application logs are high-volume but low-context.
@@ -39,6 +39,8 @@ Install only the adapter and integration packages you use.
 
 ## Quick Start (`net/http` + `slog`)
 
+Compile the runtime once, wrap the handler, annotate with `hc.Add`:
+
 ```go
 package main
 
@@ -57,11 +59,11 @@ func main() {
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
 	sink := sloghc.New(logger)
 
-	mw := stdhc.Middleware(hc.Config{
+	rt := hc.MustCompile(hc.Config{
 		Sink:         sink,
 		SamplingRate: 1.0,
-		Message:      hc.DefaultMessage,
 	})
+	mw := stdhc.Middleware(rt)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /orders/{id}", func(w http.ResponseWriter, r *http.Request) {
@@ -85,75 +87,36 @@ Other quick starts:
 - `net/http + zap` and `net/http + zerolog` are in `## More Examples`
 - `gin`, `echo`, `fiber v2`, and `fiber v3` (with `slog`) are in `## More Examples`
 - Runnable reference apps are in `cmd/examples`
+- Zero-dependency output: `hc.NewJSONSink(os.Stdout)` needs no logger at all
 
-## Quick Start (Background Job + `slog`)
+## Quick Start (Background Job)
 
 ```go
-package main
-
-import (
-	"context"
-	"log/slog"
-	"os"
-
-	hc "github.com/happytoolin/happycontext"
-	sloghc "github.com/happytoolin/happycontext/adapter/slog"
-	workerhc "github.com/happytoolin/happycontext/integration/worker"
-)
-
-func main() {
-	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
-	sink := sloghc.New(logger)
-	cfg := hc.Config{
-		Sink:         sink,
-		SamplingRate: 1,
-	}
-
-	meta := workerhc.JobMeta{
-		Name:        "billing.reconcile",
+func runImport(ctx context.Context, rt *hc.Runtime) (err error) {
+	op := hc.Start(ctx, rt, hc.OperationStart{
+		Domain:      hc.DomainJob,
+		Name:        "import",
 		ID:          "job_8472",
-		Queue:       "nightly",
-		Attempt:     1,
+		Attempt:     2,
 		MaxAttempts: 3,
-	}
+	})
+	defer op.End(&err) // captures errors AND panics; re-panics
 
-	_ = runJob(context.Background(), cfg, meta)
-}
-
-func runJob(ctx context.Context, cfg hc.Config, meta workerhc.JobMeta) (err error) {
-	op := workerhc.Start(ctx, meta)
-	defer op.End(cfg, &err)
-
-	hc.Add(op.Context(), "tenant", "enterprise")
-	return nil
+	hc.Add(ctx, "rows", 42, "source", "queue")
+	return doImport(ctx)
 }
 ```
 
-Example output:
-
-```json
-{
-  "time": "2026-02-09T14:03:12.451Z",
-  "level": "INFO",
-  "msg": "operation_completed",
-  "duration_ms": 3,
-  "job.attempt": 1,
-  "job.id": "job_8472",
-  "job.max_attempts": 3,
-  "job.name": "billing.reconcile",
-  "job.queue": "nightly",
-  "op.attempt": 1,
-  "op.domain": "job",
-  "op.id": "job_8472",
-  "op.max_attempts": 3,
-  "op.name": "billing.reconcile",
-  "op.outcome": "success",
-  "op.source": "nightly",
-  "tenant": "enterprise"
-}
-```
+One event, always: header fields, handler fields in attach order, and
+completion fields — deterministic by construction. Failures are never
+sampled away.
 
 ## Configuration
+
+Compile once at startup; `*hc.Runtime` is immutable and shared by all
+requests. Invalid configuration is a construction-time error
+(`hc.ErrInvalidRate`, `hc.ErrInvalidLevel`, `hc.ErrInvalidOutcome`) —
+use `hc.Compile` for config from files, `hc.MustCompile` for literals.
 
 `hc.Config` gives you the core controls:
 
@@ -207,7 +170,7 @@ Errors are recorded as structured metadata:
 Per-level sampling:
 
 ```go
-mw := stdhc.Middleware(hc.Config{
+mw := stdhc.Middleware(hc.MustCompile(hc.Config{
 	Sink:         sink,
 	SamplingRate: 0.05, // default for healthy traffic
 	LevelSamplingRates: map[hc.Level]float64{
@@ -220,7 +183,7 @@ mw := stdhc.Middleware(hc.Config{
 Custom sampler (route/user/latency rules):
 
 ```go
-mw := stdhc.Middleware(hc.Config{
+mw := stdhc.Middleware(hc.MustCompile(hc.Config{
 	Sink: sink,
 	Sampler: func(in hc.SampleInput) bool {
 		// Always keep failures and slow requests.
@@ -253,7 +216,7 @@ For non-HTTP operations use `Domain`, `Operation`, `Outcome`, and `Code`.
 Built-in sampler chain:
 
 ```go
-mw := stdhc.Middleware(hc.Config{
+mw := stdhc.Middleware(hc.MustCompile(hc.Config{
 	Sink: sink,
 	Sampler: hc.ChainSampler(
 		hc.RateSampler(0.05),        // base sampler
@@ -261,7 +224,7 @@ mw := stdhc.Middleware(hc.Config{
 		hc.KeepPathPrefix("/admin"), // always keep admin paths
 		hc.KeepSlowerThan(500*time.Millisecond),
 	),
-})
+}))
 ```
 
 Sampler building blocks:
@@ -276,25 +239,26 @@ Sampler building blocks:
 
 ### Generic Operation Lifecycle API
 
-For non-HTTP flows, use `hc.StartOperation` for the ergonomic stateful handle:
+For non-HTTP flows, use `hc.Start` with the compiled runtime:
 
 ```go
-func runJob(cfg hc.Config) (err error) {
-	op := hc.StartOperation(context.Background(), hc.OperationStart{
+func runJob(ctx context.Context, rt *hc.Runtime) (err error) {
+	op := hc.Start(ctx, rt, hc.OperationStart{
 		Domain: hc.DomainJob,
 		Name:   "invoice.reconcile",
 		ID:     "job_1001",
 		Source: "nightly",
 	})
-	defer op.End(cfg, &err)
+	defer op.End(&err) // direct defer: captures errors and panics
 
-	hc.Add(op.Context(), "job.queue", "nightly")
 	hc.Add(op.Context(), "account_id", "acct_42")
 	return nil
 }
 ```
 
-`op.End(cfg, &err)` is the supported non-HTTP completion path in this API.
+`op.End(&err)` is the only completion path: one-shot, returning whether
+the event was emitted. The `worker` integration wraps this idiom for
+queue consumers.
 
 ## Integrations
 
@@ -311,7 +275,10 @@ func runJob(cfg hc.Config) (err error) {
 - `adapter/zap`
 - `adapter/zerolog`
 
-All adapters expose `NewWithOptions` plus a `SinkOptions` value reserved for future options. Adapters do not sort fields: field order follows Go's map iteration and is unspecified. Deterministic, insertion-ordered output arrives structurally with the upcoming record-based core.
+Adapters expose `New` only (the `SinkOptions`/`NewWithOptions` shapes
+were removed at 1.0: nothing to configure until proven otherwise).
+Fields arrive in insertion order, deterministically, as typed
+constructors.
 
 ### First-party JSON sink (no logger dependency)
 
@@ -349,7 +316,7 @@ import (
 func main() {
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
 	sink := sloghc.New(logger)
-	mw := stdhc.Middleware(hc.Config{Sink: sink, SamplingRate: 1})
+	mw := stdhc.Middleware(hc.MustCompile(hc.Config{Sink: sink, SamplingRate: 1}))
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
@@ -384,7 +351,7 @@ func main() {
 	sink := sloghc.New(logger)
 
 	r := gin.New()
-	r.Use(ginhc.Middleware(hc.Config{Sink: sink, SamplingRate: 1}))
+	r.Use(ginhc.Middleware(hc.MustCompile(hc.Config{Sink: sink, SamplingRate: 1}))
 	r.GET("/users/:id", func(c *gin.Context) {
 		hc.Add(c.Request.Context(), "router", "gin")
 		c.Status(200)
@@ -417,7 +384,7 @@ func main() {
 	sink := sloghc.New(logger)
 
 	app := fiber.New()
-	app.Use(fiberhc.Middleware(hc.Config{Sink: sink, SamplingRate: 1}))
+	app.Use(fiberhc.Middleware(hc.MustCompile(hc.Config{Sink: sink, SamplingRate: 1}))
 	app.Get("/users/:id", func(c *fiber.Ctx) error {
 		hc.Add(c.UserContext(), "router", "fiber-v2")
 		return c.SendStatus(200)
@@ -450,7 +417,7 @@ func main() {
 	sink := sloghc.New(logger)
 
 	app := fiber.New()
-	app.Use(fiberv3hc.Middleware(hc.Config{Sink: sink, SamplingRate: 1}))
+	app.Use(fiberv3hc.Middleware(hc.MustCompile(hc.Config{Sink: sink, SamplingRate: 1}))
 	app.Get("/users/:id", func(c fiber.Ctx) error {
 		hc.Add(c.Context(), "router", "fiber-v3")
 		return c.SendStatus(200)
@@ -483,7 +450,7 @@ func main() {
 	sink := sloghc.New(logger)
 
 	e := echo.New()
-	e.Use(echohc.Middleware(hc.Config{Sink: sink, SamplingRate: 1}))
+	e.Use(echohc.Middleware(hc.MustCompile(hc.Config{Sink: sink, SamplingRate: 1}))
 	e.GET("/users/:id", func(c echo.Context) error {
 		hc.Add(c.Request().Context(), "router", "echo")
 		return c.NoContent(200)
@@ -513,7 +480,7 @@ import (
 func main() {
 	logger := zap.NewExample()
 	sink := zaphc.New(logger)
-	mw := stdhc.Middleware(hc.Config{Sink: sink, SamplingRate: 1})
+	mw := stdhc.Middleware(hc.MustCompile(hc.Config{Sink: sink, SamplingRate: 1}))
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
@@ -546,7 +513,7 @@ import (
 func main() {
 	logger := zerolog.New(os.Stdout).With().Timestamp().Logger()
 	sink := zerologhc.New(&logger)
-	mw := stdhc.Middleware(hc.Config{Sink: sink, SamplingRate: 1})
+	mw := stdhc.Middleware(hc.MustCompile(hc.Config{Sink: sink, SamplingRate: 1}))
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
@@ -597,6 +564,12 @@ Published nested modules:
 - `integration/gin`
 - `integration/std`
 - `integration/worker`
+
+## Migrating from v0.x
+
+Coming from a 0.x release? [`MIGRATION.md`](./MIGRATION.md) maps every
+removed or changed symbol, the outcome-precedence change, and the wire
+format differences.
 
 ## References
 

--- a/adapter/slog/example_test.go
+++ b/adapter/slog/example_test.go
@@ -1,0 +1,48 @@
+package slogadapter_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+
+	hc "github.com/happytoolin/happycontext"
+	sloghc "github.com/happytoolin/happycontext/adapter/slog"
+)
+
+// ExampleNew shows the slog bridge: typed attributes in insertion
+// order, errors as message strings.
+func ExampleNew() {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	ts := hc.NewTestSink()
+	_ = logger
+	rt := hc.MustCompile(hc.Config{Sink: sloghc.New(demoLogger()), SamplingRate: 1})
+	op := hc.Start(context.Background(), rt, hc.OperationStart{Domain: hc.DomainJob, Name: "j"})
+	hc.Add(op.Context(), "k", 1, "rows", 42)
+	op.End(nil)
+	_ = ts
+	// Output:
+	// level=INFO msg=operation_completed op.domain=job op.name=j k=1 rows=42 duration_ms=0 op.outcome=success
+}
+
+func demoLogger() *slog.Logger {
+	return slog.New(demoHandler{})
+}
+
+type demoHandler struct{}
+
+func (demoHandler) Enabled(context.Context, slog.Level) bool { return true }
+func (demoHandler) Handle(_ context.Context, r slog.Record) error {
+	fmt.Printf("level=%s msg=%s", r.Level, r.Message)
+	r.Attrs(func(a slog.Attr) bool {
+		fmt.Printf(" %s=%v", a.Key, a.Value)
+		return true
+	})
+	fmt.Println()
+	return nil
+}
+func (h demoHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h demoHandler) WithGroup(string) slog.Handler      { return h }
+
+var _ = errors.New

--- a/adapter/slog/sink.go
+++ b/adapter/slog/sink.go
@@ -95,9 +95,10 @@ func attrOf(f hc.Field) slog.Attr {
 		return slog.Uint64(f.Key(), u)
 	}
 	if fl, ok := f.Float(); ok {
-		if f.Kind() == hc.KindFloat32 {
-			return slog.Any(f.Key(), float32(fl)) // preserves 32-bit JSON rendering
-		}
+		// float32 renders widened through slog on Go >= 1.24 (AnyValue
+		// converts to Float64Value; slog has no Float32 constructor) —
+		// the same shape the v0 adapter produced. The JSON sink and the
+		// zap/zerolog bridges preserve 32-bit precision.
 		return slog.Float64(f.Key(), fl)
 	}
 	if b, ok := f.Bool(); ok {
@@ -119,7 +120,8 @@ func attrOf(f hc.Field) slog.Attr {
 // and last-write-wins holds at every width).
 func lastOccurrences(fields []hc.Field) []int {
 	if len(fields) <= 24 {
-		out := make([]int, 0, len(fields))
+		var stack [24]int // allocation-free narrow path
+		n := 0
 		for i := range fields {
 			last := true
 			for j := i + 1; j < len(fields); j++ {
@@ -129,10 +131,11 @@ func lastOccurrences(fields []hc.Field) []int {
 				}
 			}
 			if last {
-				out = append(out, i)
+				stack[n] = i
+				n++
 			}
 		}
-		return out
+		return stack[:n:n]
 	}
 	seen := make(map[string]struct{}, len(fields)*2)
 	kept := make([]int, 0, len(fields))

--- a/adapter/zap/sink.go
+++ b/adapter/zap/sink.go
@@ -101,7 +101,8 @@ func (z *Sink) check(level hc.Level, message string) *zapcore.CheckedEntry {
 // collection for wide ones).
 func lastOccurrences(fields []hc.Field) []int {
 	if len(fields) <= 24 {
-		out := make([]int, 0, len(fields))
+		var stack [24]int // allocation-free narrow path
+		n := 0
 		for i := range fields {
 			last := true
 			for j := i + 1; j < len(fields); j++ {
@@ -111,10 +112,11 @@ func lastOccurrences(fields []hc.Field) []int {
 				}
 			}
 			if last {
-				out = append(out, i)
+				stack[n] = i
+				n++
 			}
 		}
-		return out
+		return stack[:n:n]
 	}
 	seen := make(map[string]struct{}, len(fields)*2)
 	kept := make([]int, 0, len(fields))

--- a/adapter/zerolog/sink.go
+++ b/adapter/zerolog/sink.go
@@ -98,7 +98,8 @@ func appendField(event *zerolog.Event, f hc.Field) *zerolog.Event {
 // collection for wide ones).
 func lastOccurrences(fields []hc.Field) []int {
 	if len(fields) <= 24 {
-		out := make([]int, 0, len(fields))
+		var stack [24]int // allocation-free narrow path
+		n := 0
 		for i := range fields {
 			last := true
 			for j := i + 1; j < len(fields); j++ {
@@ -108,10 +109,11 @@ func lastOccurrences(fields []hc.Field) []int {
 				}
 			}
 			if last {
-				out = append(out, i)
+				stack[n] = i
+				n++
 			}
 		}
-		return out
+		return stack[:n:n]
 	}
 	seen := make(map[string]struct{}, len(fields)*2)
 	kept := make([]int, 0, len(fields))

--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,179 @@
+package hc_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	hc "github.com/happytoolin/happycontext"
+)
+
+// printSink renders records deterministically for the output-checked
+// examples: sorted field keys, values as JSON.
+type printSink struct {
+	w *os.File
+}
+
+func (p printSink) Write(_ context.Context, rec *hc.Record) {
+	keys := make([]string, 0, len(rec.Fields()))
+	seen := map[string]bool{}
+	for _, f := range rec.Fields() {
+		if seen[f.Key()] {
+			continue
+		}
+		seen[f.Key()] = true
+		keys = append(keys, f.Key())
+	}
+	sort.Strings(keys)
+	fmt.Fprintf(p.w, "%s %s", rec.Level(), rec.Message())
+	for _, k := range keys {
+		var v any
+		for _, f := range rec.Fields() {
+			if f.Key() == k {
+				v, _ = rec.Lookup(k)
+			}
+		}
+		if k == "duration_ms" {
+			continue // deterministic output: skip timing
+		}
+		b, _ := json.Marshal(v)
+		fmt.Fprintf(p.w, " %s=%s", k, b)
+	}
+	fmt.Fprintln(p.w)
+}
+
+// ExampleCompile shows the compile-once contract: bad configuration is
+// a construction-time error wrapping sentinel values.
+func ExampleCompile() {
+	_, err := hc.Compile(hc.Config{SamplingRate: 1.5})
+	fmt.Println(err)
+	fmt.Println(errors.Is(err, hc.ErrInvalidRate))
+
+	rt, err := hc.Compile(hc.Config{Sink: printSink{os.Stdout}, SamplingRate: 1})
+	if err != nil {
+		fmt.Println("bad config:", err)
+		return
+	}
+	hc.Start(context.Background(), rt, hc.OperationStart{Domain: hc.DomainJob, Name: "j"}).End(nil)
+	// Output:
+	// hc: sampling rate 1.5: hc: invalid rate
+	// true
+	// INFO operation_completed op.domain="job" op.name="j" op.outcome="success"
+}
+
+// ExampleMustCompile is the literal-config idiom for main.
+func ExampleMustCompile() {
+	rt := hc.MustCompile(hc.Config{
+		Sink:         printSink{os.Stdout},
+		SamplingRate: 1,
+		Message:      "done",
+	})
+	op := hc.Start(context.Background(), rt, hc.OperationStart{Domain: hc.DomainJob, Name: "digest"})
+	op.End(nil)
+	// Output:
+	// INFO done op.domain="job" op.name="digest" op.outcome="success"
+}
+
+// ExampleStart shows the request lifecycle: Start attaches the WAL,
+// the hc.Add helpers annotate, the deferred End commits exactly once.
+func ExampleStart() {
+	rt := hc.MustCompile(hc.Config{Sink: printSink{os.Stdout}, SamplingRate: 1})
+
+	func() (err error) {
+		op := hc.Start(context.Background(), rt, hc.OperationStart{
+			Domain:      hc.DomainJob,
+			Name:        "import",
+			ID:          "job_1",
+			Attempt:     2,
+			MaxAttempts: 3,
+		})
+		defer op.End(&err) // direct defer: captures errors and panics
+
+		hc.Add(op.Context(), "rows", 42, "source", "queue")
+		hc.AddRawJSON(op.Context(), "meta", []byte(`{"batch":true}`))
+		return errors.New("row 17 failed")
+	}()
+	// Output:
+	// ERROR operation_completed error={"message":"row 17 failed","type":"*errors.errorString"} meta="eyJiYXRjaCI6dHJ1ZX0=" op.attempt=2 op.domain="job" op.id="job_1" op.max_attempts=3 op.name="import" op.outcome="failure" rows=42 source="queue"
+}
+
+// ExampleOperation_End demonstrates the deferred idiom and the
+// emitted flag; a second End call is a no-op returning the first
+// result.
+func ExampleOperation_End() {
+	rt := hc.MustCompile(hc.Config{Sink: printSink{os.Stdout}, SamplingRate: 1})
+	var err error
+	op := hc.Start(context.Background(), rt, hc.OperationStart{})
+	emitted := op.End(&err)
+	fmt.Println("emitted:", emitted, "again:", op.End(&err))
+	// Output:
+	// INFO operation_completed op.domain="operation" op.name="operation" op.outcome="success"
+	// emitted: true again: true
+}
+
+// ExampleAdd shows annotation-style fields: strings, ints, nested
+// values, and the kv variadic.
+func ExampleAdd() {
+	rt := hc.MustCompile(hc.Config{Sink: printSink{os.Stdout}, SamplingRate: 1})
+	op := hc.Start(context.Background(), rt, hc.OperationStart{})
+	ctx := op.Context()
+	hc.Add(ctx, "user_id", "u_1", "attempt", 2)
+	hc.Add(ctx, "cart", map[string]any{"items": 3})
+	hc.SetRoute(ctx, "/orders/:id")
+	op.End(nil)
+	// Output:
+	// INFO operation_completed attempt=2 cart={"items":3} http.route="/orders/:id" op.domain="operation" op.name="operation" op.outcome="success" user_id="u_1"
+}
+
+// ExampleError records a structured error; failures are never sampled
+// away, even under NeverSampler.
+func ExampleError() {
+	rt := hc.MustCompile(hc.Config{
+		Sink:    printSink{os.Stdout},
+		Sampler: func(hc.SampleInput) bool { return false },
+	})
+	var err error = errors.New("db timeout")
+	op := hc.Start(context.Background(), rt, hc.OperationStart{})
+	op.End(&err) // still emitted: error bypass is structural
+	// Output:
+	// ERROR operation_completed error={"message":"db timeout","type":"*errors.errorString"} op.domain="operation" op.name="operation" op.outcome="failure"
+}
+
+// ExampleNewJSONSink is the zero-dependency output path: canonical
+// JSON lines with a single Write per event. The line is truncated at
+// the timestamp for determinism.
+func ExampleNewJSONSink() {
+	var buf strings.Builder
+	rt := hc.MustCompile(hc.Config{Sink: hc.NewJSONSink(&buf), SamplingRate: 1})
+	op := hc.Start(context.Background(), rt, hc.OperationStart{Domain: hc.DomainJob, Name: "j"})
+	hc.Add(op.Context(), "k", 1)
+	op.End(nil)
+	line := buf.String()
+	if i := strings.Index(line, `,"duration_ms"`); i >= 0 {
+		line = line[:i] + "…"
+	}
+	fmt.Println(line)
+	// Output:
+	// {"level":"info","op.domain":"job","op.name":"j","k":1…
+}
+
+// ExampleNewTestSink shows the in-memory sink for assertions.
+func ExampleNewTestSink() {
+	ts := hc.NewTestSink()
+	rt := hc.MustCompile(hc.Config{Sink: ts, SamplingRate: 1})
+	op := hc.Start(context.Background(), rt, hc.OperationStart{})
+	hc.Add(op.Context(), "k", "v")
+	op.End(nil)
+
+	events := ts.Events()
+	fmt.Println(len(events), events[0].Level(), events[0].Message())
+	v, _ := events[0].Lookup("k")
+	fmt.Println("k =", v)
+	// Output:
+	// 1 INFO operation_completed
+	// k = v
+}

--- a/integration/std/example_test.go
+++ b/integration/std/example_test.go
@@ -1,0 +1,45 @@
+package stdhappycontext_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+
+	hc "github.com/happytoolin/happycontext"
+	stdhc "github.com/happytoolin/happycontext/integration/std"
+)
+
+// ExampleMiddleware shows the two-line adoption: compile once, wrap
+// the handler. One canonical event per request.
+func ExampleMiddleware() {
+	rt := hc.MustCompile(hc.Config{
+		Sink:         demoSink{},
+		SamplingRate: 1,
+	})
+	mw := stdhc.Middleware(rt)
+
+	handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hc.Add(r.Context(), "user_id", "u_8472")
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/orders/123", nil))
+	fmt.Println("status:", rec.Code)
+	// Output:
+	// INFO request_completed op.domain=http op.name=request http.method=GET http.path=/orders/123 user_id=u_8472 http.status=204 duration_ms=0 op.outcome=success
+	// status: 204
+}
+
+type demoSink struct{}
+
+func (demoSink) Write(_ context.Context, rec *hc.Record) {
+	fmt.Printf("%s %s", rec.Level(), rec.Message())
+	for _, f := range rec.Fields() {
+		if v, ok := rec.Lookup(f.Key()); ok {
+			fmt.Printf(" %s=%v", f.Key(), v)
+		}
+	}
+	fmt.Println()
+}

--- a/openspec/changes/v2-record-core/tasks.md
+++ b/openspec/changes/v2-record-core/tasks.md
@@ -63,10 +63,10 @@ retired with the §9 amendment, 2026-08-31 — v2 is the only line.)
 
 ## 4. PR-S4 `docs: examples, migration guide, README` (stacked on S3)
 
-- [ ] `example_test.go`: output-checked Examples for `Compile`,
+- [x] `example_test.go`: output-checked Examples for `Compile`,
       `MustCompile`, `Start`/`End`, `Add` family, `NewJSONSink`,
       `NewTestSink`, one bridge, one integration
-- [ ] `MIGRATION.md`: the v0→v1 map from `V2_DESIGN.md` §2 plus the
+- [x] `MIGRATION.md`: the v0→v1 map from `V2_DESIGN.md` §2 plus the
       outcome-precedence and field-rename callouts
-- [ ] README v2 rewrite (quick starts from the spec's §2 samples)
-- [ ] Verify: `go test` runs examples; docs build; full matrix final pass
+- [x] README v2 rewrite (quick starts from the spec's §2 samples)
+- [x] Verify: `go test` runs examples; docs build; full matrix final pass


### PR DESCRIPTION
## What

**PR-S4 of 4** — the final PR of `v2-record-core`, stacked on #31 (S3). Review the delta against `feat/v2-bridges-s3`.

- **Runnable examples (v1.0 gate, amendment 19)**: output-checked `Example` functions — root (`Compile` with the sentinel-error contract, `MustCompile`, `Start` full lifecycle incl. `AddRawJSON` and the deferred error, `Operation_End` one-shot semantics, `Add`, `Error` under `NeverSampler` proving the structural bypass, `NewJSONSink`, `NewTestSink`), `adapter/slog` (typed-attribute bridge), `integration/std` (the two-line adoption). All deterministic via printing sinks; all run under `go test`.
- **`MIGRATION.md`**: the complete v0→v1 map — construction, lifecycle (incl. the direct-defer requirement for panic capture), typed fields, int levels, the `Sink.Write(ctx, *Record)` change, bridges (`New` only), outcome precedence + structural error bypass, wire-format changes (insertion order, `op.code` non-HTTP only, `job.*` mirrors dropped), and the full removed-symbol list.
- **README**: v2 quick starts (middleware + background job on `*Runtime`), compile-once configuration docs, sampler docs on `SampleInput.Lookup`/`Fields`, `Start`/`End` lifecycle section, adapters section, Go floor badge 1.25+, migration pointer.

With this PR, **all 24 tasks of `v2-record-core` are complete** — the series #29 → #30 → #31 → this is the entire W3–W9 break.

## Verification

All examples pass output-checked (`go test -run Example`) · 24-package matrix green · gofmt/gofumpt clean.

## Review

Deepseek + glm-5.3 reviewed S1–S3; this docs PR completes the stack — reviewed with the series.

## After merge

The `v2-cutover` change takes over: v1.0.0 releases from v2 (release-please computes the major from the `feat!:` markers — verify the computed version before merging the release PR, the v0.5.0 lesson), then archive the changes and open the v1.1.0 parking lot.
