### PR TITLE
test: integration stress — middleware fuzz, worker scenarios, fan-out, canonical-key rename

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -109,6 +109,15 @@ panics also **bypass sampling structurally** — before any custom
   `job.scheduled_at` remains.
 - **Duplicate keys**: last write wins (v0 maps did the same); encoding
   emits each key once.
+- **Canonical-key collisions** (the logrus precedent): user fields
+  named `message`, `time`, or `level` collide with the canonical
+  envelope members, which used to produce duplicate JSON keys on the
+  line. They are now renamed to `fields.message`, `fields.time`,
+  `fields.level` on the wire (dedupe runs over the renamed keys, so a
+  user `message` and a user `fields.message` fold into one last-write-
+  wins member). The rename is wire-only: `Record.Fields()`/`Lookup`
+  keep the original keys; adapters that consume `Fields()` still see
+  them unrenamed.
 - **Durations** through bridges render each host's native shape
   (unchanged from v0 adapters); the first-party JSON sink renders float
   milliseconds.

--- a/canonical_collision_test.go
+++ b/canonical_collision_test.go
@@ -1,0 +1,166 @@
+package hc
+
+// Canonical-key collision policy (T5 decision, logrus precedent):
+// user fields named "message", "time", or "level" collide with the
+// canonical envelope members the encoder appends around the fields,
+// which used to yield duplicate JSON keys that parsers disagree on.
+// The encoder now renames colliding user keys to "fields.message",
+// "fields.time", "fields.level" on the wire (record.go aliasKey) —
+// the logrus Fields.*-prefix convention. The rename is wire-only:
+// Record.Fields() and Lookup keep returning the user's original key.
+//
+// These tests pin the decision; the dedupe fuzz targets pin the same
+// policy across the width boundaries and the fuzzer's key space.
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestCanonicalCollisionRename: user "message"/"time"/"level" appear
+// on the wire as fields.*, and the canonical envelope members stay
+// unique.
+func TestCanonicalCollisionRename(t *testing.T) {
+	cases := []struct {
+		userKey string
+		wireKey string
+		value   any
+	}{
+		{"message", "fields.message", "user-msg"},
+		{"time", "fields.time", "user-time"},
+		{"level", "fields.level", "user-level"},
+	}
+	for _, c := range cases {
+		t.Run(c.userKey, func(t *testing.T) {
+			r := recOf(LevelInfo, "m", fieldOf(c.userKey, c.value))
+			line := string(r.Encoded())
+
+			// The user value travels under the renamed fields.* key.
+			var s string
+			if raw := memberValue(t, line, c.wireKey); raw == nil {
+				t.Fatalf("wire lacks %q: %s", c.wireKey, line)
+			} else if err := json.Unmarshal(raw, &s); err != nil || s != c.value {
+				t.Fatalf("%s = %s, want %q", c.wireKey, raw, c.value)
+			}
+			// The raw key appears exactly once — the canonical envelope
+			// member, carrying the canonical value (no duplicate keys).
+			if n := strings.Count(line, `"`+c.userKey+`":`); n != 1 {
+				t.Fatalf("raw key %q appears %d times on the wire: %s", c.userKey, n, line)
+			}
+			wantCanonical := map[string]string{
+				"message": "m",
+				"time":    r.completedAt.Format(time.RFC3339), // recOf's fixed clock
+				"level":   "info",
+			}[c.userKey]
+			if raw := memberValue(t, line, c.userKey); raw == nil || string(raw) != `"`+wantCanonical+`"` {
+				t.Fatalf("canonical %q = %s, want %q: %s", c.userKey, raw, wantCanonical, line)
+			}
+		})
+	}
+}
+
+// memberValue returns the raw value of the FIRST member with the key
+// (nil when absent).
+func memberValue(t *testing.T, line, key string) json.RawMessage {
+	t.Helper()
+	_, members := decodeLineStrict(t, []byte(line))
+	for _, m := range members {
+		if m.key == key {
+			return m.val
+		}
+	}
+	return nil
+}
+
+// TestCanonicalCollisionEnvelopeIntact: the canonical message/time/
+// level values are untouched by a same-named user field, and the wire
+// parses without duplicate keys.
+func TestCanonicalCollisionEnvelopeIntact(t *testing.T) {
+	ts := NewTestSink()
+	rt := MustCompile(Config{Sink: ts, SamplingRate: 1})
+	op := Start(context.Background(), rt, OperationStart{Domain: DomainJob, Name: "collide"})
+	Add(op.Context(), "message", "user-message")
+	Add(op.Context(), "time", "user-time")
+	Add(op.Context(), "level", "user-level")
+	op.End(nil)
+
+	ev := ts.Events()[0]
+	if ev.Message() != DefaultOperationMessage {
+		t.Fatalf("message = %q, want the canonical default", ev.Message())
+	}
+	// the parsed map must have exactly one of each envelope key: parse
+	// the captured record's canonical line
+	line := capturedLine(t, ev)
+	var payload map[string]any
+	if err := json.Unmarshal(line, &payload); err != nil {
+		t.Fatalf("line not parseable: %v (%s)", err, line)
+	}
+	for _, k := range []string{"level", "time", "message"} {
+		if _, ok := payload[k]; !ok {
+			t.Fatalf("canonical %q missing from the parsed payload", k)
+		}
+	}
+	if payload["message"] != DefaultOperationMessage {
+		t.Fatalf("parsed message = %v, want the canonical default", payload["message"])
+	}
+	if payload["fields.message"] != "user-message" {
+		t.Fatalf("fields.message = %v", payload["fields.message"])
+	}
+}
+
+// TestCanonicalCollisionLWW: a user "message" and a user
+// "fields.message" fold into ONE member — the encoder dedupes over
+// the aliased keys (last write wins at its last occurrence).
+func TestCanonicalCollisionLWW(t *testing.T) {
+	// fields.message first, message later → message wins
+	r := recOf(
+		LevelInfo, "m",
+		fieldOf("fields.message", "first"),
+		fieldOf("message", "second"),
+	)
+	line := string(r.Encoded())
+	if strings.Count(line, `"fields.message"`) != 1 {
+		t.Fatalf("fields.message emitted %d times: %s", strings.Count(line, `"fields.message"`), line)
+	}
+	if !strings.Contains(line, `"fields.message":"second"`) {
+		t.Fatalf("last write did not win: %s", line)
+	}
+
+	// message first, fields.message later → fields.message wins
+	r = recOf(
+		LevelInfo, "m",
+		fieldOf("message", "first"),
+		fieldOf("fields.message", "second"),
+	)
+	line = string(r.Encoded())
+	if strings.Count(line, `"fields.message"`) != 1 || !strings.Contains(line, `"fields.message":"second"`) {
+		t.Fatalf("last write did not win: %s", line)
+	}
+}
+
+// TestCanonicalCollisionLookupKeepsRawKey: the rename is wire-only —
+// the typed view keeps the user's original key.
+func TestCanonicalCollisionLookupKeepsRawKey(t *testing.T) {
+	r := recOf(LevelInfo, "m", fieldOf("message", "user-msg"))
+	if v, ok := r.Lookup("message"); !ok || v != "user-msg" {
+		t.Fatalf("Lookup(message) = %v %v", v, ok)
+	}
+	fields := r.Fields()
+	if len(fields) != 1 || fields[0].Key() != "message" {
+		t.Fatalf("Fields() = %v", fields)
+	}
+}
+
+// capturedLine re-encodes a captured event for parsing (TestSink does
+// not retain the wire bytes).
+func capturedLine(t *testing.T, ev CapturedEvent) []byte {
+	t.Helper()
+	r := &Record{
+		level: ev.Level(), msg: ev.Message(), fields: ev.Fields(),
+		completedAt: time.Date(2026, 9, 1, 10, 0, 0, 0, time.Local),
+	}
+	return r.Encoded()
+}

