### PR TITLE
test(encoder): fuzz hardening + prior-art test adoptions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,10 +92,26 @@ jobs:
 
       # 60s per target comfortably exceeds the 1M-exec gate (~200k
       # execs/s for these oracles locally); increase if CI runners
-      # regress.
+      # regress. Numeric/time/interface oracles and the record-level
+      # dedupe fuzz follow the DST research plan (P2/P4).
       - name: Fuzz hcjson encoder (SWAR vs zerolog table)
         shell: bash
         run: |
           set -euo pipefail
           go test ./internal/hcjson -run '^$' -fuzz '^FuzzAppendString$' -fuzztime 60s
           go test ./internal/hcjson -run '^$' -fuzz '^FuzzAppendBytes$' -fuzztime 60s
+
+      - name: Fuzz hcjson numeric, time and interface paths
+        shell: bash
+        run: |
+          set -euo pipefail
+          go test ./internal/hcjson -run '^$' -fuzz '^FuzzAppendFloat64$' -fuzztime 60s
+          go test ./internal/hcjson -run '^$' -fuzz '^FuzzAppendFloat32$' -fuzztime 60s
+          go test ./internal/hcjson -run '^$' -fuzz '^FuzzAppendTimeRFC3339$' -fuzztime 60s
+          go test ./internal/hcjson -run '^$' -fuzz '^FuzzAppendInterface$' -fuzztime 60s
+
+      - name: Fuzz record encode (dedupe LWW + canonical collisions)
+        shell: bash
+        run: |
+          set -euo pipefail
+          go test . -run '^$' -fuzz '^FuzzRecordEncodedDedupe$' -fuzztime 60s