--- a/dedupe_fuzz_test.go
+++ b/dedupe_fuzz_test.go
@@ -8,12 +8,14 @@ package hc
 // (map + last-occurrence ordering), never appendDedupedFields itself.
 //
 // Canonical-key collisions (user fields named "message"/"time"/"level")
-// are PINNED as documented behavior (G2, user error): the envelope
-// keys occupy fixed slots — level is member 0, time and message are
-// the last two members — so a colliding user field yields duplicate
-// JSON keys and a last-wins parser sees the canonical value. The
-// assertions here compare the user span strictly between the envelope
-// slots, so collisions cannot break the oracle.
+// follow the logrus rename policy (record.go aliasKey): colliding user
+// keys are emitted as "fields.message"/"fields.time"/"fields.level" so
+// the wire never carries duplicate envelope keys. The envelope keys
+// occupy fixed slots — level is member 0, time and message are the
+// last two members — and the user span sits strictly between them. The
+// oracle folds over the ALIASED keys (a user "message" and a user
+// "fields.message" resolve as one last-write-wins member), matching
+// the encoder's dedupe.
 
 import (
 	"encoding/json"
@@ -134,14 +136,18 @@ func verifyDedupeFields(t *testing.T, fields []Field) {
 	}
 	userSpan := members[1 : len(members)-2]
 
-	// Reference fold: each key's last write, in last-occurrence order.
+	// Reference fold over the ALIASED keys: each aliased key's last
+	// write, in last-occurrence order (record.go aliases colliding user
+	// keys to fields.* before deduping, so the fold keyspace is the
+	// aliased one).
 	type lw struct {
 		field Field
 		pos   int
 	}
 	lastWrite := map[string]lw{}
 	for i, f := range fields {
-		lastWrite[f.key] = lw{f, i}
+		key := aliasedFieldKey(f.key)
+		lastWrite[key] = lw{f, i}
 	}
 	order := make([]int, 0, len(lastWrite))
 	for _, v := range lastWrite {
@@ -158,10 +164,10 @@ func verifyDedupeFields(t *testing.T, fields []Field) {
 			len(userSpan), len(order), line)
 	}
 	for i, pos := range order {
-		want := lastWrite[fields[pos].key].field
+		want := lastWrite[aliasedFieldKey(fields[pos].key)].field
 		got := userSpan[i]
-		if got.key != want.key {
-			t.Fatalf("user member %d = %q, want %q (last-occurrence order)", i, got.key, want.key)
+		if got.key != aliasedFieldKey(want.key) {
+			t.Fatalf("user member %d = %q, want %q (last-occurrence order)", i, got.key, aliasedFieldKey(want.key))
 		}
 		if err := checkFieldWire(want, got.val); err != nil {
 			t.Fatalf("user member %d: %v", i, err)

--- a/fanout_test.go
+++ b/fanout_test.go
@@ -1,0 +1,195 @@
+package hc
+
+// P8.3 multi-sink fan-out (dst-research §8.3): a test-only FanoutSink
+// that writes each record to N sinks, one of which panics on a
+// schedule. The other sinks must still receive the record, the record
+// must not be corrupted, and the pool must stay clean. The core's
+// emit path calls sink.Write once — fan-out happens INSIDE one sink,
+// so a panicking member must not prevent the remaining members from
+// writing (and must not corrupt the shared pool).
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// FanoutSink writes every record to each member sink in order. If a
+// member panics, the remaining members still receive the record and
+// the panic propagates to the caller (who decides what to do with it).
+type FanoutSink struct {
+	sinks []Sink
+}
+
+// NewFanoutSink creates a fan-out over the given sinks.
+func NewFanoutSink(sinks ...Sink) *FanoutSink {
+	return &FanoutSink{sinks: sinks}
+}
+
+// Write delivers the record to every member sink, continuing past
+// panicking members (their panic is re-raised after the fan-out so the
+// caller sees the first failure).
+func (f *FanoutSink) Write(ctx context.Context, rec *Record) {
+	if f == nil {
+		return
+	}
+	var firstPanic any
+	for _, s := range f.sinks {
+		func() {
+			defer func() {
+				if r := recover(); r != nil && firstPanic == nil {
+					firstPanic = r
+				}
+			}()
+			s.Write(ctx, rec)
+		}()
+	}
+	if firstPanic != nil {
+		panic(firstPanic)
+	}
+}
+
+var _ Sink = (*FanoutSink)(nil)
+
+// captureSink records every record it receives (deep copy via the
+// shared TestSink machinery).
+type fanCaptureSink struct {
+	mu     sync.Mutex
+	events []CapturedEvent
+}
+
+func (s *fanCaptureSink) Write(_ context.Context, rec *Record) {
+	if rec == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.events = append(s.events, CapturedEvent{
+		level:   rec.Level(),
+		message: rec.Message(),
+		fields:  copyFields(rec.Fields()),
+	})
+}
+
+func (s *fanCaptureSink) count() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.events)
+}
+
+func (s *fanCaptureSink) last() CapturedEvent {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.events[len(s.events)-1]
+}
+
+// panicSink panics on Write.
+type panicSink struct{}
+
+func (panicSink) Write(context.Context, *Record) { panic("sink exploded") }
+
+// TestFanoutSinkPanicIsolation: one panicking member must not stop the
+// others from receiving the record.
+func TestFanoutSinkPanicIsolation(t *testing.T) {
+	for _, n := range []int{2, 4, 8} {
+		for _, panicIdx := range []int{0, n / 2, n - 1} {
+			t.Run(fmt.Sprintf("n=%d panic=%d", n, panicIdx), func(t *testing.T) {
+				captures := make([]*fanCaptureSink, n)
+				sinks := make([]Sink, n)
+				for i := range sinks {
+					captures[i] = &fanCaptureSink{}
+					sinks[i] = captures[i]
+				}
+				sinks[panicIdx] = panicSink{}
+				ts := NewFanoutSink(sinks...)
+				rt := MustCompile(Config{Sink: ts, SamplingRate: 1})
+				op := Start(context.Background(), rt, OperationStart{Domain: DomainJob, Name: "fan"})
+				Add(op.Context(), "k", "v")
+
+				var escaped any
+				func() {
+					defer func() { escaped = recover() }()
+					op.End(nil)
+				}()
+				if escaped == nil {
+					t.Fatal("the panicking sink's panic did not escape")
+				}
+				// every non-panicking member received the record
+				for i, c := range captures {
+					if i == panicIdx {
+						continue // this slot holds the panicking sink
+					}
+					if c.count() != 1 {
+						t.Fatalf("sink %d captured %d events", i, c.count())
+					}
+					if v, _ := c.last().Lookup("k"); v != "v" {
+						t.Fatalf("sink %d event corrupted", i)
+					}
+				}
+				// pool clean after the panic
+				ok := &fanCaptureSink{}
+				rt2 := MustCompile(Config{Sink: ok, SamplingRate: 1})
+				op2 := Start(context.Background(), rt2, OperationStart{Domain: DomainJob, Name: "after"})
+				Add(op2.Context(), "clean", true)
+				op2.End(nil)
+				if ok.count() != 1 {
+					t.Fatal("pool corrupted after the panicking fan-out")
+				}
+			})
+		}
+	}
+}
+
+// TestFanoutAllPanicking: when every member panics the caller sees the
+// first panic, and the request still does not corrupt the pool.
+func TestFanoutAllPanicking(t *testing.T) {
+	for _, n := range []int{2, 4} {
+		sinks := make([]Sink, n)
+		for i := range sinks {
+			sinks[i] = panicSink{}
+		}
+		rt := MustCompile(Config{Sink: NewFanoutSink(sinks...), SamplingRate: 1})
+		op := Start(context.Background(), rt, OperationStart{Domain: DomainJob, Name: "all-panic"})
+		Add(op.Context(), "k", 1)
+		var escaped any
+		func() {
+			defer func() { escaped = recover() }()
+			op.End(nil)
+		}()
+		if escaped == nil || escaped != "sink exploded" {
+			t.Fatalf("escaped %v", escaped)
+		}
+		// pool clean: the next request works
+		ok := &fanCaptureSink{}
+		rt2 := MustCompile(Config{Sink: ok, SamplingRate: 1})
+		op2 := Start(context.Background(), rt2, OperationStart{Domain: DomainJob, Name: "after"})
+		op2.End(nil)
+		if ok.count() != 1 {
+			t.Fatal("pool corrupted after all-panic fan-out")
+		}
+	}
+}
+
+// TestFanoutRetainingSink: a member that retains the Record past Write
+// must copy it (amendment 9) — a buggy retaining member would observe
+// recycled memory, which the pool-safety tests pin elsewhere; here we
+// pin that the fan-out passes the SAME record view to every member.
+func TestFanoutSinkOrder(t *testing.T) {
+	a, b := &fanCaptureSink{}, &fanCaptureSink{}
+	rt := MustCompile(Config{Sink: NewFanoutSink(a, b), SamplingRate: 1})
+	op := Start(context.Background(), rt, OperationStart{Domain: DomainJob, Name: "order"})
+	Add(op.Context(), "k", "v")
+	op.End(nil)
+	la, lb := a.last(), b.last()
+	if la.Message() != lb.Message() || la.Level() != lb.Level() {
+		t.Fatalf("members disagree: %+v vs %+v", la, lb)
+	}
+	if !strings.Contains(fmt.Sprint(la.Lookup("k")), "v") {
+		t.Fatalf("first member lost the field")
+	}
+	if _, ok := lb.Lookup("k"); !ok {
+		t.Fatal("second member lost the field")
+	}
+}

--- a/integration/std/middleware_fuzz_test.go
+++ b/integration/std/middleware_fuzz_test.go
@@ -1,0 +1,566 @@
+package stdhappycontext
+
+// FuzzMiddlewareRequest (dst-research §6.5): fuzz bytes decode into a
+// request-behavior script (handler actions: Add fields, SetMessage,
+// SetLevel, WriteHeader with a status, body writes, flush, hijack,
+// panic) plus an interface mask selecting which optional
+// ResponseWriter capabilities the underlying writer exposes (Flusher,
+// Hijacker, Pusher — the interfaces the middleware promotes). Each
+// request runs through the real middleware and the emitted event is
+// checked against an INDEPENDENT model that mirrors the documented
+// middleware semantics: exactly one event, http.status == the
+// first-committed status (ResolveStatus's rules: 500 on a
+// pre-response panic, 200 for an implicit status), the outcome/level/
+// message resolution of the lifecycle core, and last-write-wins user
+// fields. Hijacks and flushes have no status effect and are exercised
+// for interface delegation and -race cleanliness.
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	hc "github.com/happytoolin/happycontext"
+)
+
+// ---------------------------------------------------------------------------
+// Interface-masked ResponseWriter
+
+// fuzzBaseWriter is the fake network: it records what the middleware
+// forwarded. It implements io.ReaderFrom and http.CloseNotifier so the
+// tracker's own delegation paths are exercised (the middleware tracker
+// always exposes ReaderFrom/CloseNotify itself).
+type fuzzBaseWriter struct {
+	header     http.Header
+	code       int
+	body       bytes.Buffer
+	flushed    bool
+	hijacked   bool
+	pushed     bool
+	hijackErr  error
+	hijackConn io.ReadWriteCloser
+	readFromN  int64
+}
+
+func (w *fuzzBaseWriter) Header() http.Header { return w.header }
+func (w *fuzzBaseWriter) Write(p []byte) (int, error) {
+	if w.code == 0 {
+		w.code = http.StatusOK
+	}
+	return w.body.Write(p)
+}
+func (w *fuzzBaseWriter) WriteHeader(code int) { w.code = code }
+func (w *fuzzBaseWriter) ReadFrom(r io.Reader) (int64, error) {
+	if w.code == 0 {
+		w.code = http.StatusOK
+	}
+	n, err := w.body.ReadFrom(r)
+	w.readFromN = n
+	return n, err
+}
+func (w *fuzzBaseWriter) CloseNotify() <-chan bool { return nil }
+
+// fuzzBase exposes the shared base writer through any wrapper type.
+func (w *fuzzBaseWriter) fuzzBase() *fuzzBaseWriter { return w }
+
+// The optional-interface wrappers mirror the middleware's promotion
+// switch: one concrete type per (Flusher, Hijacker, Pusher) combo, so
+// the fuzz exercises every promotion shape and the mask semantics are
+// exact (a writer only exposes what its mask selected).
+type fwFlush struct{ *fuzzBaseWriter }
+
+func (w *fwFlush) Flush() { w.flushed = true }
+
+type fwHijack struct{ *fuzzBaseWriter }
+
+func (w *fwHijack) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	w.hijacked = true
+	return nil, nil, errHijackUnavailable
+}
+
+type fwPush struct{ *fuzzBaseWriter }
+
+func (w *fwPush) Push(string, *http.PushOptions) error {
+	w.pushed = true
+	return nil
+}
+
+type fwFlushHijack struct {
+	*fuzzBaseWriter
+}
+
+func (w *fwFlushHijack) Flush() { w.flushed = true }
+func (w *fwFlushHijack) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	w.hijacked = true
+	return nil, nil, errHijackUnavailable
+}
+
+type fwFlushPush struct {
+	*fuzzBaseWriter
+}
+
+func (w *fwFlushPush) Flush() { w.flushed = true }
+func (w *fwFlushPush) Push(string, *http.PushOptions) error {
+	w.pushed = true
+	return nil
+}
+
+type fwHijackPush struct {
+	*fuzzBaseWriter
+}
+
+func (w *fwHijackPush) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	w.hijacked = true
+	return nil, nil, errHijackUnavailable
+}
+
+func (w *fwHijackPush) Push(string, *http.PushOptions) error {
+	w.pushed = true
+	return nil
+}
+
+type fwFull struct {
+	*fuzzBaseWriter
+}
+
+func (w *fwFull) Flush() { w.flushed = true }
+func (w *fwFull) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	w.hijacked = true
+	return nil, nil, errHijackUnavailable
+}
+
+func (w *fwFull) Push(string, *http.PushOptions) error {
+	w.pushed = true
+	return nil
+}
+
+// maskedWriterFor builds a writer whose concrete type implements the
+// mask-selected optional interfaces (bit 0x1 Flusher, 0x2 Hijacker,
+// 0x4 Pusher) — the mirror of the middleware's own promotion switch.
+func maskedWriterFor(mask byte) http.ResponseWriter {
+	base := &fuzzBaseWriter{header: make(http.Header)}
+	switch mask & 0x7 {
+	case 0:
+		return base
+	case 0x1:
+		return &fwFlush{base}
+	case 0x2:
+		return &fwHijack{base}
+	case 0x3:
+		return &fwFlushHijack{base}
+	case 0x4:
+		return &fwPush{base}
+	case 0x5:
+		return &fwFlushPush{base}
+	case 0x6:
+		return &fwHijackPush{base}
+	default:
+		return &fwFull{base}
+	}
+}
+
+var errHijackUnavailable = errors.New("hijack unavailable")
+
+// ---------------------------------------------------------------------------
+// Script decoding
+
+// mwAction is one handler behavior.
+type mwAction struct {
+	kind   byte
+	key    string
+	value  any
+	msg    string
+	level  hc.Level
+	status int
+	body   string
+	panic  any
+}
+
+const (
+	mwAdd byte = iota
+	mwSetMsg
+	mwSetLevel
+	mwWriteHeader
+	mwWrite
+	mwFlush
+	mwPanic
+	mwHijack
+)
+
+var (
+	mwKeys     = []string{"ua", "ub", "uc"}
+	mwStatuses = []int{0, 200, 201, 204, 301, 400, 404, 418, 500, 503}
+	mwLevels   = []hc.Level{hc.LevelDebug, hc.LevelInfo, hc.LevelWarn, hc.LevelError, hc.Level(99)}
+)
+
+// decodeScript parses fuzz bytes into an action list (total: any byte
+// stream decodes; truncated streams stop cleanly).
+func decodeScript(b []byte) (mask byte, actions []mwAction) {
+	if len(b) == 0 {
+		return 0, nil // empty program: no mask, no actions
+	}
+	mask = b[0]
+	rest := b[1:]
+	for len(rest) > 0 && len(actions) < 24 {
+		cmd := rest[0] % 8
+		rest = rest[1:]
+		next := func() byte {
+			if len(rest) == 0 {
+				return 0
+			}
+			v := rest[0]
+			rest = rest[1:]
+			return v
+		}
+		window := func(n int) string {
+			if len(rest) < n {
+				n = len(rest)
+			}
+			s := string(rest[:n])
+			rest = rest[n:]
+			return s
+		}
+		a := mwAction{kind: cmd}
+		switch cmd {
+		case mwAdd:
+			a.key = mwKeys[int(next())%len(mwKeys)]
+			switch next() % 3 {
+			case 0:
+				a.value = fmt.Sprintf("v%d", next())
+			case 1:
+				a.value = int64(int8(next()))
+			default:
+				a.value = next()&1 == 0
+			}
+		case mwSetMsg:
+			switch next() % 3 {
+			case 0:
+				a.msg = ""
+			case 1:
+				a.msg = fmt.Sprintf("msg-%d", next())
+			default:
+				a.msg = window(int(next() % 9))
+			}
+		case mwSetLevel:
+			a.level = mwLevels[int(next())%len(mwLevels)]
+		case mwWriteHeader:
+			a.status = mwStatuses[int(next())%len(mwStatuses)]
+		case mwWrite:
+			a.body = window(1 + int(next()%5))
+		case mwPanic:
+			if next()%2 == 0 {
+				a.panic = fmt.Sprintf("boom-%d", next())
+			} else {
+				a.panic = int64(int8(next()))
+			}
+		}
+		actions = append(actions, a)
+	}
+	return mask, actions
+}
+
+// ---------------------------------------------------------------------------
+// The model — independent re-derivation of the middleware contract
+
+// mwModel is the expected event state for one executed request.
+type mwModel struct {
+	msg            string
+	requested      hc.Level
+	hasRequested   bool
+	committed      int  // first committed status (0 = nothing committed)
+	started        bool // any Write/WriteHeader/ReadFrom happened
+	lastHeader     int  // last WriteHeader forwarded (for the base writer)
+	userFields     map[string]any
+	panicValue     any
+	hasPanic       bool
+	flushExecuted  bool
+	hijackExecuted bool
+}
+
+// apply mirrors the handler + tracker semantics for one action.
+func (m *mwModel) apply(a mwAction, mask byte) {
+	switch a.kind {
+	case mwAdd:
+		m.userFields[a.key] = a.value // last write wins
+	case mwSetMsg:
+		if a.msg != "" {
+			m.msg = a.msg
+		}
+	case mwSetLevel:
+		if validMWLevel(a.level) {
+			m.requested = a.level
+			m.hasRequested = true
+		}
+	case mwWriteHeader:
+		if !m.started {
+			m.committed = a.status
+			m.started = true
+		}
+		m.lastHeader = a.status // forwarded regardless
+	case mwWrite:
+		if !m.started {
+			m.committed = http.StatusOK
+			m.started = true
+		}
+	case mwFlush:
+		if mask&0x1 != 0 { // the flush only reaches the writer when promoted
+			m.flushExecuted = true
+		}
+	case mwHijack:
+		if mask&0x2 != 0 {
+			m.hijackExecuted = true
+		}
+	case mwPanic:
+		m.hasPanic = true
+		m.panicValue = a.panic
+	}
+}
+
+func validMWLevel(l hc.Level) bool {
+	switch l {
+	case hc.LevelDebug, hc.LevelInfo, hc.LevelWarn, hc.LevelError:
+		return true
+	}
+	return false
+}
+
+// resolveStatus mirrors common.ResolveStatus.
+func (m *mwModel) resolveStatus() int {
+	if m.hasPanic && !m.started {
+		return http.StatusInternalServerError
+	}
+	if m.committed == 0 {
+		return http.StatusOK
+	}
+	return m.committed
+}
+
+// finalize mirrors common.FinalizeRequest + End's resolution.
+func (m *mwModel) finalize() (outcome hc.Outcome, level hc.Level, status int) {
+	status = m.resolveStatus()
+	switch {
+	case m.hasPanic:
+		outcome = hc.OutcomePanic
+		level = hc.LevelError
+	case status >= 500:
+		outcome = hc.OutcomeFailure
+		level = hc.LevelError
+	default:
+		outcome = hc.OutcomeSuccess
+		level = hc.LevelInfo
+	}
+	if m.hasRequested && m.requested > level {
+		level = m.requested
+	}
+	if m.msg == "" {
+		m.msg = hc.DefaultMessage
+	}
+	return outcome, level, status
+}
+
+// ---------------------------------------------------------------------------
+// Fuzz target
+
+func FuzzMiddlewareRequest(f *testing.F) {
+	// Seeds: happy path, panic-before-write, panic-after-write,
+	// flush-then-write, double-write-header, hijack, interface combos.
+	seed := func(mask byte, actions ...mwAction) {
+		b := []byte{mask}
+		for _, a := range actions {
+			b = append(b, a.kind)
+			switch a.kind {
+			case mwAdd:
+				ki := 0
+				for i, k := range mwKeys {
+					if k == a.key {
+						ki = i
+					}
+				}
+				b = append(b, byte(ki), 0)
+				b = append(b, byte(len(fmt.Sprint(a.value))))
+			case mwWriteHeader:
+				si := 0
+				for i, s := range mwStatuses {
+					if s == a.status {
+						si = i
+					}
+				}
+				b = append(b, byte(si))
+			case mwPanic:
+				b = append(b, 0, byte(len(fmt.Sprint(a.panic))))
+			case mwWrite:
+				b = append(b, byte(len(a.body)))
+				b = append(b, a.body...)
+			}
+		}
+		f.Add(b)
+	}
+	seed(
+		0x0,
+		mwAction{kind: mwAdd, key: "ua", value: "1"},
+		mwAction{kind: mwWriteHeader, status: http.StatusOK},
+	)
+	seed(
+		0x7,
+		mwAction{kind: mwAdd, key: "ub", value: int64(7)},
+		mwAction{kind: mwWriteHeader, status: http.StatusCreated},
+		mwAction{kind: mwWrite, body: "hi"},
+	)
+	seed(0x7, mwAction{kind: mwPanic, panic: "boom"}) // panic before any write
+	seed(
+		0x7,
+		mwAction{kind: mwWriteHeader, status: http.StatusTeapot},
+		mwAction{kind: mwPanic, panic: "late"}, // panic after commit
+	)
+	seed(
+		0x1,
+		mwAction{kind: mwFlush},
+		mwAction{kind: mwWriteHeader, status: http.StatusAccepted},
+	)
+	seed(
+		0x0,
+		mwAction{kind: mwWriteHeader, status: http.StatusNotFound},
+		mwAction{kind: mwWriteHeader, status: http.StatusOK}, // double header
+	)
+	seed(
+		0x2,
+		mwAction{kind: mwHijack},
+		mwAction{kind: mwWriteHeader, status: http.StatusOK},
+	)
+	seed(0x0, mwAction{kind: mwWrite, body: "no-header"})
+	seed(
+		0x7,
+		mwAction{kind: mwSetMsg, msg: "custom"},
+		mwAction{kind: mwAdd, key: "uc", value: true},
+		mwAction{kind: mwWriteHeader, status: http.StatusInternalServerError},
+	)
+
+	f.Fuzz(func(t *testing.T, program []byte) {
+		mask, actions := decodeScript(program)
+		m := &mwModel{userFields: map[string]any{}}
+		for _, a := range actions {
+			m.apply(a, mask)
+			if a.kind == mwPanic {
+				break // the panic unwinds; later actions never run
+			}
+		}
+
+		ts := hc.NewTestSink()
+		rt := hc.MustCompile(hc.Config{Sink: ts, SamplingRate: 1})
+		mw := Middleware(rt)
+		base := maskedWriterFor(mask)
+
+		handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			for _, a := range actions {
+				switch a.kind {
+				case mwAdd:
+					hc.Add(r.Context(), a.key, a.value)
+				case mwSetMsg:
+					hc.SetMessage(r.Context(), a.msg)
+				case mwSetLevel:
+					hc.SetLevel(r.Context(), a.level)
+				case mwWriteHeader:
+					w.WriteHeader(a.status)
+				case mwWrite:
+					_, _ = w.Write([]byte(a.body))
+				case mwFlush:
+					if fl, ok := w.(http.Flusher); ok {
+						fl.Flush()
+					}
+				case mwHijack:
+					if hj, ok := w.(http.Hijacker); ok {
+						_, _, _ = hj.Hijack()
+					}
+				case mwPanic:
+					panic(a.panic)
+				}
+			}
+		}))
+
+		var escaped any
+		func() {
+			defer func() { escaped = recover() }()
+			handler.ServeHTTP(base, httptest.NewRequest(http.MethodGet, "/x", nil))
+		}()
+
+		// The middleware re-raises panics with the original value.
+		if m.hasPanic {
+			if escaped == nil || fmt.Sprint(escaped) != fmt.Sprint(m.panicValue) {
+				t.Fatalf("panic escaped as %#v, want %#v (mask %x)", escaped, m.panicValue, mask)
+			}
+		} else if escaped != nil {
+			t.Fatalf("unexpected panic %#v (mask %x)", escaped, mask)
+		}
+
+		// Interface delegation: flushes and hijacks reached the writer
+		// exactly when the mask promoted them (unwrap the middleware's
+		// responseWriter to read the base's flags).
+		fb := base.(interface{ fuzzBase() *fuzzBaseWriter }).fuzzBase()
+		if m.flushExecuted != fb.flushed {
+			t.Fatalf("flush executed=%v, writer saw %v (mask %x)", m.flushExecuted, fb.flushed, mask)
+		}
+		if m.hijackExecuted != fb.hijacked {
+			t.Fatalf("hijack executed=%v, writer saw %v (mask %x)", m.hijackExecuted, fb.hijacked, mask)
+		}
+
+		// Exactly one event, checked against the model.
+		events := ts.Events()
+		if len(events) != 1 {
+			t.Fatalf("captured %d events, want 1 (mask %x)", len(events), mask)
+		}
+		ev := events[0]
+		outcome, level, status := m.finalize()
+
+		if ev.Message() != m.msg {
+			t.Fatalf("message = %q, want %q", ev.Message(), m.msg)
+		}
+		if ev.Level() != level {
+			t.Fatalf("level = %v, want %v (outcome %s)", ev.Level(), level, outcome)
+		}
+		if v, _ := ev.Lookup("http.status"); v != int64(status) {
+			t.Fatalf("http.status = %v, want %d (first-committed)", v, status)
+		}
+		if v, _ := ev.Lookup("op.outcome"); v != string(outcome) {
+			t.Fatalf("op.outcome = %v, want %s", v, outcome)
+		}
+		if m.hasPanic {
+			if p, ok := ev.Lookup("panic"); !ok {
+				t.Fatal("missing panic field")
+			} else if pm := p.(map[string]any); pm["value"] != fmt.Sprint(m.panicValue) {
+				t.Fatalf("panic.value = %v", pm["value"])
+			}
+			if e, ok := ev.Lookup("error"); !ok {
+				t.Fatal("missing error field")
+			} else if em := e.(map[string]any); em["message"] != "panic: "+fmt.Sprint(m.panicValue) {
+				t.Fatalf("error.message = %v", em["message"])
+			}
+		}
+		// user fields, last write wins
+		for k, want := range m.userFields {
+			if v, ok := ev.Lookup(k); !ok || !mwValueEqual(v, want) {
+				t.Fatalf("field %q = %v (%v), want %v", k, v, ok, want)
+			}
+		}
+		// canonical http fields
+		if v, _ := ev.Lookup("http.method"); v != http.MethodGet {
+			t.Fatalf("http.method = %v", v)
+		}
+		if v, _ := ev.Lookup("http.path"); v != "/x" {
+			t.Fatalf("http.path = %v", v)
+		}
+	})
+}
+
+// mwValueEqual compares Lookup values with the model's (int64 vs int).
+func mwValueEqual(got, want any) bool {
+	if i, ok := want.(int); ok {
+		return got == int64(i)
+	}
+	return got == want
+}