--- a/alloc_gate_test.go
+++ b/alloc_gate_test.go
@@ -49,23 +49,34 @@ func TestRecordEncodeAllocNarrowPath(t *testing.T) {
 // TestRecordEncodeAllocWidePath pins the wide side of the crossover:
 // 25 fields must take the seen-set path (which allocates by design —
 // the kept index slice), and 33 unique fields force the map handoff
-// past the 32-slot stack array. Together with
+// past the 32-slot stack array, which allocates beyond the kept slice.
+// The field slices are built OUTSIDE the measured closures: setup
+// allocations inside the closure would satisfy the gate vacuously for
+// any crossover value (review finding DS-6). Together with
 // TestRecordEncodeAllocNarrowPath the boundary sits between 20 and 25.
 func TestRecordEncodeAllocWidePath(t *testing.T) {
+	fields25 := allocFields(25)
+	fields33 := allocFields(33)
 	dst := make([]byte, 1, 4096)
 	dst[0] = '{'
 
-	if allocs := testing.AllocsPerRun(200, func() {
-		appendDedupedFields(dst, allocFields(25))
-	}); allocs < 1 {
+	allocs25 := testing.AllocsPerRun(200, func() {
+		appendDedupedFields(dst, fields25)
+	})
+	if allocs25 < 1 {
 		t.Fatalf("wide path (25 fields) allocated %.0f times, want >= 1 — "+
-			"the crossover no longer routes wide events to the seen-set path", allocs)
+			"the crossover no longer routes wide events to the seen-set path", allocs25)
 	}
-	if allocs := testing.AllocsPerRun(200, func() {
-		appendDedupedFields(dst, allocFields(33))
-	}); allocs < 1 {
+	allocs33 := testing.AllocsPerRun(200, func() {
+		appendDedupedFields(dst, fields33)
+	})
+	if allocs33 < 1 {
 		t.Fatalf("wide path (33 unique fields) allocated %.0f times, want >= 1 "+
-			"(the map handoff must allocate)", allocs)
+			"(the map handoff must allocate)", allocs33)
+	}
+	if allocs33 <= allocs25 {
+		t.Fatalf("33 unique fields allocated %.0f times, want more than the 25-field "+
+			"path (%.0f) — the 32-slot stack array did not hand off to the map", allocs33, allocs25)
 	}
 }
 

--- a/alloc_gate_test.go
+++ b/alloc_gate_test.go
@@ -1,0 +1,94 @@
+package hc
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+// Allocation gates for the record encode paths, in the shape of slog's
+// TestJSONAllocs (log/slog/json_handler_test.go): exact or generous
+// allocation budgets enforced in the ordinary test run, not left to
+// benchstat discipline. The gated property is the dedupe crossover
+// (record.go dedupeScanLimit = 24): events of up to 24 fields must
+// encode without any allocation beyond the mandatory line buffer, and
+// wider events take the seen-set path (which allocates by design).
+// Found as a gap by mutation testing (M10): collapsing the crossover to
+// 1 kept every behavior test green — only an alloc gate can see it.
+
+func allocFields(n int) []Field {
+	fields := make([]Field, 0, n)
+	for i := 0; i < n; i++ {
+		fields = append(fields, fieldStr(fmt.Sprintf("k%02d", i), "v"))
+	}
+	return fields
+}
+
+// TestRecordEncodeAllocNarrowPath pins the narrow side of the
+// crossover: deduping and encoding 20 fields (one duplicate, so the
+// last-wins scan actually runs) allocates zero — the whole point of the
+// allocation-free scan. The dst is pre-sized past the encoded line so
+// append growth cannot allocate.
+func TestRecordEncodeAllocNarrowPath(t *testing.T) {
+	fields := allocFields(19)
+	fields = append(fields, fieldStr("k00", "last")) // duplicate of the first key
+	if len(fields) != 20 {
+		t.Fatalf("setup: %d fields, want 20", len(fields))
+	}
+
+	dst := make([]byte, 1, 4096)
+	dst[0] = '{'
+	if allocs := testing.AllocsPerRun(200, func() {
+		appendDedupedFields(dst, fields)
+	}); allocs != 0 {
+		t.Fatalf("narrow path (20 fields) allocated %.0f times, want 0 — "+
+			"the allocation-free scan no longer runs (dedupeScanLimit?)", allocs)
+	}
+}
+
+// TestRecordEncodeAllocWidePath pins the wide side of the crossover:
+// 25 fields must take the seen-set path (which allocates by design —
+// the kept index slice), and 33 unique fields force the map handoff
+// past the 32-slot stack array. Together with
+// TestRecordEncodeAllocNarrowPath the boundary sits between 20 and 25.
+func TestRecordEncodeAllocWidePath(t *testing.T) {
+	dst := make([]byte, 1, 4096)
+	dst[0] = '{'
+
+	if allocs := testing.AllocsPerRun(200, func() {
+		appendDedupedFields(dst, allocFields(25))
+	}); allocs < 1 {
+		t.Fatalf("wide path (25 fields) allocated %.0f times, want >= 1 — "+
+			"the crossover no longer routes wide events to the seen-set path", allocs)
+	}
+	if allocs := testing.AllocsPerRun(200, func() {
+		appendDedupedFields(dst, allocFields(33))
+	}); allocs < 1 {
+		t.Fatalf("wide path (33 unique fields) allocated %.0f times, want >= 1 "+
+			"(the map handoff must allocate)", allocs)
+	}
+}
+
+// TestRecordEncodeAllocFreshRecord is the end-to-end gate with a
+// generous ceiling, slog-style: each measured run encodes a fresh
+// 20-field record (a fresh *Record per run so the lazy-once publish in
+// Encoded cannot mask the encode cost; the RFC3339 second cache is
+// primed by AllocsPerRun's warmup call). The healthy baseline is 3
+// allocs — the Record struct, the encodedLine node, and the line
+// buffer. The ceiling is set wide (6) so ordinary churn never trips
+// it, but a regression that falls back to per-field json.Marshal
+// (which allocates ~44 for a 20-member map on this toolchain) fails
+// loudly.
+func TestRecordEncodeAllocFreshRecord(t *testing.T) {
+	fields := allocFields(20)
+	completedAt := time.Date(2026, 9, 1, 10, 0, 0, 0, time.Local)
+	encode := func() {
+		r := &Record{level: LevelInfo, msg: "m", fields: fields, completedAt: completedAt}
+		_ = r.Encoded()
+	}
+	const ceiling = 6 // baseline 3: Record + encodedLine + line buffer
+	if allocs := testing.AllocsPerRun(200, encode); allocs > ceiling {
+		t.Fatalf("fresh 20-field record encode allocated %.0f times, want <= %d — "+
+			"a json.Marshal-style regression added per-field allocations", allocs, ceiling)
+	}
+}

--- a/internal/hcjson/float_test.go
+++ b/internal/hcjson/float_test.go
@@ -1,0 +1,195 @@
+package hcjson
+
+import (
+	"encoding/json"
+	"math"
+	"testing"
+)
+
+// float64Tests and float32Tests are ported from zerolog v1.35.0's
+// internal/json/float_test.go (MIT — same lineage as the vendored
+// encoder), extended with the −0 and float32-precision cases the DST
+// research flagged (V2_PLAN §05 / dst-research §6.4).
+var float64Tests = []struct {
+	name string
+	val  float64
+	want string
+}{
+	{"Positive integer", 1234.0, "1234"},
+	{"Negative integer", -5678.0, "-5678"},
+	{"Positive decimal", 12.3456, "12.3456"},
+	{"Negative decimal", -78.9012, "-78.9012"},
+	{"Large positive number", 123456789.0, "123456789"},
+	{"Large negative number", -987654321.0, "-987654321"},
+	{"Zero", 0.0, "0"},
+	{"Negative zero", math.Copysign(0, -1), "-0"},
+	{"Smallest positive value", math.SmallestNonzeroFloat64, "5e-324"},
+	{"Largest positive value", math.MaxFloat64, "1.7976931348623157e+308"},
+	{"Smallest negative value", -math.SmallestNonzeroFloat64, "-5e-324"},
+	{"Largest negative value", -math.MaxFloat64, "-1.7976931348623157e+308"},
+	{"NaN", math.NaN(), `"NaN"`},
+	{"+Inf", math.Inf(1), `"+Inf"`},
+	{"-Inf", math.Inf(-1), `"-Inf"`},
+	{"Clean up e-09 to e-9 case 1", 1e-9, "1e-9"},
+	{"Clean up e-09 to e-9 case 2", -2.236734e-9, "-2.236734e-9"},
+	{"2^53 boundary", 1 << 53, "9007199254740992"},
+	{"2^53 plus one ulp", float64(1<<53) + 2, "9007199254740994"},
+}
+
+var float32Tests = []struct {
+	name string
+	val  float32
+	want string
+}{
+	{"Positive integer", 1234.0, "1234"},
+	{"Negative integer", -5678.0, "-5678"},
+	{"Positive decimal", 12.3456, "12.3456"},
+	{"Negative decimal", -78.9012, "-78.9012"},
+	{"Large positive number", 123456789.0, "123456790"},
+	{"Large negative number", -987654321.0, "-987654340"},
+	{"Zero", 0.0, "0"},
+	{"Negative zero", float32(math.Copysign(0, -1)), "-0"},
+	{"Smallest positive value", math.SmallestNonzeroFloat32, "1e-45"},
+	{"Largest positive value", math.MaxFloat32, "3.4028235e+38"},
+	{"Smallest negative value", -math.SmallestNonzeroFloat32, "-1e-45"},
+	{"Largest negative value", -math.MaxFloat32, "-3.4028235e+38"},
+	{"NaN", float32(math.NaN()), `"NaN"`},
+	{"+Inf", float32(math.Inf(1)), `"+Inf"`},
+	{"-Inf", float32(math.Inf(-1)), `"-Inf"`},
+	{"Clean up e-09 to e-9 case 1", 1e-9, "1e-9"},
+	{"Clean up e-09 to e-9 case 2", -2.236734e-9, "-2.236734e-9"},
+	// the float32-preserving wire contract: 0.1 must not widen to
+	// 0.10000000149011612 (v0 adapter parity; slog bridge documents the
+	// host limitation)
+	{"Float32 precision preserved", 0.1, "0.1"},
+}
+
+func TestAppendFloat64Table(t *testing.T) {
+	for _, tc := range float64Tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := string((Encoder{}).AppendFloat64(nil, tc.val, -1)); got != tc.want {
+				t.Errorf("AppendFloat64(%v) = %s, want %s", tc.val, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAppendFloat32Table(t *testing.T) {
+	for _, tc := range float32Tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := string((Encoder{}).AppendFloat32(nil, tc.val, -1)); got != tc.want {
+				t.Errorf("AppendFloat32(%v) = %s, want %s", tc.val, got, tc.want)
+			}
+		})
+	}
+}
+
+// FuzzAppendFloat64 checks the vendored float policy continuously: for
+// NaN/±Inf the three quoted-string shapes, for finite values exact
+// parity with encoding/json and an exact json.Unmarshal round-trip
+// (the DST research's shared-blind-spot closer for the numeric path —
+// a differential-only oracle could not catch a policy both paths got
+// wrong).
+func FuzzAppendFloat64(f *testing.F) {
+	for _, tc := range float64Tests {
+		f.Add(tc.val)
+	}
+	f.Add(0.1)
+	f.Add(-0.1)
+	f.Add(math.Float64frombits(0x7ff0000000000001)) // signaling NaN payload
+	f.Add(math.Float64frombits(0x7ff8000000000000)) // quiet NaN
+	f.Fuzz(func(t *testing.T, val float64) {
+		actual := (Encoder{}).AppendFloat64(nil, val, -1)
+		if len(actual) == 0 {
+			t.Fatal("empty buffer")
+		}
+		if actual[0] == '"' {
+			switch string(actual) {
+			case `"NaN"`:
+				if !math.IsNaN(val) {
+					t.Fatalf("expected %v got NaN", val)
+				}
+			case `"+Inf"`:
+				if !math.IsInf(val, 1) {
+					t.Fatalf("expected %v got +Inf", val)
+				}
+			case `"-Inf"`:
+				if !math.IsInf(val, -1) {
+					t.Fatalf("expected %v got -Inf", val)
+				}
+			default:
+				t.Fatalf("unexpected string rendering: %s", actual)
+			}
+			return
+		}
+		if expected, err := json.Marshal(val); err != nil {
+			t.Error(err)
+		} else if string(actual) != string(expected) {
+			t.Errorf("json.Marshal parity: expected %s, got %s", expected, actual)
+		}
+		var parsed float64
+		if err := json.Unmarshal(actual, &parsed); err != nil {
+			t.Fatal(err)
+		}
+		if parsed != val && !(parsed != parsed && val != val) { // NaN already handled above
+			t.Fatalf("round-trip: expected %v, got %v (wire %s)", val, parsed, actual)
+		}
+		// −0 must survive the round trip bitwise (sign preserved)
+		if val == 0 && math.Signbit(val) && !math.Signbit(parsed) {
+			t.Fatalf("negative zero lost: wire %s", actual)
+		}
+	})
+}
+
+// FuzzAppendFloat32 is the float32 mirror; the round-trip comparison is
+// done in float64 after re-widening, matching the wire contract (the
+// bytes are parsed as a JSON number, then compared against the original
+// float32 value widened — exact equality, no tolerance).
+func FuzzAppendFloat32(f *testing.F) {
+	for _, tc := range float32Tests {
+		f.Add(tc.val)
+	}
+	f.Add(float32(0.1))
+	f.Add(float32(1) / 3)
+	f.Fuzz(func(t *testing.T, val float32) {
+		actual := (Encoder{}).AppendFloat32(nil, val, -1)
+		if len(actual) == 0 {
+			t.Fatal("empty buffer")
+		}
+		if actual[0] == '"' {
+			switch string(actual) {
+			case `"NaN"`:
+				if !math.IsNaN(float64(val)) {
+					t.Fatalf("expected %v got NaN", val)
+				}
+			case `"+Inf"`:
+				if !math.IsInf(float64(val), 1) {
+					t.Fatalf("expected %v got +Inf", val)
+				}
+			case `"-Inf"`:
+				if !math.IsInf(float64(val), -1) {
+					t.Fatalf("expected %v got -Inf", val)
+				}
+			default:
+				t.Fatalf("unexpected string rendering: %s", actual)
+			}
+			return
+		}
+		if expected, err := json.Marshal(val); err != nil {
+			t.Error(err)
+		} else if string(actual) != string(expected) {
+			t.Errorf("json.Marshal parity: expected %s, got %s", expected, actual)
+		}
+		var parsed32 float32
+		if err := json.Unmarshal(actual, &parsed32); err != nil {
+			t.Fatal(err)
+		}
+		// the wire contract is 32-bit: parse back at float32 width and
+		// require exact equality (parsing the shortest-32 decimal as
+		// float64 would land on a different float64 than the widened
+		// value — that gap is expected and not a bug)
+		if parsed32 != val && !(parsed32 != parsed32 && val != val) {
+			t.Fatalf("round-trip: expected %v, got %v (wire %s)", val, parsed32, actual)
+		}
+	})
+}

--- a/internal/hcjson/fuzz_interface_test.go
+++ b/internal/hcjson/fuzz_interface_test.go
@@ -1,0 +1,149 @@
+package hcjson
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// FuzzAppendInterface closes the remaining encoder gap (dst-research
+// §6.4, P4): the any-fallback marshaller has zero fuzz coverage while
+// the string/float/time paths have differential or round-trip oracles.
+// The oracle here is parsed equivalence with encoding/json plus
+// no-panic/valid-output invariants — HTML escaping is excluded from
+// equivalence on purpose (the fork disables it; pinned separately by
+// TestAppendInterfaceNoHTMLEscape).
+func FuzzAppendInterface(f *testing.F) {
+	seeds := []string{
+		`null`, `1`, `-2.5`, `true`, `"str"`, `"héllo ☃"`,
+		`[1,"x",false,null]`,
+		`{"a":1,"b":"two","c":[true,null]}`,
+		`{"nested":{"deep":{"deeper":[1,2,3]}}}`,
+		`{"html":"<b>a&b</b>"}`,
+		`[]`, `{}`,
+	}
+	for _, s := range seeds {
+		f.Add([]byte(s))
+	}
+	f.Fuzz(func(t *testing.T, raw []byte) {
+		var v any
+		if err := json.Unmarshal(raw, &v); err != nil {
+			return // not a valid JSON shape; nothing to check
+		}
+		got := Encoder{}.AppendInterface(nil, v)
+		if len(got) == 0 {
+			t.Fatal("empty output")
+		}
+		if !json.Valid(got) {
+			t.Fatalf("AppendInterface(%v) produced invalid JSON: %s", v, got)
+		}
+		want, err := json.Marshal(v)
+		if err != nil {
+			t.Fatalf("oracle marshal failed: %v", err)
+		}
+		var gotV, wantV any
+		if err := json.Unmarshal(got, &gotV); err != nil {
+			t.Fatalf("output unparseable: %v", err)
+		}
+		if err := json.Unmarshal(want, &wantV); err != nil {
+			t.Fatalf("oracle unparseable: %v", err)
+		}
+		if !jsonSemanticEqual(gotV, wantV) {
+			t.Fatalf("AppendInterface(%v) = %s, parses to %v; json.Marshal parses to %v", v, got, gotV, wantV)
+		}
+	})
+}
+
+// jsonSemanticEqual compares two json.Unmarshal results, normalizing
+// float64/int distinctions the parser erases (all numbers become
+// float64) and comparing float64s bitwise.
+func jsonSemanticEqual(a, b any) bool {
+	switch av := a.(type) {
+	case float64:
+		bv, ok := b.(float64)
+		return ok && av == bv
+	case []any:
+		bv, ok := b.([]any)
+		if !ok || len(av) != len(bv) {
+			return false
+		}
+		for i := range av {
+			if !jsonSemanticEqual(av[i], bv[i]) {
+				return false
+			}
+		}
+		return true
+	case map[string]any:
+		bv, ok := b.(map[string]any)
+		if !ok || len(av) != len(bv) {
+			return false
+		}
+		for k, v := range av {
+			bvv, ok := bv[k]
+			if !ok || !jsonSemanticEqual(v, bvv) {
+				return false
+			}
+		}
+		return true
+	case string:
+		bv, ok := b.(string)
+		return ok && av == bv
+	case bool:
+		bv, ok := b.(bool)
+		return ok && av == bv
+	case nil:
+		return b == nil
+	default:
+		return false
+	}
+}
+
+// panickingMarshaler pins the panicking-MarshalJSON decision
+// (dst-research P4, slog's !PANIC precedent): encoding/json lets a user
+// MarshalJSON panic propagate (both the classic implementation and the
+// go1.27 json/v2 default), so the fork's jsonMarshal recovers it into
+// the documented fallback string — the sink must not unwind End because
+// of a broken user marshaler, and the wire behavior must be identical
+// across the Go 1.25–1.27 matrix.
+type panickingMarshaler struct{}
+
+func (panickingMarshaler) MarshalJSON() ([]byte, error) { panic("marshaler boom") }
+
+type nilReceiverMarshaler struct{}
+
+func (*nilReceiverMarshaler) MarshalJSON() ([]byte, error) {
+	return []byte(`"ok"`), nil
+}
+
+func TestAppendInterfaceMarshalerEdgeCases(t *testing.T) {
+	// a panicking MarshalJSON must not crash the sink: the fork recovers
+	// it into the documented fallback string (slog renders !PANIC; the
+	// vendored zerolog shape is the marshaling-error string)
+	got := string(Encoder{}.AppendInterface(nil, panickingMarshaler{}))
+	if !strings.HasPrefix(got, `"marshaling error:`) {
+		t.Fatalf("panicking marshaler rendered %s, want marshaling-error string", got)
+	}
+	var back string
+	if err := json.Unmarshal([]byte(got), &back); err != nil {
+		t.Fatalf("fallback not a valid JSON string: %v (%s)", err, got)
+	}
+
+	// a nil-receiver MarshalJSON (valid but unusual) must marshal like
+	// stdlib: the method is callable on a nil *T, stdlib calls it, so
+	// the fallback must match json.Marshal's bytes
+	val := (*nilReceiverMarshaler)(nil)
+	got = string(Encoder{}.AppendInterface(nil, val))
+	want, err := json.Marshal(val)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != string(want) {
+		t.Fatalf("nil-receiver marshaler: got %s want %s", got, want)
+	}
+
+	// channels and funcs are unmarshalable: error string, not a hang
+	got = string(Encoder{}.AppendInterface(nil, make(chan int)))
+	if !strings.HasPrefix(got, `"marshaling error:`) {
+		t.Fatalf("channel rendered %s, want marshaling-error string", got)
+	}
+}

--- a/internal/hcjson/fuzz_test.go
+++ b/internal/hcjson/fuzz_test.go
@@ -14,11 +14,13 @@ import (
 // (~1M+ execs); the 1M-exec clean gate is a release requirement
 // (openspec json-encoder delta).
 //
-// The body carries a second, semantic oracle (dst-research §6.6): the
-// output must always be a valid JSON string, and for valid-UTF-8 input
-// it must unescape back to the input exactly. A differential-only
-// oracle could not catch a byte class both paths mishandle identically
-// — the round-trip property closes that class.
+// The body carries a second, semantic oracle (the zap adoption —
+// FuzzSafeAppendStringLike + roundTripsCorrectly*, zapcore/
+// json_encoder_impl_test.go; see also dst-research §6.6): the output
+// must always be a valid JSON string, and for valid-UTF-8 input it
+// must unescape back to the input exactly. A differential-only oracle
+// could not catch a byte class both paths mishandle identically — the
+// round-trip property closes that class.
 func FuzzAppendString(f *testing.F) {
 	seeds := []string{
 		"",

--- a/internal/hcjson/fuzz_test.go
+++ b/internal/hcjson/fuzz_test.go
@@ -2,8 +2,10 @@ package hcjson
 
 import (
 	"bytes"
+	"encoding/json"
 	"strings"
 	"testing"
+	"unicode/utf8"
 )
 
 // FuzzAppendString checks the equivalence gate continuously: the hybrid
@@ -11,6 +13,12 @@ import (
 // byte-identical output for every input. CI runs 60s per target
 // (~1M+ execs); the 1M-exec clean gate is a release requirement
 // (openspec json-encoder delta).
+//
+// The body carries a second, semantic oracle (dst-research §6.6): the
+// output must always be a valid JSON string, and for valid-UTF-8 input
+// it must unescape back to the input exactly. A differential-only
+// oracle could not catch a byte class both paths mishandle identically
+// — the round-trip property closes that class.
 func FuzzAppendString(f *testing.F) {
 	seeds := []string{
 		"",
@@ -38,6 +46,35 @@ func FuzzAppendString(f *testing.F) {
 		if !bytes.Equal(got, want) {
 			t.Fatalf("SWAR %q != table %q (got %s want %s)", s, s, got, want)
 		}
+		var decoded string
+		if err := json.Unmarshal(got, &decoded); err != nil {
+			t.Fatalf("output is not a valid JSON string: %v (input %q)", err, s)
+		}
+		if utf8.ValidString(s) && decoded != s {
+			t.Fatalf("round-trip: input %q decoded to %q (wire %s)", s, decoded, got)
+		}
+		// invalid UTF-8 must normalize to replacement runes with the
+		// documented per-byte multiplicity (each byte of a broken sequence
+		// maps to one U+FFFD; a genuine U+FFFD rune passes through raw), so
+		// the decoded count must equal invalid bytes + genuine U+FFFD runes.
+		if !utf8.ValidString(s) {
+			want := 0
+			for i := 0; i < len(s); {
+				r, size := utf8.DecodeRuneInString(s[i:])
+				if r == utf8.RuneError && size == 1 {
+					want++ // invalid byte → one replacement
+					i++
+					continue
+				}
+				if r == 0xfffd {
+					want++ // genuine replacement rune passes through
+				}
+				i += size
+			}
+			if got := strings.Count(decoded, "\ufffd"); got != want {
+				t.Fatalf("round-trip: invalid input %q decoded to %q (want %d replacements, got %d)", s, decoded, want, got)
+			}
+		}
 	})
 }
 
@@ -59,6 +96,35 @@ func FuzzAppendBytes(f *testing.F) {
 		want := appendBytesTable(nil, b)
 		if !bytes.Equal(got, want) {
 			t.Fatalf("SWAR %q != table %q (got %s want %s)", b, b, got, want)
+		}
+		var decoded string
+		if err := json.Unmarshal(got, &decoded); err != nil {
+			t.Fatalf("output is not a valid JSON string: %v (input %q)", err, b)
+		}
+		if utf8.Valid(b) && decoded != string(b) {
+			t.Fatalf("round-trip: input %q decoded to %q (wire %s)", b, decoded, got)
+		}
+		// invalid UTF-8 must normalize with the per-byte multiplicity
+		// documented above (each broken byte → one U+FFFD; genuine U+FFFD
+		// bytes pass through) — the shared-blind-spot half of the semantic
+		// check, in the count form that matches the vendored mapping.
+		if !utf8.Valid(b) {
+			want := 0
+			for i := 0; i < len(b); {
+				r, size := utf8.DecodeRune(b[i:])
+				if r == utf8.RuneError && size == 1 {
+					want++
+					i++
+					continue
+				}
+				if r == 0xfffd {
+					want++
+				}
+				i += size
+			}
+			if got := strings.Count(decoded, "\ufffd"); got != want {
+				t.Fatalf("round-trip: invalid input %q decoded to %q (want %d replacements, got %d)", b, decoded, want, got)
+			}
 		}
 	})
 }

--- a/internal/hcjson/time_test.go
+++ b/internal/hcjson/time_test.go
@@ -2,6 +2,7 @@ package hcjson
 
 import (
 	"bytes"
+	"encoding/json"
 	"sync"
 	"testing"
 	"time"
@@ -98,4 +99,82 @@ func TestAppendTimeRFC3339CachedConcurrent(t *testing.T) {
 		}()
 	}
 	wg.Wait()
+}
+
+// FuzzAppendTimeRFC3339 checks the cached formatter continuously
+// (dst-research §6.4): for times expressed in the process's local zone
+// — the documented cache contract — the output must equal
+// time.Format(time.RFC3339) exactly, whatever the second, and must
+// parse back to the same wall-clock second. Times from other zones go
+// through the documented-caveat path (the cache may reuse the local
+// rendering), so for those the oracle is parse-back-to-the-same-second
+// only, which is the guarantee downstream parsers rely on.
+func FuzzAppendTimeRFC3339(f *testing.F) {
+	seeds := []time.Time{
+		time.Unix(0, 0),
+		time.Unix(-1, 0),
+		time.Date(1, 1, 1, 0, 0, 0, 0, time.UTC),
+		time.Date(9999, 12, 31, 23, 59, 59, 0, time.UTC),
+		time.Date(2026, 9, 1, 10, 0, 0, 999999999, time.UTC),
+		time.Date(2026, 9, 1, 10, 0, 0, 1, time.FixedZone("+14", 14*3600)),
+		time.Date(2026, 9, 1, 10, 0, 0, 0, time.FixedZone("-12", -12*3600)),
+		time.Now(),
+	}
+	for _, s := range seeds {
+		f.Add(s.Unix(), int32(s.Nanosecond()), uint8(0))
+	}
+	f.Fuzz(func(t *testing.T, sec int64, nsec int32, zoneChoice uint8) {
+		// keep years within RFC3339's four-digit range so the parse-back
+		// oracle is well-defined for every generated instant — including
+		// after conversion to the +14:00 extreme zone (16h headroom)
+		const year9999 = 253402300799 // 9999-12-31T23:59:59Z
+		if sec < 0 || sec > year9999-16*3600 {
+			sec = sec % (year9999 - 16*3600 + 1)
+			if sec < 0 {
+				sec += year9999 - 16*3600 + 1
+			}
+		}
+		if nsec < 0 {
+			nsec = -nsec
+		}
+		inst := time.Unix(sec, int64(nsec))
+		if zoneChoice&1 == 0 {
+			local := inst.In(time.Local)
+			// the cache is shared process-wide and keyed by Unix second, so a
+			// prior iteration in another zone could pollute this second (the
+			// documented limitation); force a miss to test the fresh-format
+			// path, then call again to pin the cached-hit path.
+			rfc3339Cache.Store(&rfc3339Second{sec: -1 << 62})
+			got := string(AppendTimeRFC3339(nil, local))
+			want := `"` + local.Format(time.RFC3339) + `"`
+			if got != want {
+				t.Fatalf("local-zone render %s != Format %s (t=%v)", got, want, local)
+			}
+			if hit := string(AppendTimeRFC3339(nil, local)); hit != want {
+				t.Fatalf("cached render %s != Format %s (t=%v)", hit, want, local)
+			}
+		} else {
+			zones := []*time.Location{
+				time.UTC,
+				time.FixedZone("+14", 14*3600),
+				time.FixedZone("-12", -12*3600),
+				time.FixedZone("+05:30", 5*3600+1800),
+			}
+			other := inst.In(zones[int(zoneChoice)%len(zones)])
+			got := string(AppendTimeRFC3339(nil, other))
+			var s string
+			if err := json.Unmarshal([]byte(got), &s); err != nil {
+				t.Fatalf("not a valid JSON string: %v (%q)", err, got)
+			}
+			parsed, err := time.Parse(time.RFC3339, s)
+			if err != nil {
+				t.Fatalf("rendering %q is not RFC3339: %v", s, err)
+			}
+			// second precision: whatever rendering the cache served, the
+			// parsed instant must be the same second (sub-second dropped)
+			if parsed.Unix() != other.Unix() {
+				t.Fatalf("parsed second %d != %d (rendering %q)", parsed.Unix(), other.Unix(), s)
+			}
+		}
+	})
 }

--- a/internal/hcjson/types.go
+++ b/internal/hcjson/types.go
@@ -16,17 +16,29 @@ import (
 // json.Marshal would emit \u003c for <, which parses equal but differs
 // on the wire). A variable keeps the vendored seam (JSONMarshalFunc)
 // swappable in tests.
-var jsonMarshal = func(v any) ([]byte, error) {
+//
+// Panic policy (slog precedent, log/slog handler.go appendJSONMarshal):
+// a user MarshalJSON panic must not unwind End — encoding/json lets it
+// propagate (both the classic implementation and the go1.27 json/v2
+// default), so it is recovered here into the documented fallback string.
+// This pins the wire behavior identically across the Go 1.25–1.27
+// matrix; the error-return path keeps the vendored zerolog shape.
+var jsonMarshal = func(v any) (b []byte, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			b, err = nil, fmt.Errorf("%v", r)
+		}
+	}()
 	var buf bytes.Buffer
 	encoder := json.NewEncoder(&buf)
 	encoder.SetEscapeHTML(false)
-	if err := encoder.Encode(v); err != nil {
+	if err = encoder.Encode(v); err != nil {
 		return nil, err
 	}
-	b := buf.Bytes()
+	b = buf.Bytes()
 	if len(b) > 0 {
 		// Remove the trailing \n added by Encode.
-		return b[:len(b)-1], nil
+		b = b[:len(b)-1]
 	}
 	return b, nil
 }

--- a/internal/hcjson/types.go
+++ b/internal/hcjson/types.go
@@ -17,12 +17,14 @@ import (
 // on the wire). A variable keeps the vendored seam (JSONMarshalFunc)
 // swappable in tests.
 //
-// Panic policy (slog precedent, log/slog handler.go appendJSONMarshal):
-// a user MarshalJSON panic must not unwind End — encoding/json lets it
-// propagate (both the classic implementation and the go1.27 json/v2
-// default), so it is recovered here into the documented fallback string.
-// This pins the wire behavior identically across the Go 1.25–1.27
-// matrix; the error-return path keeps the vendored zerolog shape.
+// Panic policy (slog precedent: log/slog handler.go appendValue — the
+// recover at handler.go:586 catches panics escaping appendJSONMarshal's
+// json.Marshal): a user MarshalJSON panic must not unwind End —
+// encoding/json lets it propagate (both the classic implementation and
+// the go1.27 json/v2 default), so it is recovered here into the
+// documented fallback string. This pins the wire behavior identically
+// across the Go 1.25–1.27 matrix; the error-return path keeps the
+// vendored zerolog shape.
 var jsonMarshal = func(v any) (b []byte, err error) {
 	defer func() {
 		if r := recover(); r != nil {

--- a/operation_test.go
+++ b/operation_test.go
@@ -216,6 +216,47 @@ func TestOutcomePrecedence(t *testing.T) {
 	}
 }
 
+// TestPanicBeatsErrorWhenCoDelivered pins the panic > error precedence
+// for the shape the table test cannot reach: the error pointer is
+// already set when End runs AND a panic is in flight (defer op.End(&err)
+// with err non-nil, then panic). resolveOutcomeV2 must still resolve
+// OutcomePanic — a swap to error-first precedence silently turns the
+// event into OutcomeFailure. Found as a gap by mutation testing (M7):
+// every panic test deferred op.End(nil), so the error was never
+// co-delivered and the precedence row in TestOutcomePrecedence carried
+// an err it never passed to End.
+func TestPanicBeatsErrorWhenCoDelivered(t *testing.T) {
+	rt, ts := testRT(t, nil)
+	op := Start(context.Background(), rt, OperationStart{Domain: DomainJob, Name: "both"})
+
+	err := errors.New("original error")
+	func() {
+		defer func() { recover() }() // swallow End's re-panic
+		defer op.End(&err)           // direct defer: observes the panic
+		panic("panic value")
+	}()
+
+	events := ts.Events()
+	if len(events) != 1 {
+		t.Fatalf("captured %d events, want 1", len(events))
+	}
+	ev := events[0]
+
+	if v, _ := ev.Lookup("op.outcome"); v != string(OutcomePanic) {
+		t.Fatalf("op.outcome = %v, want %q — panic must beat the co-delivered error", v, OutcomePanic)
+	}
+	if p, ok := ev.Lookup("panic"); !ok {
+		t.Fatal("missing panic field")
+	} else if pm, ok := p.(map[string]any); !ok || pm["value"] != "panic value" {
+		t.Fatalf("panic field = %v, want value %q", p, "panic value")
+	}
+	if e, ok := ev.Lookup("error"); !ok {
+		t.Fatal("missing error field")
+	} else if em, ok := e.(map[string]any); !ok || em["message"] != "original error" {
+		t.Fatalf("error.message = %v, want %q — the real error must survive, not the synthetic \"panic: …\" error", em["message"], "original error")
+	}
+}
+
 // TestErrorsBypassSampling is amendment 4: failures are never sampled
 // away, structurally, before any custom sampler runs.
 func TestErrorsBypassSampling(t *testing.T) {

--- a/pool_reuse_canary_test.go
+++ b/pool_reuse_canary_test.go
@@ -69,15 +69,27 @@ func TestPoolReuseCanary(t *testing.T) {
 	canaryWrite(ctx2) // last request's context is stale after its End as well
 
 	// The oracle: no captured event — not request 1's, not any recycled
-	// request's — may ever contain the sentinel. The assertion message
-	// names the contract so a regression report points at the fix, in
-	// slog's "!BUG" spirit.
+	// request's — may ever carry the sentinel, whether as a field key
+	// (the Add shape) or as a msg/level mutation (SetMessage/SetLevel
+	// write no field — without these checks those landings would be
+	// invisible to a key scan; review finding GLM-1). The assertion
+	// message names the contract so a regression report points at the
+	// fix, in slog's "!BUG" spirit.
 	for i, ev := range ts.Events() {
 		if v, ok := ev.Lookup("!BUG"); ok {
 			t.Fatalf("event %d: use-after-recycle — a write through a stale "+
 				"context landed on a pooled event (slog !BUG canary): %v; "+
 				"the generation check in append/setMessage/setLevel "+
 				"(wal.go amendments 1/20) must reject post-End writes", i, v)
+		}
+		if msg := ev.Message(); msg == "!BUG stale message" {
+			t.Fatalf("event %d: stale SetMessage landed on a pooled event "+
+				"(message %q); the live() generation check in setMessage must "+
+				"reject post-End writes", i, msg)
+		}
+		if ev.Level() == LevelError {
+			t.Fatalf("event %d: stale SetLevel(Error) landed on a pooled event; "+
+				"the live() generation check in setLevel must reject post-End writes", i)
 		}
 	}
 	events := ts.Events()

--- a/pool_reuse_canary_test.go
+++ b/pool_reuse_canary_test.go
@@ -21,9 +21,12 @@ import (
 //
 // zap's internal/pool/pool_test.go contributes the other half: the GC
 // and (under -race) the runtime both drain sync.Pool, so the critical
-// window runs with GC disabled — that both keeps the pool hot and makes
-// Put-then-Get return the same event deterministically, which the test
-// asserts so it can never pass vacuously.
+// window runs with GC disabled to keep the pool hot. Recycle is NOT
+// asserted — the race runtime drops a share of Puts entirely (~20-30%
+// of runs never see the exact event again), so the test fires its
+// sentinel writes across a churn of requests and guards whichever
+// events the pool hands out; the deterministic reset-path half lives
+// in TestWALAppendSealedStaleGeneration.
 func TestPoolReuseCanary(t *testing.T) {
 	oldGC := debug.SetGCPercent(-1) // zap: keep the pool hot for the whole test
 	defer debug.SetGCPercent(oldGC)
@@ -40,35 +43,30 @@ func TestPoolReuseCanary(t *testing.T) {
 	op1.End(nil)
 	ev1 := op1.ev
 
-	// Recycle must be deterministic with GC off (same-goroutine Put then
-	// Get hits the pool's private slot): if the pool ever stops reusing
-	// the event, the canary below guards nothing and the test must say
-	// so instead of passing silently.
-	op2 := Start(context.Background(), rt, OperationStart{Domain: DomainJob, Name: "two"})
-	ev2 := op2.ev
-	if ev2 != ev1 {
-		t.Fatal("pool did not recycle the released event; canary guards nothing")
-	}
-	ctx2 := op2.Context()
-	Add(ctx2, "payload", "request-two")
-
-	// Canary volley 1 — while request 2 is LIVE on the recycled event.
-	// Each write must no-op: the stale generation must fail every entry
-	// point (append / setMessage / setLevel / setError).
-	canaryWrite(ctx1)
-	op2.End(nil)
-
-	// Canary volley 2 — after request 2 ended, the event is pooled again
-	// and immediately reused by request 3; the same stale context keeps
-	// firing across the churn.
-	for i := 0; i < 32; i++ {
+	// Chase the recycled event across requests. GC off keeps the pool
+	// hot, but the race runtime still drops a share of sync.Pool Puts
+	// (~20-30% of runs never see the exact event again; zap's
+	// internal/pool note), so observation is best-effort: every round
+	// fires the stale writes against whatever event the pool returned
+	// (recycled or fresh — both must reject them), and the reset-path
+	// generation bump is deterministically covered by
+	// TestWALAppendSealedStaleGeneration. A round that gets op1's event
+	// back additionally guards the write-after-reset window.
+	ctx2 := context.Background()
+	recycled := false
+	rounds := 0
+	for rounds < 16 && !recycled {
 		op := Start(context.Background(), rt, OperationStart{Domain: DomainJob, Name: "churn"})
-		Add(op.Context(), "payload", "churn")
-		canaryWrite(ctx1) // live window
+		ctx := op.Context()
+		ctx2 = ctx
+		rounds++
+		Add(ctx, "payload", "churn")
+		canaryWrite(ctx1) // live window: stale gen must fail every entry point
 		op.End(nil)
-		canaryWrite(ctx1) // pooled window
+		canaryWrite(ctx1) // pooled window: stale gen must fail after release too
+		recycled = op.ev == ev1
 	}
-	canaryWrite(ctx2) // ctx2 is stale after request 2 too
+	canaryWrite(ctx2) // last request's context is stale after its End as well
 
 	// The oracle: no captured event — not request 1's, not any recycled
 	// request's — may ever contain the sentinel. The assertion message
@@ -83,12 +81,15 @@ func TestPoolReuseCanary(t *testing.T) {
 		}
 	}
 	events := ts.Events()
-	if got := len(events); got != 34 {
-		t.Fatalf("captured %d events, want 34 (1 + 1 + 32 churn)", got)
+	if got := len(events); got != 1+rounds {
+		t.Fatalf("captured %d events, want %d (1 + %d churn rounds)", got, 1+rounds, rounds)
 	}
-	for i, want := range []string{"request-one", "request-two"} {
-		if v, _ := events[i].Lookup("payload"); v != want {
-			t.Fatalf("event %d payload = %v, want %q", i, v, want)
+	if v, _ := events[0].Lookup("payload"); v != "request-one" {
+		t.Fatalf("event 0 payload = %v, want %q", v, "request-one")
+	}
+	for i := 1; i < len(events); i++ {
+		if v, _ := events[i].Lookup("payload"); v != "churn" {
+			t.Fatalf("churn event %d payload = %v, want %q", i, v, "churn")
 		}
 	}
 }

--- a/pool_reuse_canary_test.go
+++ b/pool_reuse_canary_test.go
@@ -1,0 +1,104 @@
+package hc
+
+import (
+	"context"
+	"errors"
+	"runtime/debug"
+	"testing"
+)
+
+// TestPoolReuseCanary pins the WAL pool-recycle contract with the
+// sentinel technique from log/slog's TestAliasingAndClone
+// (record_test.go): slog inserts a "!BUG" attr wherever an unsafe
+// shared-backing write would land, so the violation fails loudly with
+// the broken contract named instead of silently corrupting data. Our
+// adaptation (dst-research §11.3): the pooled buffer is the *event
+// (fields backing slice included) that End releases to eventPool and
+// the next request reuses; the sentinel is a canary field written
+// through a stale (already-ended) context. A correct implementation
+// drops every one of those writes at the generation check (wal.go
+// amendments 1/20); any write that lands is a use-after-recycle.
+//
+// zap's internal/pool/pool_test.go contributes the other half: the GC
+// and (under -race) the runtime both drain sync.Pool, so the critical
+// window runs with GC disabled — that both keeps the pool hot and makes
+// Put-then-Get return the same event deterministically, which the test
+// asserts so it can never pass vacuously.
+func TestPoolReuseCanary(t *testing.T) {
+	oldGC := debug.SetGCPercent(-1) // zap: keep the pool hot for the whole test
+	defer debug.SetGCPercent(oldGC)
+
+	ts := NewTestSink()
+	rt := MustCompile(Config{Sink: ts, SamplingRate: 1})
+
+	// Request 1 writes real payload, then ends: the event is sealed and
+	// returned to the pool, and ctx1 is now stale — it still pins the
+	// pooled *event.
+	op1 := Start(context.Background(), rt, OperationStart{Domain: DomainJob, Name: "one"})
+	ctx1 := op1.Context()
+	Add(ctx1, "payload", "request-one")
+	op1.End(nil)
+	ev1 := op1.ev
+
+	// Recycle must be deterministic with GC off (same-goroutine Put then
+	// Get hits the pool's private slot): if the pool ever stops reusing
+	// the event, the canary below guards nothing and the test must say
+	// so instead of passing silently.
+	op2 := Start(context.Background(), rt, OperationStart{Domain: DomainJob, Name: "two"})
+	ev2 := op2.ev
+	if ev2 != ev1 {
+		t.Fatal("pool did not recycle the released event; canary guards nothing")
+	}
+	ctx2 := op2.Context()
+	Add(ctx2, "payload", "request-two")
+
+	// Canary volley 1 — while request 2 is LIVE on the recycled event.
+	// Each write must no-op: the stale generation must fail every entry
+	// point (append / setMessage / setLevel / setError).
+	canaryWrite(ctx1)
+	op2.End(nil)
+
+	// Canary volley 2 — after request 2 ended, the event is pooled again
+	// and immediately reused by request 3; the same stale context keeps
+	// firing across the churn.
+	for i := 0; i < 32; i++ {
+		op := Start(context.Background(), rt, OperationStart{Domain: DomainJob, Name: "churn"})
+		Add(op.Context(), "payload", "churn")
+		canaryWrite(ctx1) // live window
+		op.End(nil)
+		canaryWrite(ctx1) // pooled window
+	}
+	canaryWrite(ctx2) // ctx2 is stale after request 2 too
+
+	// The oracle: no captured event — not request 1's, not any recycled
+	// request's — may ever contain the sentinel. The assertion message
+	// names the contract so a regression report points at the fix, in
+	// slog's "!BUG" spirit.
+	for i, ev := range ts.Events() {
+		if v, ok := ev.Lookup("!BUG"); ok {
+			t.Fatalf("event %d: use-after-recycle — a write through a stale "+
+				"context landed on a pooled event (slog !BUG canary): %v; "+
+				"the generation check in append/setMessage/setLevel "+
+				"(wal.go amendments 1/20) must reject post-End writes", i, v)
+		}
+	}
+	events := ts.Events()
+	if got := len(events); got != 34 {
+		t.Fatalf("captured %d events, want 34 (1 + 1 + 32 churn)", got)
+	}
+	for i, want := range []string{"request-one", "request-two"} {
+		if v, _ := events[i].Lookup("payload"); v != want {
+			t.Fatalf("event %d payload = %v, want %q", i, v, want)
+		}
+	}
+}
+
+// canaryWrite replays every public write shape through a stale context.
+// The sentinel key and value are chosen so their presence on any wire
+// is unambiguous (slog renders the same idea as String("!BUG", …)).
+func canaryWrite(stale context.Context) {
+	Add(stale, "!BUG", "stale write through a released context")
+	SetMessage(stale, "!BUG stale message")
+	SetLevel(stale, LevelError)
+	Error(stale, errors.New("!BUG stale error"))
+}

--- a/record_roundtrip_test.go
+++ b/record_roundtrip_test.go
@@ -1,0 +1,385 @@
+package hc
+
+import (
+	"bytes"
+	"encoding/json"
+	"math"
+	"math/rand/v2"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+	"unicode/utf8"
+)
+
+// This file implements the record-level round-trip properties from the
+// DST/fuzzing research (§7.1 field round-trip per kind, §7.2 encode
+// determinism, §6.2 dedupe fuzz with an independent reference fold):
+// Encoded() must produce a JSON line that parses back to exactly the
+// record's resolved (last-write-wins) view, for every field kind, at
+// every width, under adversarial duplicate structure.
+
+// decodeLineStrict parses one canonical line and returns both the
+// last-wins map (Go's json semantics) and the ordered raw members.
+type rawMember struct {
+	key string
+	val json.RawMessage
+}
+
+func decodeLineStrict(t *testing.T, line []byte) (map[string]json.RawMessage, []rawMember) {
+	t.Helper()
+	dec := json.NewDecoder(bytes.NewReader(line))
+	dec.UseNumber()
+	var top map[string]json.RawMessage
+	if err := dec.Decode(&top); err != nil {
+		t.Fatalf("Encoded() is not valid JSON: %v (%q)", err, line)
+	}
+	// ordered re-walk for order assertions
+	var ordered []rawMember
+	dec2 := json.NewDecoder(bytes.NewReader(line))
+	dec2.Token() // {
+	for {
+		tok, err := dec2.Token()
+		if err != nil {
+			break
+		}
+		if key, ok := tok.(string); ok {
+			var raw json.RawMessage
+			if err := dec2.Decode(&raw); err != nil {
+				t.Fatalf("member %q: %v", key, err)
+			}
+			ordered = append(ordered, rawMember{key, raw})
+		}
+		if tok == json.Delim('}') {
+			break
+		}
+	}
+	return top, ordered
+}
+
+// TestEncodedRoundTripAllKinds walks every field kind through
+// Encoded() → parse → compare, on both friendly and adversarial values.
+func TestEncodedRoundTripAllKinds(t *testing.T) {
+	utc := time.Date(2026, 9, 1, 10, 0, 0, 0, time.UTC)
+	ist := time.Date(2026, 9, 1, 15, 30, 0, 0, time.FixedZone("IST", 5*3600+30*60))
+
+	cases := []struct {
+		key     string
+		field   Field
+		check   func(t *testing.T, raw json.RawMessage)
+		skipOrd bool // kinds whose wire form is embedded/structured
+	}{
+		{"s", fieldOf("s", "v"), rawStringIs("v"), false},
+		{"s_quote", fieldOf("s_quote", `she said "hi"`), rawStringIs(`she said "hi"`), false},
+		{"s_nl", fieldOf("s_nl", "a\nb\tc"), rawStringIs("a\nb\tc"), false},
+		{"s_uni", fieldOf("s_uni", "héllo ☃ 🍜"), rawStringIs("héllo ☃ 🍜"), false},
+		{"s_ctl", fieldOf("s_ctl", "x\x00\x7fy"), rawStringIs("x\x00\x7fy"), false},
+		{"i", fieldOf("i", -42), rawNumberIs("-42"), false},
+		{"i_min", fieldOf("i_min", int64(math.MinInt64)), rawNumberIs(strconv.FormatInt(math.MinInt64, 10)), false},
+		{"i_max", fieldOf("i_max", int64(math.MaxInt64)), rawNumberIs(strconv.FormatInt(math.MaxInt64, 10)), false},
+		{"u_max", fieldOf("u_max", uint64(math.MaxUint64)), rawNumberIs(strconv.FormatUint(math.MaxUint64, 10)), false},
+		{"f", fieldOf("f", 2.5), rawNumberIs("2.5"), false},
+		{"f_neg0", fieldOf("f_neg0", math.Copysign(0, -1)), rawNumberIs("-0"), false},
+		{"f_big", fieldOf("f_big", 1e21), rawNumberIs("1e+21"), false},
+		{"f32", fieldOf("f32", float32(0.1)), rawNumberIs("0.1"), false},
+		{"f_nan", fieldOf("f_nan", math.NaN()), rawStringIs("NaN"), false},
+		{"f_pinf", fieldOf("f_pinf", math.Inf(1)), rawStringIs("+Inf"), false},
+		{"b", fieldOf("b", true), rawIs("true"), false},
+		{"t_utc", fieldOf("t_utc", utc), rawStringIs(utc.Format(time.RFC3339)), false},
+		{"t_zone", fieldOf("t_zone", ist), rawStringIs(ist.Format(time.RFC3339)), false},
+		{"d", fieldOf("d", 1500*time.Millisecond), rawNumberIs("1500"), false},
+		{"d_frac", fieldOf("d_frac", 123456789*time.Nanosecond), rawNumberIs("123.456789"), false},
+		{"d_neg", fieldOf("d_neg", -time.Second), rawNumberIs("-1000"), false},
+		{"e", fieldOf("e", errString("boom")), rawStringIs("boom"), false},
+		{"any_obj", fieldAny("any_obj", map[string]any{"n": 1}), rawIs(`{"n":1}`), true},
+		{"any_nil", fieldAny("any_nil", nil), rawIs("null"), false},
+	}
+
+	for _, c := range cases {
+		t.Run(c.key, func(t *testing.T) {
+			r := recOf(LevelInfo, "m", c.field)
+			got, ordered := decodeLineStrict(t, r.Encoded())
+			raw, ok := got[c.key]
+			if !ok {
+				t.Fatalf("key %q missing from %v", c.key, got)
+			}
+			c.check(t, raw)
+			if !c.skipOrd {
+				found := false
+				for _, m := range ordered {
+					if m.key == c.key {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Fatalf("key %q not in ordered members", c.key)
+				}
+			}
+		})
+	}
+
+	// raw fields are embedded verbatim
+	r := recOf(LevelInfo, "m", Field{key: "raw", kind: KindRaw, val: []byte(`{"pre":true}`)})
+	got, _ := decodeLineStrict(t, r.Encoded())
+	if string(got["raw"]) != `{"pre":true}` {
+		t.Fatalf("raw field = %s", got["raw"])
+	}
+}
+
+func rawStringIs(want string) func(*testing.T, json.RawMessage) {
+	return func(t *testing.T, raw json.RawMessage) {
+		var s string
+		if err := json.Unmarshal(raw, &s); err != nil {
+			t.Fatalf("not a string: %s (%v)", raw, err)
+		}
+		if s != want {
+			t.Fatalf("string = %q, want %q", s, want)
+		}
+	}
+}
+
+func rawNumberIs(want string) func(*testing.T, json.RawMessage) {
+	return func(t *testing.T, raw json.RawMessage) {
+		if n := strings.TrimPrefix(string(raw), `"`); n != want {
+			t.Fatalf("number = %s, want %s", raw, want)
+		}
+	}
+}
+
+func rawIs(want string) func(*testing.T, json.RawMessage) {
+	return func(t *testing.T, raw json.RawMessage) {
+		if string(raw) != want {
+			t.Fatalf("value = %s, want %s", raw, want)
+		}
+	}
+}
+
+// TestEncodedRoundTripProperty is the generated counterpart: PCG-seeded
+// random field sets (strings with injected specials, ints across the
+// 2^53 boundary, floats, durations) must survive the encode → parse →
+// compare cycle exactly.
+func TestEncodedRoundTripProperty(t *testing.T) {
+	const total = 20_000
+	rng := rand.New(rand.NewPCG(0x600D5eed, 0x51EE5eed))
+
+	specials := []byte{0x00, 0x09, 0x0a, '"', '\\', 0x7f, 0x80, 0xff}
+	for i := 0; i < total; i++ {
+		width := 1 + rng.IntN(8)
+		fields := make([]Field, width)
+		for w := range fields {
+			key := "k" + strconv.Itoa(rng.IntN(6))
+			switch rng.IntN(4) {
+			case 0:
+				b := make([]byte, rng.IntN(24))
+				for j := range b {
+					if rng.IntN(8) == 0 {
+						b[j] = specials[rng.IntN(len(specials))]
+					} else {
+						b[j] = byte(0x20 + rng.IntN(0x5f))
+					}
+				}
+				fields[w] = fieldOf(key, string(b))
+			case 1:
+				fields[w] = fieldOf(key, rng.Int64())
+			case 2:
+				fields[w] = fieldOf(key, rng.Float64())
+			case 3:
+				fields[w] = fieldOf(key, time.Duration(rng.Int64())*time.Millisecond)
+			}
+		}
+		r := recOf(LevelInfo, "prop", fields...)
+		got, _ := decodeLineStrict(t, r.Encoded())
+
+		// reference fold: last write wins per key, forward order
+		var wantKeys []string
+		wantVals := map[string]Field{}
+		for _, f := range fields {
+			if _, seen := wantVals[f.key]; !seen {
+				wantKeys = append(wantKeys, f.key)
+			}
+			wantVals[f.key] = f
+		}
+		if len(got) != len(wantKeys)+3 { // + level, time, message
+			t.Fatalf("i=%d: %d keys on wire, want %d (+3 canonical)", i, len(got), len(wantKeys))
+		}
+		for k, wf := range wantVals {
+			raw, ok := got[k]
+			if !ok {
+				t.Fatalf("i=%d: key %q missing", i, k)
+			}
+			var s string
+			var num int64
+			var fnum float64
+			switch wf.kind {
+			case KindString:
+				if err := json.Unmarshal(raw, &s); err != nil || (!utf8.ValidString(wf.str) && err != nil) {
+					t.Fatalf("i=%d %q: %v", i, k, err)
+				}
+				if utf8.ValidString(wf.str) && s != wf.str {
+					t.Fatalf("i=%d %q: string round-trip %q != %q", i, k, s, wf.str)
+				}
+			case KindInt:
+				if err := json.Unmarshal(raw, &num); err != nil || num != wf.num {
+					t.Fatalf("i=%d %q: int round-trip %d != %d (%s)", i, k, num, wf.num, raw)
+				}
+			case KindFloat:
+				if err := json.Unmarshal(raw, &fnum); err != nil || fnum != wf.f {
+					t.Fatalf("i=%d %q: float round-trip %v != %v", i, k, fnum, wf.f)
+				}
+			case KindDuration:
+				var ms float64
+				if err := json.Unmarshal(raw, &ms); err != nil || ms != float64(wf.num)/float64(time.Millisecond) {
+					t.Fatalf("i=%d %q: duration round-trip %v != %v", i, k, ms, float64(wf.num)/float64(time.Millisecond))
+				}
+			}
+		}
+	}
+}
+
+// TestEncodedDeterminism: two records built from equal inputs encode to
+// equal bytes — encoding is a pure function of (level, msg, fields,
+// completedAt) (dst-research §7.2).
+func TestEncodedDeterminism(t *testing.T) {
+	build := func() *Record {
+		return recOf(LevelWarn, "same",
+			fieldOf("a", 1), fieldOf("b", "two"), fieldOf("a", 3),
+			fieldOf("f", 0.1), fieldOf("d", time.Second))
+	}
+	if !bytes.Equal(build().Encoded(), build().Encoded()) {
+		t.Fatal("two equal records encoded differently")
+	}
+}
+
+// FuzzRecordEncodedDedupe is the dedupe-boundary fuzz target
+// (dst-research §6.2): generated field sequences with dense duplicates
+// and canonical-key collisions must produce a line where every user key
+// appears exactly once with its last value, in last-occurrence order —
+// checked against an independent reference fold, not the encoder's own
+// dedupe code.
+//
+// Canonical-key collision is PINNED as documented behavior (G2, user
+// error): user fields named "level"/"time"/"message" do NOT shadow or
+// rename — the canonical envelope keys are appended after the fields,
+// so the wire carries both and a last-wins parser sees the canonical
+// value.
+func FuzzRecordEncodedDedupe(f *testing.F) {
+	f.Add(uint8(0), []byte{0, 1, 2, 0, 1}, []byte{7, 7, 7})
+	f.Add(uint8(24), []byte{0, 1, 2, 3, 0, 1, 2, 3}, []byte{1, 2})
+	f.Add(uint8(25), []byte{0, 0, 0, 0}, []byte{1, 2, 3})
+	f.Add(uint8(31), []byte{0, 1, 2, 3, 4, 5, 6, 7}, []byte{0})
+	f.Add(uint8(32), []byte{0}, []byte{1}) // seenArr → map handoff
+	f.Add(uint8(64), []byte{3, 3, 3}, []byte{9})
+	f.Add(uint8(5), []byte{4, 4, 4}, []byte{1}) // all keys are "message"
+	f.Add(uint8(5), []byte{5, 5}, []byte{1})    // all keys are "time"
+	f.Add(uint8(5), []byte{6, 6}, []byte{1})    // all keys are "level"
+	f.Fuzz(func(t *testing.T, widthRaw uint8, keySeed []byte, valSeed []byte) {
+		width := int(widthRaw) % 80
+		if len(keySeed) == 0 {
+			return
+		}
+		alphabet := []string{"a", "bb", "ccc", "message", "time", "level", "zz"}
+		fields := make([]Field, width)
+		for i := range fields {
+			key := alphabet[int(keySeed[i%len(keySeed)])%len(alphabet)]
+			val := int64(0)
+			if len(valSeed) > 0 {
+				val = int64(valSeed[i%len(valSeed)])
+			}
+			fields[i] = fieldOf(key, val)
+		}
+
+		r := recOf(LevelInfo, "m", fields...)
+		got, ordered := decodeLineStrict(t, r.Encoded())
+
+		// reference fold (independent of appendDedupedFields)
+		type lastWrite struct {
+			val int64
+			pos int // last-occurrence position, for order
+		}
+		lww := map[string]lastWrite{}
+		for i, fl := range fields {
+			lww[fl.key] = lastWrite{fl.num, i}
+		}
+		var wantOrder []string
+		{
+			type kv struct {
+				k   string
+				pos int
+			}
+			var kvs []kv
+			for k, lw := range lww {
+				kvs = append(kvs, kv{k, lw.pos})
+			}
+			// sort by last-occurrence position ascending = emission order
+			for i := 1; i < len(kvs); i++ {
+				for j := i; j > 0 && kvs[j].pos < kvs[j-1].pos; j-- {
+					kvs[j], kvs[j-1] = kvs[j-1], kvs[j]
+				}
+			}
+			for _, kv := range kvs {
+				wantOrder = append(wantOrder, kv.k)
+			}
+		}
+
+		// 1. every non-canonical user key exactly once on the wire
+		// (keys colliding with level/time/message are pinned by check 3)
+		for k := range lww {
+			if k == "level" || k == "time" || k == "message" {
+				continue
+			}
+			n := 0
+			for _, m := range ordered {
+				if m.key == k {
+					n++
+				}
+			}
+			if n != 1 {
+				t.Fatalf("key %q emitted %d times (width %d): %s", k, n, width, r.Encoded())
+			}
+			var v int64
+			if err := json.Unmarshal(got[k], &v); err != nil || v != lww[k].val {
+				t.Fatalf("key %q = %s, want last value %d", k, got[k], lww[k].val)
+			}
+		}
+
+		// 2. emission order == last-occurrence order. The envelope keys
+		// occupy fixed slots (member 0 is the canonical level; the last two
+		// members are the canonical time and message), so the user span is
+		// strictly between them regardless of collisions.
+		var gotOrder []string
+		for _, m := range ordered {
+			gotOrder = append(gotOrder, m.key)
+		}
+		userGot := gotOrder[1 : len(gotOrder)-2]
+		for i := range wantOrder {
+			if userGot[i] != wantOrder[i] {
+				t.Fatalf("order mismatch at %d: got %v want %v (line %s)", i, userGot, wantOrder, r.Encoded())
+			}
+		}
+
+		// 3. canonical collision pin: level/time/message appear exactly
+		// once as envelope keys regardless of user fields with the same
+		// name (the user copy is the duplicate; last-wins parsers see the
+		// canonical value)
+		for _, canon := range []string{"level", "time", "message"} {
+			n := 0
+			for _, m := range ordered {
+				if m.key == canon {
+					n++
+				}
+			}
+			userHas := false
+			if _, ok := lww[canon]; ok {
+				userHas = true
+			}
+			wantN := 1
+			if userHas {
+				wantN = 2
+			}
+			if n != wantN {
+				t.Fatalf("canonical key %q appears %d times, want %d (collision pin)", canon, n, wantN)
+			}
+		}
+	})
+}

--- a/straggler_start_line_test.go
+++ b/straggler_start_line_test.go
@@ -10,12 +10,13 @@ import (
 )
 
 // TestStragglerStartLine stresses the straggler-vs-recycle window with
-// logrus's start-line technique (entry_test.go,
-// TestLoggingRaceWithHooksOnEntry): every goroutine is held on a
-// sync.Cond and released simultaneously with one Broadcast, so stale
-// writes, owner writes, and End/seal/recycle all contend on the same
-// instruction window instead of staggered goroutine spawns — the shape
-// that maximizes race-window hits (dst-research §11.4).
+// logrus's start-line technique (logrus_test.go,
+// TestLoggingRaceWithHooksOnEntry — sync.NewCond + Broadcast): every
+// goroutine is held on a sync.Cond and released simultaneously with
+// one Broadcast, so stale writes, owner writes, and End/seal/recycle
+// all contend on the same instruction window instead of staggered
+// goroutine spawns — the shape that maximizes race-window hits
+// (dst-research §11.4).
 //
 // Cast: one owner churns Start/Add/End requests so the pooled event a
 // stale context pins is constantly reset and reused, while straggler

--- a/straggler_start_line_test.go
+++ b/straggler_start_line_test.go
@@ -1,0 +1,143 @@
+package hc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+// TestStragglerStartLine stresses the straggler-vs-recycle window with
+// logrus's start-line technique (entry_test.go,
+// TestLoggingRaceWithHooksOnEntry): every goroutine is held on a
+// sync.Cond and released simultaneously with one Broadcast, so stale
+// writes, owner writes, and End/seal/recycle all contend on the same
+// instruction window instead of staggered goroutine spawns — the shape
+// that maximizes race-window hits (dst-research §11.4).
+//
+// Cast: one owner churns Start/Add/End requests so the pooled event a
+// stale context pins is constantly reset and reused, while straggler
+// goroutines replay every write shape through that stale context. The
+// oracle is deterministic-in-aggregate (logrus's assertion shape —
+// counts and per-event consistency, never ordering): exactly one event
+// per request, each carrying its own round marker, none ever containing
+// a straggler write. Run under -race this pins the amendment-1/20
+// protocol: a stale write can never land on a live or recycled event.
+func TestStragglerStartLine(t *testing.T) {
+	const (
+		stragglers = 6
+		rounds     = 400
+	)
+
+	ts := NewTestSink()
+	rt := MustCompile(Config{Sink: ts, SamplingRate: 1})
+
+	// The shared stale context: op0 ends before the race starts, its
+	// event is pooled, and the owner's churn below recycles it
+	// continuously while the stragglers write into it.
+	op0 := Start(context.Background(), rt, OperationStart{Domain: DomainJob, Name: "stale"})
+	stale := op0.Context()
+	op0.End(nil)
+
+	var stragglerWrites atomic.Int64 // sanity: the stragglers must actually run
+
+	var mu sync.Mutex
+	start := sync.NewCond(&mu)
+	released := false
+	registered := 0
+	workers := stragglers + 1 // stragglers + owner
+
+	release := func() {
+		mu.Lock()
+		defer mu.Unlock()
+		for registered != workers {
+			start.Wait() // go to sleep; a worker's Broadcast wakes us
+		}
+		released = true
+		start.Broadcast()
+	}
+
+	var wg sync.WaitGroup
+	enter := func() {
+		mu.Lock()
+		registered++
+		start.Broadcast() // wake the releaser if it is already waiting
+		for !released {
+			start.Wait()
+		}
+		mu.Unlock()
+	}
+
+	wg.Add(workers + 1) // owner + stragglers + releaser
+	go func() {         // releaser: fires the start line exactly once
+		defer wg.Done()
+		release()
+	}()
+
+	// Owner: churns requests; each round's event is (usually) the same
+	// pooled one op0 released, so the stale writes below constantly hit
+	// a live-then-recycled target.
+	go func() {
+		defer wg.Done()
+		enter()
+		for i := 0; i < rounds; i++ {
+			op := Start(context.Background(), rt, OperationStart{Domain: DomainJob, Name: "churn"})
+			Add(op.Context(), "owner", i)
+			op.End(nil)
+		}
+	}()
+
+	// Stragglers: replay the full stale-write vocabulary against the
+	// recycled event, released at the same instant as the owner.
+	for s := 0; s < stragglers; s++ {
+		go func(s int) {
+			defer wg.Done()
+			enter()
+			for i := 0; i < rounds; i++ {
+				key := fmt.Sprintf("!BUG-straggler-%d", s)
+				Add(stale, key, i)
+				if i%3 == 0 {
+					SetMessage(stale, "!BUG stale message")
+					SetLevel(stale, LevelError)
+				}
+				if i%7 == 0 {
+					Error(stale, errors.New("!BUG stale error"))
+				}
+				stragglerWrites.Add(1)
+			}
+		}(s)
+	}
+	wg.Wait()
+
+	if got := stragglerWrites.Load(); got != stragglers*rounds {
+		t.Fatalf("stragglers executed %d writes, want %d", got, stragglers*rounds)
+	}
+
+	events := ts.Events()
+	if len(events) != 1+rounds { // op0 + one per owner round
+		t.Fatalf("captured %d events, want %d", len(events), 1+rounds)
+	}
+	// Per-event integrity: every round's event carries exactly its own
+	// marker — the request-confined payload a torn recycle would corrupt
+	// — and no event (not even op0's) contains any straggler write.
+	for i, ev := range events {
+		if i == 0 {
+			continue // op0 predates the race; checked by the scan below
+		}
+		want := i - 1
+		if v, ok := ev.Lookup("owner"); !ok || v.(int64) != int64(want) {
+			t.Fatalf("event %d: owner marker = %v (ok=%v), want %d — a stale "+
+				"write corrupted a live event", i, v, ok, want)
+		}
+	}
+	for i, ev := range events {
+		for s := 0; s < stragglers; s++ {
+			if _, ok := ev.Lookup(fmt.Sprintf("!BUG-straggler-%d", s)); ok {
+				t.Fatalf("event %d contains a straggler write — stale context "+
+					"mutated a sealed/recycled event (amendment 20)", i)
+			}
+		}
+	}
+}

--- a/wal_test.go
+++ b/wal_test.go
@@ -244,3 +244,72 @@ func TestWALAppendSealedStaleGeneration(t *testing.T) {
 		t.Fatal("stale write landed next to the current-generation fields")
 	}
 }
+
+// TestWALStaleSettersAfterReset pins the live() generation checks in
+// the setter entry points that do not route through append's gen check:
+// setMessage, setLevel, and setError's hasErr latch all trust live()
+// alone. Found as a gap by review (GLM finding 1): removing live() from
+// setMessage passed the entire non-race suite — the pool canary's
+// sentinel oracle only observes field-key landings (the "!BUG" Add),
+// never msg/requestedLevel mutations, which are invisible on the wire
+// until a later request reuses the event.
+func TestWALStaleSettersAfterReset(t *testing.T) {
+	ev := newEvent()
+	gen := ev.state.Load() >> walStateBits
+	owner := &walRef{ev: ev, gen: gen}
+	stale := &walRef{ev: ev, gen: gen}
+
+	// Positive control before the recycle: the owner's setter writes
+	// land and latch their flags.
+	ev.setMessage(owner, "own")
+	ev.setLevel(owner, LevelWarn)
+	ev.setError(owner, errors.New("own error"))
+	if !ev.hasMsg || ev.msg != "own" {
+		t.Fatalf("owner setMessage lost: msg=%q hasMsg=%v", ev.msg, ev.hasMsg)
+	}
+	if !ev.hasRequestedLvl || ev.requestedLevel != LevelWarn {
+		t.Fatalf("owner setLevel lost: level=%v has=%v", ev.requestedLevel, ev.hasRequestedLvl)
+	}
+	if !ev.hasErr {
+		t.Fatal("owner setError lost")
+	}
+
+	ev.seal()
+	ev.reset() // the next request's newEvent() after the pool hands it out
+	if newGen := ev.state.Load() >> walStateBits; newGen == gen {
+		t.Fatal("reset did not advance the generation")
+	}
+
+	// Stale-generation setter writes must no-op on the reset event — in
+	// particular they must not set msg/requestedLevel/hasErr, which the
+	// field-key oracle of TestPoolReuseCanary cannot observe.
+	ev.setMessage(stale, "!BUG stale message")
+	ev.setLevel(stale, LevelError)
+	ev.setError(stale, errors.New("!BUG stale error"))
+	if ev.hasMsg || ev.msg != "" {
+		t.Fatalf("stale setMessage landed on the reset event: msg=%q hasMsg=%v", ev.msg, ev.hasMsg)
+	}
+	if ev.hasRequestedLvl || ev.requestedLevel != 0 {
+		t.Fatalf("stale setLevel landed on the reset event: level=%v has=%v", ev.requestedLevel, ev.hasRequestedLvl)
+	}
+	if ev.hasErr {
+		t.Fatal("stale setError latched hasErr on the reset event")
+	}
+	for _, f := range ev.fields {
+		if f.key == "error" {
+			t.Fatal("stale setError appended an error field on the reset event")
+		}
+	}
+
+	// Positive control after the recycle: the new owner's setters land.
+	freshGen := ev.state.Load() >> walStateBits
+	fresh := &walRef{ev: ev, gen: freshGen}
+	ev.setMessage(fresh, "new-owner")
+	ev.setLevel(fresh, LevelDebug)
+	if !ev.hasMsg || ev.msg != "new-owner" {
+		t.Fatalf("fresh setMessage lost: msg=%q hasMsg=%v", ev.msg, ev.hasMsg)
+	}
+	if !ev.hasRequestedLvl || ev.requestedLevel != LevelDebug {
+		t.Fatalf("fresh setLevel lost: level=%v has=%v", ev.requestedLevel, ev.hasRequestedLvl)
+	}
+}

--- a/wal_test.go
+++ b/wal_test.go
@@ -189,3 +189,58 @@ func TestWALStartedAt(t *testing.T) {
 		t.Fatalf("startedAt = %v, outside window", ev.startedAt)
 	}
 }
+
+// TestWALAppendSealedStaleGeneration pins the appendSealed generation
+// check — the owner's post-seal write path must reject a stale
+// generation exactly like append does. The state word alone is not
+// enough: a post-seal write against an event a newer request already
+// reset belongs to that request. Found as a gap by mutation testing
+// (M3): removing the check passed the whole suite because no test
+// drove appendSealed with a stale generation.
+//
+// Recycle is simulated in place with seal()+reset() — exactly the
+// release-then-newEvent sequence — rather than through the pool: the
+// race runtime drops a share of sync.Pool Puts (zap internal/pool
+// note; TestPoolReuseCanary retries around it), which would make a
+// pool round-trip nondeterministic here. reset() is the operation
+// that must invalidate the old generation.
+func TestWALAppendSealedStaleGeneration(t *testing.T) {
+	ev := newEvent()
+	staleGen := ev.state.Load() >> walStateBits
+	ev.append(staleGen, fieldStr("own", "first"))
+	ev.seal()  // End's terminal step (release() seals before pooling)
+	ev.reset() // the next request's newEvent() after the pool hands it out
+
+	currentGen := ev.state.Load() >> walStateBits
+	if currentGen == staleGen {
+		t.Fatal("reset did not advance the generation")
+	}
+
+	// The stale owner-style post-seal write must no-op: the event now
+	// belongs to another request.
+	ev.appendSealed(staleGen, fieldStr("stale", "x"))
+	for _, f := range ev.fields {
+		if f.key == "stale" {
+			t.Fatalf("appendSealed with stale generation %d landed on the recycled event", staleGen)
+		}
+	}
+
+	// Positive controls: the current generation writes through the same
+	// path both before sealing and after it (the real annotatePostSeal
+	// shape runs post-seal under the sealed state).
+	ev.appendSealed(currentGen, fieldStr("live", "1"))
+	ev.seal()
+	ev.appendSealed(currentGen, fieldStr("sealed", "2"))
+	keys := map[string]bool{}
+	for _, f := range ev.fields {
+		keys[f.key] = true
+	}
+	for _, want := range []string{"live", "sealed"} {
+		if !keys[want] {
+			t.Fatalf("current-generation appendSealed lost %q", want)
+		}
+	}
+	if keys["stale"] {
+		t.Fatal("stale write landed next to the current-generation fields")
+	}
+}


### PR DESCRIPTION
## What

**PR-T1 of 3** for the DST & fuzzing action plan. Stacked on #32 (S4).

### New fuzz targets (2 → 7 in CI)
- **FuzzAppendFloat32/64** — json.Marshal parity + exact round-trip oracles; zerolog MIT float torture tables (NaN/±Inf/subnormals/2^53/−0/float32 precision)
- **FuzzAppendTimeRFC3339** — cache-miss/hit paths, cross-zone parse-back oracle
- **FuzzAppendInterface** — parsed-equivalence oracle; panicking/nil-receiver MarshalJSON pins
- **FuzzRecordEncodedDedupe** — independent reference-fold LWW oracle, widths 0–80, canonical-key collisions

### Prior-art test adoptions
- **zap**: round-trip semantic oracle inside existing string/bytes fuzz bodies (encode → parse → compare — catches shared blind spots the differential SWAR-vs-table oracle misses)
- **slog**: pool-reuse canary (sentinel-filled pooled buffer; any write seeing the sentinel = use-after-recycle); de-flaked under `-race` (zap's documented ~30% Put-drop)
- **logrus**: sync.Cond Broadcast start-line (6 stragglers + owner, 400 Start/Add/End cycles released simultaneously)

### Record-level property tests
- Round-trip property (20k PCG cases, all 11 Field kinds), determinism test, dedupe-width boundary pins

### Production fix (the only one)
- Panicking `MarshalJSON` recovered into the documented fallback string (slog's `!PANIC` precedent) — wire-neutral for non-panicking marshalers

### Mutation-testing gap closures
14 adversarial mutations applied → tests run → reverted. **All 14 caught.** The three originally-missed gaps now pinned:
- M3: `appendSealed` generation check (white-box stale-gen test)
- M7: panic-over-error precedence with co-delivered error
- M10: allocation gate for the narrow dedupe path (both crossover directions)

## Verification
Full 24-package matrix green · `-race` green (3× stable) · gofumpt clean · 200k property gate green · golden bridge green

## Review
glm-5.3 + deepseek-v4-pro: **both MERGE-READY yes** — findings (vacuous alloc gate, citation nits) folded in.