--- a/integration/worker/lifecycle_scenarios_test.go
+++ b/integration/worker/lifecycle_scenarios_test.go
@@ -1,0 +1,231 @@
+package workerhc
+
+// P8.2 worker lifecycle scenario battery (dst-research §8.2): the
+// job-shaped scenarios assembled as end-to-end flows with real
+// contexts — retries with attempt metadata, cancellation, deadlines,
+// retryable errors, panics, nil runtimes, scheduled_at preservation,
+// and consecutive jobs over the same pool. Each scenario drives the
+// real worker Start + a deferred End(&err) closure (the documented
+// usage shape) and asserts the captured event.
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	hc "github.com/happytoolin/happycontext"
+)
+
+// TestWorkerRetryMetadata: attempt/max_attempts survive to the wire
+// through op.*, and a retryable error produces a failure outcome with
+// the error level.
+func TestWorkerRetryMetadata(t *testing.T) {
+	ts := hc.NewTestSink()
+	rt := hc.MustCompile(hc.Config{Sink: ts, SamplingRate: 1})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var err error = errors.New("retryable")
+	op := Start(ctx, rt, JobMeta{Name: "sync", Attempt: 3, MaxAttempts: 5})
+	op.End(&err)
+
+	ev := ts.Events()[0]
+	for _, tc := range []struct {
+		key  string
+		want any
+	}{
+		{"op.attempt", int64(3)},
+		{"op.max_attempts", int64(5)},
+	} {
+		if v, ok := ev.Lookup(tc.key); !ok || v != tc.want {
+			t.Fatalf("%s = %v (%v), want %v", tc.key, v, ok, tc.want)
+		}
+	}
+	if v, _ := ev.Lookup("op.outcome"); v != string(hc.OutcomeFailure) {
+		t.Fatalf("outcome = %v, want failure", v)
+	}
+	if ev.Level() != hc.LevelError {
+		t.Fatalf("level = %v, want error", ev.Level())
+	}
+	if e, ok := ev.Lookup("error"); !ok {
+		t.Fatal("missing error field")
+	} else if em := e.(map[string]any); em["message"] != "retryable" {
+		t.Fatalf("error.message = %v", em["message"])
+	}
+}
+
+// TestWorkerCancellation: a canceled context yields OutcomeCanceled
+// with the error bypass (never sampled away, even at rate 0).
+func TestWorkerCancellation(t *testing.T) {
+	for _, rate := range []float64{1, 0} { // error bypass at any rate
+		ts := hc.NewTestSink()
+		rt := hc.MustCompile(hc.Config{Sink: ts, SamplingRate: rate})
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // canceled before the job starts
+		var err error = context.Canceled
+		op := Start(ctx, rt, JobMeta{Name: "cancel"})
+		op.End(&err)
+		if len(ts.Events()) != 1 {
+			t.Fatalf("rate %v: canceled event dropped", rate)
+		}
+		ev := ts.Events()[0]
+		if v, _ := ev.Lookup("op.outcome"); v != string(hc.OutcomeCanceled) {
+			t.Fatalf("rate %v: outcome = %v, want canceled", rate, v)
+		}
+		if ev.Level() != hc.LevelError {
+			t.Fatalf("rate %v: level = %v", rate, ev.Level())
+		}
+	}
+}
+
+// TestWorkerDeadline: an expired context deadline yields
+// OutcomeTimeout with the error bypass.
+func TestWorkerDeadline(t *testing.T) {
+	ts := hc.NewTestSink()
+	rt := hc.MustCompile(hc.Config{Sink: ts, SamplingRate: 1})
+	ctx, cancel := context.WithTimeout(context.Background(), time.Nanosecond)
+	defer cancel()
+	time.Sleep(time.Millisecond) // let the deadline expire
+	var err error = context.DeadlineExceeded
+	op := Start(ctx, rt, JobMeta{Name: "slow"})
+	op.End(&err)
+	ev := ts.Events()[0]
+	if v, _ := ev.Lookup("op.outcome"); v != string(hc.OutcomeTimeout) {
+		t.Fatalf("outcome = %v, want timeout", v)
+	}
+}
+
+// TestWorkerJobPanic: a panic in the job function yields
+// OutcomePanic + the panic field, re-panics the original value, and
+// records error level.
+func TestWorkerJobPanic(t *testing.T) {
+	ts := hc.NewTestSink()
+	rt := hc.MustCompile(hc.Config{Sink: ts, SamplingRate: 1})
+
+	repanicked := false
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				repanicked = r == "worker-boom"
+			}
+		}()
+		op := Start(context.Background(), rt, JobMeta{Name: "boom-job"})
+		defer op.End(nil) // direct defer observes the panic
+		panic("worker-boom")
+	}()
+	if !repanicked {
+		t.Fatal("the panic did not propagate")
+	}
+	ev := ts.Events()[0]
+	if v, _ := ev.Lookup("op.outcome"); v != string(hc.OutcomePanic) {
+		t.Fatalf("outcome = %v", v)
+	}
+	if ev.Level() != hc.LevelError {
+		t.Fatalf("level = %v", ev.Level())
+	}
+	if p, ok := ev.Lookup("panic"); !ok {
+		t.Fatal("missing panic field")
+	} else if pm := p.(map[string]any); pm["value"] != "worker-boom" {
+		t.Fatalf("panic.value = %v", pm["value"])
+	}
+}
+
+// TestWorkerNilRuntime: with a nil runtime the job still runs; nothing
+// emits.
+func TestWorkerNilRuntime(t *testing.T) {
+	ran := false
+	op := Start(context.Background(), nil, JobMeta{Name: "noop"})
+	var err error
+	func() {
+		defer op.End(&err)
+		ran = true
+	}()
+	if !ran {
+		t.Fatal("job did not run")
+	}
+	if op.End(&err) {
+		t.Fatal("nil runtime emitted")
+	}
+}
+
+// TestWorkerScheduledAtPreserved: job.scheduled_at survives to the
+// wire as the RFC3339 string of the UTC instant.
+func TestWorkerScheduledAtPreserved(t *testing.T) {
+	ts := hc.NewTestSink()
+	rt := hc.MustCompile(hc.Config{Sink: ts, SamplingRate: 1})
+	scheduled := time.Date(2026, 2, 10, 8, 30, 0, 0, time.FixedZone("+05:30", 5*3600+1800))
+	op := Start(context.Background(), rt, JobMeta{Name: "sched", ScheduledAt: scheduled})
+	op.End(nil)
+	ev := ts.Events()[0]
+	// Lookup returns the typed value (KindTime); the worker stores the
+	// UTC instant.
+	if v, ok := ev.Lookup("job.scheduled_at"); !ok {
+		t.Fatal("missing job.scheduled_at")
+	} else if tm, isTime := v.(time.Time); !isTime || !tm.Equal(scheduled.UTC()) {
+		t.Fatalf("job.scheduled_at = %v (%T), want the UTC instant %v", v, v, scheduled.UTC())
+	}
+	// the wire rendering of KindTime fields is RFC3339 (pinned by the
+	// core round-trip suites); the typed value is what survives here
+	_ = ev
+}
+
+// TestWorkerConsecutiveJobs: consecutive jobs on one runtime recycle
+// the pooled event between them; each event carries only its own
+// fields.
+func TestWorkerConsecutiveJobs(t *testing.T) {
+	ts := hc.NewTestSink()
+	rt := hc.MustCompile(hc.Config{Sink: ts, SamplingRate: 1})
+	const jobs = 32
+	for i := 0; i < jobs; i++ {
+		op := Start(context.Background(), rt, JobMeta{Name: "job", ID: string(rune('a' + i))})
+		hc.Add(op.Context(), "index", i)
+		var err error
+		op.End(&err)
+	}
+	events := ts.Events()
+	if len(events) != jobs {
+		t.Fatalf("captured %d events, want %d", len(events), jobs)
+	}
+	for i, ev := range events {
+		if v, _ := ev.Lookup("index"); v != int64(i) {
+			t.Fatalf("event %d index = %v — pool cross-contamination", i, v)
+		}
+		if v, _ := ev.Lookup("op.name"); v != "job" {
+			t.Fatalf("event %d name = %v", i, v)
+		}
+	}
+}
+
+// TestWorkerConcurrentJobs: many workers over one runtime, each with
+// its own request-confined event (the -race pin for the pooled WAL).
+func TestWorkerConcurrentJobs(t *testing.T) {
+	ts := hc.NewTestSink()
+	rt := hc.MustCompile(hc.Config{Sink: ts, SamplingRate: 1})
+	var wg sync.WaitGroup
+	for w := 0; w < 12; w++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			for i := 0; i < 100; i++ {
+				op := Start(context.Background(), rt, JobMeta{Name: "worker", ID: "w"})
+				hc.Add(op.Context(), "worker", w, "seq", i)
+				var err error
+				op.End(&err)
+			}
+		}(w)
+	}
+	wg.Wait()
+	if got := len(ts.Events()); got != 1200 {
+		t.Fatalf("captured %d events, want 1200", got)
+	}
+	for _, ev := range ts.Events() {
+		if _, ok := ev.Lookup("worker"); !ok {
+			t.Fatal("event lost its worker field")
+		}
+		if _, ok := ev.Lookup("seq"); !ok {
+			t.Fatal("event lost its seq field")
+		}
+	}
+}

--- a/record.go
+++ b/record.go
@@ -68,13 +68,65 @@ func (r *Record) Encoded() []byte {
 func (r *Record) encode() []byte {
 	b := make([]byte, 0, 64+len(r.fields)*24)
 	b = append(b, jsonLevelPrefix(r.level)...)
-	b = appendDedupedFields(b, r.fields)
+	fields := r.fields
+	if needsFieldAliasing(fields) {
+		fields = aliasFields(fields)
+	}
+	b = appendDedupedFields(b, fields)
 	b = jsonEnc.AppendKey(b, "time")
 	b = hcjson.AppendTimeRFC3339(b, r.completedAt)
 	b = jsonEnc.AppendKey(b, "message")
 	b = jsonEnc.AppendString(b, r.msg)
 	b = append(b, '}', '\n')
 	return b
+}
+
+// Canonical-key collision policy (the logrus precedent, §5 of the T5
+// plan): a user field named "message", "time", or "level" would collide
+// with the canonical envelope members the encoder appends around the
+// fields, producing duplicate JSON keys that parsers disagree on. The
+// colliding user keys are therefore RENAMED to "fields.message",
+// "fields.time", and "fields.level" on the wire — the logrus
+// Fields.*-prefix convention. The rename happens after the event is
+// sealed, on the encoded line only: Record.Fields() and Lookup keep
+// returning the user's original key. The dedupe runs over the aliased
+// keys, so a user "message" and a user "fields.message" resolve as one
+// last-write-wins member, and the canonical envelope stays unique.
+
+var aliasKey = map[string]string{
+	"message": "fields.message",
+	"time":    "fields.time",
+	"level":   "fields.level",
+}
+
+func aliasedFieldKey(key string) string {
+	if aliased, ok := aliasKey[key]; ok {
+		return aliased
+	}
+	return key
+}
+
+// needsFieldAliasing reports whether any field key collides with the
+// envelope (cheap scan on the sealed WAL).
+func needsFieldAliasing(fields []Field) bool {
+	for _, f := range fields {
+		if _, ok := aliasKey[f.key]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// aliasFields returns a copy of the field list with colliding keys
+// renamed. Only called when a collision exists, so the common path
+// stays allocation-free.
+func aliasFields(fields []Field) []Field {
+	out := make([]Field, len(fields))
+	for i, f := range fields {
+		out[i] = f
+		out[i].key = aliasedFieldKey(f.key)
+	}
+	return out
 }
 
 // dedupeScanLimit sets the crossover between the allocation-free

--- a/record_roundtrip_test.go
+++ b/record_roundtrip_test.go
@@ -258,11 +258,13 @@ func TestEncodedDeterminism(t *testing.T) {
 // checked against an independent reference fold, not the encoder's own
 // dedupe code.
 //
-// Canonical-key collision is PINNED as documented behavior (G2, user
-// error): user fields named "level"/"time"/"message" do NOT shadow or
-// rename — the canonical envelope keys are appended after the fields,
-// so the wire carries both and a last-wins parser sees the canonical
-// value.
+// Canonical-key collision follows the logrus rename policy (record.go
+// aliasKey, T5 decision): user fields named "level"/"time"/"message"
+// are emitted as "fields.level"/"fields.time"/"fields.message", so the
+// envelope keys — member 0 level, last two members time and message —
+// stay unique on the wire. The reference fold aliases the keys the
+// same way (a user "message" and a user "fields.message" fold into one
+// member).
 func FuzzRecordEncodedDedupe(f *testing.F) {
 	f.Add(uint8(0), []byte{0, 1, 2, 0, 1}, []byte{7, 7, 7})
 	f.Add(uint8(24), []byte{0, 1, 2, 3, 0, 1, 2, 3}, []byte{1, 2})
@@ -299,7 +301,7 @@ func FuzzRecordEncodedDedupe(f *testing.F) {
 		}
 		lww := map[string]lastWrite{}
 		for i, fl := range fields {
-			lww[fl.key] = lastWrite{fl.num, i}
+			lww[aliasedFieldKey(fl.key)] = lastWrite{fl.num, i}
 		}
 		var wantOrder []string
 		{
@@ -322,11 +324,13 @@ func FuzzRecordEncodedDedupe(f *testing.F) {
 			}
 		}
 
-		// 1. every non-canonical user key exactly once on the wire
-		// (keys colliding with level/time/message are pinned by check 3)
+		// 1. every aliased user key exactly once on the wire. The
+		// envelope keys (level/time/message) never appear among the user
+		// members — collisions were renamed to fields.* — so every fold
+		// key must be a user member.
 		for k := range lww {
 			if k == "level" || k == "time" || k == "message" {
-				continue
+				continue // envelope members, checked by check 3
 			}
 			n := 0
 			for _, m := range ordered {
@@ -340,6 +344,21 @@ func FuzzRecordEncodedDedupe(f *testing.F) {
 			var v int64
 			if err := json.Unmarshal(got[k], &v); err != nil || v != lww[k].val {
 				t.Fatalf("key %q = %s, want last value %d", k, got[k], lww[k].val)
+			}
+		}
+
+		// 1b. colliding user keys never appear under their raw names in
+		// the user span, and their fields.* copies are covered by the
+		// fold loop above.
+		for _, m := range ordered {
+			switch m.key {
+			case "level", "time", "message":
+				// envelope members only — the user span excludes them
+				// by construction (check 3)
+			default:
+				if _, user := lww[m.key]; !user {
+					t.Fatalf("wire member %q is not a fold key (line %s)", m.key, r.Encoded())
+				}
 			}
 		}
 
@@ -358,10 +377,9 @@ func FuzzRecordEncodedDedupe(f *testing.F) {
 			}
 		}
 
-		// 3. canonical collision pin: level/time/message appear exactly
-		// once as envelope keys regardless of user fields with the same
-		// name (the user copy is the duplicate; last-wins parsers see the
-		// canonical value)
+		// 3. canonical envelope pin: level/time/message appear exactly
+		// once each as envelope members regardless of colliding user
+		// fields — the rename guarantees the wire is duplicate-free.
 		for _, canon := range []string{"level", "time", "message"} {
 			n := 0
 			for _, m := range ordered {
@@ -369,16 +387,9 @@ func FuzzRecordEncodedDedupe(f *testing.F) {
 					n++
 				}
 			}
-			userHas := false
-			if _, ok := lww[canon]; ok {
-				userHas = true
-			}
-			wantN := 1
-			if userHas {
-				wantN = 2
-			}
-			if n != wantN {
-				t.Fatalf("canonical key %q appears %d times, want %d (collision pin)", canon, n, wantN)
+			if n != 1 {
+				t.Fatalf("canonical key %q appears %d times, want exactly 1 "+
+					"(rename policy; line %s)", canon, n, r.Encoded())
 			}
 		}
 	})

--- a/size_monotonicity_test.go
+++ b/size_monotonicity_test.go
@@ -1,0 +1,53 @@
+package hc
+
+// P6-adjacent size-monotonicity property (dst-research §7.3): adding
+// one field with a NEW key to a record never reduces the total encoded
+// size. The encoder emits each unique key once in last-occurrence
+// order, so a genuinely new key adds its own member (key + value +
+// separator) — never removes anything. The property runs across widths
+// 1-80 and every value kind; the added key is guaranteed unique so the
+// dedupe cannot hide it.
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand/v2"
+	"testing"
+)
+
+// TestRecordEncodeSizeMonotonicProperty generates a record, encodes
+// it, appends one field with a brand-new key, and asserts the encoded
+// line strictly grows.
+func TestRecordEncodeSizeMonotonicProperty(t *testing.T) {
+	rng := rand.New(rand.NewPCG(0x51E5E5eed, 0x600D5eed))
+	for width := 1; width <= 80; width++ {
+		for iter := 0; iter < 50; iter++ {
+			used := map[string]bool{}
+			fields := make([]Field, 0, width+1)
+			for i := 0; i < width; i++ {
+				key := fmt.Sprintf("k%03d", rng.IntN(width+5))
+				if used[key] {
+					continue // keep the generated list unique-keyed
+				}
+				used[key] = true
+				kind := FieldKind(1 + rng.IntN(11)) // every value kind
+				fields = append(fields, fieldOf(key, rtFieldValue(rng, kind)))
+			}
+			// find a brand-new key
+			newKey := "k-new"
+			for used[newKey] {
+				newKey += "x"
+			}
+			base := recOf(LevelInfo, "m", fields...)
+			grown := recOf(LevelInfo, "m", append(append([]Field(nil), fields...), fieldOf(newKey, rtFieldValue(rng, FieldKind(1+rng.IntN(11)))))...)
+			before, after := base.Encoded(), grown.Encoded()
+			if !bytes.Contains(after, []byte(`"`+newKey+`":`)) {
+				t.Fatalf("width %d iter %d: new key %q missing from %s", width, iter, newKey, after)
+			}
+			if len(after) <= len(before) {
+				t.Fatalf("width %d iter %d: adding %q shrank the line (%d -> %d)\nbefore %s\nafter  %s",
+					width, iter, newKey, len(before), len(after), before, after)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## What

**PR-T5** — the application-level stress items. Stacked on #37 (T4). Three commits:

### Commit 1: Canonical-key rename + fan-out + monotonicity (PRODUCTION CHANGE)
- **Canonical-key collision resolved** (logrus precedent): user fields named `"message"`/`"time"`/`"level"` renamed to `"fields.message"`/`"fields.time"`/`"fields.level"` on the wire. The dedupe runs over aliased keys; `Record.Fields()`/`Lookup` keep raw keys; allocation-free when no collision exists. MIGRATION.md updated.
- **Multi-sink fan-out** (test-only `FanoutSink`): N sinks with panic isolation — panicking members don't stop others, first panic re-raises after all members write.
- **Size monotonicity**: adding one unique-key field never shrinks the encoded line (80 widths × all 11 kinds).

### Commit 2: FuzzMiddlewareRequest
Fuzz bytes → handler-action script (Add/SetMessage/SetLevel/WriteHeader/Write/Flush/Hijack/Panic) + 3-bit interface mask. Independent model oracle mirrors the middleware contract (first-committed status, outcome/level/message resolution, LWW fields, panic handling, promotion delegation). 30s live fuzz clean.

### Commit 3: Worker lifecycle scenarios
8 end-to-end tests with real contexts: retry metadata, cancellation (rate 0 + 1), deadline timeout, panic in job function, nil runtime no-op, scheduled_at preservation, 32 consecutive pool-recycled jobs, 12 concurrent workers × 100 jobs under `-race`.

## Verification
Root + integration/std + integration/worker + benches all green (plain + race) · golden bridge green against the renamed encoder · gofumpt clean

## Review
glm-5.3 + deepseek-v4-pro: **both MERGE-READY yes**. The canonical-key rename verified mutation-sensitive, consumer-safe, perf-neutral, and migration-documented. Middleware fuzz model confirmed genuinely independent with all 8 promotion branches exercised.
