### PR TITLE
logic-audit round 2 (DeepSeek V4 Pro) + fixes, simplification pass

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -51,7 +51,7 @@ panic capture.
 | v0 | v1 |
 |---|---|
 | `hc.Add(ctx, k, v)` returning `bool` | same call, returns nothing (silent no-op without an event — the `slog` helper idiom) |
-| `hc.EventFields(e)` / `EventMessage` / `EventHasMessage` / `EventHasError` / `EventStartTime` | gone; sinks receive `*hc.Record` (`Fields()`, `Lookup`, `Message()`, `Level()`); samplers receive `SampleInput.Fields()`/`Lookup`. HTTP `SampleInput.Operation` is the last-write `op.name` (the route template), not the Start name `"request"`. |
+| `hc.EventFields(e)` / `EventMessage` / `EventHasMessage` / `EventHasError` / `EventStartTime` | gone; sinks receive `*hc.Record` (`Fields()`, `Lookup`, `Message()`, `Level()`); samplers receive `SampleInput.Fields()`/`Lookup`. HTTP `SampleInput.Operation` is the last-write `op.name` (the route template), not the Start name `"request"`. Non-HTTP `SampleInput.Code` surfaces the canonical `op.code` (`StatusCode` stays the `http.status` view); HTTP `Code` remains `http.status`. |
 | `hc.NewContext(ctx)` / `hc.FromContext(ctx)` | gone (internal) |
 | `hc.AddRaw(ctx, k, raw)` | `hc.AddRawJSON(ctx, k, raw)` |
 | — | `hc.SetLevel(ctx, level)` unchanged in shape; `GetLevel` removed |

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ use `hc.Compile` for config from files, `hc.MustCompile` for literals.
 - `LevelSamplingRates`: optional level-specific sampling overrides
 - `Sampler`: optional custom sampling function (full control)
 - `OperationPolicies`: optional per-domain level/sampling policy for all lifecycle domains, including HTTP and background operations; domain sampling overrides generic level/default sampling
+- Precedence when both are set: a domain policy's `SamplingRate` overrides `LevelSamplingRates` for that domain (v0 behavior); `LevelSamplingRates` overrides the global `SamplingRate`
 - `Message`: final log message (defaults to `hc.DefaultMessage` for HTTP and `hc.DefaultOperationMessage` for non-HTTP)
 
 Notes:

--- a/adapter/slog/sink.go
+++ b/adapter/slog/sink.go
@@ -5,7 +5,9 @@ package slogadapter
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
+	"reflect"
 	"slices"
 	"sync"
 
@@ -84,7 +86,7 @@ func (s *Sink) Write(ctx context.Context, rec *hc.Record) {
 // (base64) — both the v0 adapter's shapes.
 func attrOf(f hc.Field) slog.Attr {
 	if err, ok := f.Err(); ok {
-		return slog.String(f.Key(), err.Error())
+		return slog.String(f.Key(), errMessage(err))
 	}
 	if raw, ok := f.Raw(); ok {
 		return slog.Any(f.Key(), raw)
@@ -153,3 +155,13 @@ func lastOccurrences(fields []hc.Field) []int {
 }
 
 var _ hc.Sink = (*Sink)(nil)
+
+// errMessage renders an error field's message, tolerating typed-nil
+// errors (non-nil interface, nil pointer): their Error() panics on nil
+// dereference, and fmt renders them safely as "<nil>".
+func errMessage(err error) string {
+	if v := reflect.ValueOf(err); v.Kind() == reflect.Pointer && v.IsNil() {
+		return fmt.Sprint(err)
+	}
+	return err.Error()
+}

--- a/adapter/slog/typednil_test.go
+++ b/adapter/slog/typednil_test.go
@@ -1,0 +1,26 @@
+package slogadapter
+
+// Typed-nil error fields must render "<nil>", not panic the bridge.
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"testing"
+
+	hc "github.com/happytoolin/happycontext"
+	"log/slog"
+)
+
+func TestCrashTypedNilErrorField(t *testing.T) {
+	var pe *os.PathError
+	var buf bytes.Buffer
+	s := &recSink{}
+	rt := hc.MustCompile(hc.Config{Sink: s, SamplingRate: 1})
+	op := hc.Start(context.Background(), rt, hc.OperationStart{Domain: hc.DomainJob, Name: "j"})
+	hc.Add(op.Context(), "e", pe)
+	hc.Error(op.Context(), pe)
+	_ = op.End(nil)
+	rec := s.rec
+	New(slog.New(slog.NewTextHandler(&buf, nil))).Write(context.Background(), rec)
+}

--- a/adapter/zap/sink.go
+++ b/adapter/zap/sink.go
@@ -5,6 +5,8 @@ package zapadapter
 
 import (
 	"context"
+	"fmt"
+	"reflect"
 	"slices"
 
 	"github.com/happytoolin/happycontext"
@@ -51,7 +53,7 @@ func (z *Sink) Write(ctx context.Context, rec *hc.Record) {
 // zap.Any (base64) — both the v0 adapter's shapes for those payloads.
 func fieldOf(f hc.Field) zap.Field {
 	if err, ok := f.Err(); ok {
-		return zap.String(f.Key(), err.Error())
+		return zap.String(f.Key(), errMessage(err))
 	}
 	if raw, ok := f.Raw(); ok {
 		return zap.Any(f.Key(), raw)
@@ -133,3 +135,13 @@ func lastOccurrences(fields []hc.Field) []int {
 }
 
 var _ hc.Sink = (*Sink)(nil)
+
+// errMessage renders an error field's message, tolerating typed-nil
+// errors (non-nil interface, nil pointer): their Error() panics on nil
+// dereference, and fmt renders them safely as "<nil>".
+func errMessage(err error) string {
+	if v := reflect.ValueOf(err); v.Kind() == reflect.Pointer && v.IsNil() {
+		return fmt.Sprint(err)
+	}
+	return err.Error()
+}

--- a/adapter/zap/typednil_test.go
+++ b/adapter/zap/typednil_test.go
@@ -1,0 +1,27 @@
+package zapadapter
+
+// Typed-nil error fields must render "<nil>", not panic the bridge.
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"testing"
+
+	hc "github.com/happytoolin/happycontext"
+	"go.uber.org/zap"
+)
+
+func TestCrashTypedNilErrorField(t *testing.T) {
+	var pe *os.PathError
+	var buf bytes.Buffer
+	s := &recSink{}
+	rt := hc.MustCompile(hc.Config{Sink: s, SamplingRate: 1})
+	op := hc.Start(context.Background(), rt, hc.OperationStart{Domain: hc.DomainJob, Name: "j"})
+	hc.Add(op.Context(), "e", pe)
+	hc.Error(op.Context(), pe)
+	_ = op.End(nil)
+	rec := s.rec
+	_ = buf
+	New(zap.NewExample()).Write(context.Background(), rec)
+}

--- a/adapter/zerolog/sink.go
+++ b/adapter/zerolog/sink.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"reflect"
 	"slices"
 	"unsafe"
 
@@ -254,7 +255,7 @@ func appendField(event *zerolog.Event, f hc.Field) *zerolog.Event {
 		return event.Dur(key, d)
 	}
 	if err, ok := f.Err(); ok {
-		return event.Str(key, err.Error())
+		return event.Str(key, errMessage(err))
 	}
 	if raw, ok := f.Raw(); ok {
 		return event.RawJSON(key, raw)
@@ -299,3 +300,13 @@ func lastOccurrences(fields []hc.Field) []int {
 }
 
 var _ hc.Sink = (*Sink)(nil)
+
+// errMessage renders an error field's message, tolerating typed-nil
+// errors (non-nil interface, nil pointer): their Error() panics on nil
+// dereference, and fmt renders them safely as "<nil>".
+func errMessage(err error) string {
+	if v := reflect.ValueOf(err); v.Kind() == reflect.Pointer && v.IsNil() {
+		return fmt.Sprint(err)
+	}
+	return err.Error()
+}

--- a/adapter/zerolog/typednil_test.go
+++ b/adapter/zerolog/typednil_test.go
@@ -1,0 +1,27 @@
+package zerologadapter
+
+// Typed-nil error fields must render "<nil>", not panic the bridge.
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"testing"
+
+	hc "github.com/happytoolin/happycontext"
+	"github.com/rs/zerolog"
+)
+
+func TestCrashTypedNilErrorField(t *testing.T) {
+	var pe *os.PathError
+	var buf bytes.Buffer
+	s := &recSink{}
+	rt := hc.MustCompile(hc.Config{Sink: s, SamplingRate: 1})
+	op := hc.Start(context.Background(), rt, hc.OperationStart{Domain: hc.DomainJob, Name: "j"})
+	hc.Add(op.Context(), "e", pe)
+	hc.Error(op.Context(), pe)
+	_ = op.End(nil)
+	rec := s.rec
+	zl := zerolog.New(&buf)
+	New(&zl).Write(context.Background(), rec)
+}

--- a/crash_test.go
+++ b/crash_test.go
@@ -1081,11 +1081,7 @@ func TestCrashHostileOperationStart(t *testing.T) {
 // encodedOf renders the single captured event via the JSON sink shape.
 func encodedOf(t *testing.T, ts *TestSink) string {
 	t.Helper()
-	evs := ts.Events()
-	if len(evs) != 1 {
-		t.Fatalf("events = %d, want 1", len(evs))
-	}
-	rec := recOf(evs[0].Level(), evs[0].Message(), evs[0].Fields()...)
+	rec := recOf(LevelInfo, "m", evs2Fields(t, ts)...)
 	return string(rec.Encoded())
 }
 
@@ -1231,11 +1227,7 @@ func TestCrashMegaFields(t *testing.T) {
 		t.Fatalf("events = %d", len(evs))
 	}
 	// Spot check first/last fields through the encoder.
-	var fields []Field
-	for _, f := range evs[0].Fields() {
-		fields = append(fields, f)
-	}
-	rec := recOf(LevelInfo, "mega", fields...)
+	rec := recOf(LevelInfo, "mega", evs[0].Fields()...)
 	line := rec.Encoded()
 	var m map[string]any
 	if err := json.Unmarshal(line, &m); err != nil {

--- a/integration/std/middleware.go
+++ b/integration/std/middleware.go
@@ -127,13 +127,13 @@ func promoteOptional(w http.ResponseWriter, core *responseWriter) http.ResponseW
 	pusher, hasPush := w.(http.Pusher)
 	switch {
 	case hasFlush && hasHijack && hasPush:
-		return &fullTracker{core, flusher, hijacker, pusher}
+		return &fullTracker{core, flushGuard{core, flusher}, hijacker, pusher}
 	case hasFlush && hasHijack:
-		return &flushHijackTracker{core, flusher, hijacker}
+		return &flushHijackTracker{core, flushGuard{core, flusher}, hijacker}
 	case hasFlush && hasPush:
-		return &flushPushTracker{core, flusher, pusher}
+		return &flushPushTracker{core, flushGuard{core, flusher}, pusher}
 	case hasFlush:
-		return &flushTracker{core, flusher}
+		return &flushTracker{core, flushGuard{core, flusher}}
 	case hasHijack && hasPush:
 		return &hijackPushTracker{core, hijacker, pusher}
 	case hasHijack:
@@ -145,18 +145,19 @@ func promoteOptional(w http.ResponseWriter, core *responseWriter) http.ResponseW
 	}
 }
 
-type flushTracker struct {
-	*responseWriter
-	flusher http.Flusher
+// flushGuard is embedded by every wrapper that promotes a Flusher: it
+// records the implicit commit before flushing, because net/http sends
+// the header (status 200 if unset) on the first Flush — without it, a
+// panic after the first flush resolves to 500 against a 200 the
+// client already received.
+type flushGuard struct {
+	rw *responseWriter
+	f  http.Flusher
 }
 
-// Flush records the implicit commit before flushing: net/http sends
-// the header (status 200 if unset) on the first Flush, so the tracker
-// must observe it — otherwise a panic after the first flush resolves
-// to 500 against a 200 the client already received.
-func (t *flushTracker) Flush() {
-	t.markFlushed()
-	t.flusher.Flush()
+func (g flushGuard) Flush() {
+	g.rw.markFlushed()
+	g.f.Flush()
 }
 
 func (rw *responseWriter) markFlushed() {
@@ -164,6 +165,11 @@ func (rw *responseWriter) markFlushed() {
 		rw.statusCode = http.StatusOK
 		rw.wroteHeader = true
 	}
+}
+
+type flushTracker struct {
+	*responseWriter
+	flushGuard
 }
 
 type hijackTracker struct {
@@ -178,24 +184,14 @@ type pushTracker struct {
 
 type flushHijackTracker struct {
 	*responseWriter
-	flusher http.Flusher
+	flushGuard
 	http.Hijacker
-}
-
-func (t *flushHijackTracker) Flush() {
-	t.markFlushed()
-	t.flusher.Flush()
 }
 
 type flushPushTracker struct {
 	*responseWriter
-	flusher http.Flusher
+	flushGuard
 	http.Pusher
-}
-
-func (t *flushPushTracker) Flush() {
-	t.markFlushed()
-	t.flusher.Flush()
 }
 
 type hijackPushTracker struct {
@@ -206,14 +202,9 @@ type hijackPushTracker struct {
 
 type fullTracker struct {
 	*responseWriter
-	flusher http.Flusher
+	flushGuard
 	http.Hijacker
 	http.Pusher
-}
-
-func (t *fullTracker) Flush() {
-	t.markFlushed()
-	t.flusher.Flush()
 }
 
 // Unwrap lets http.ResponseController discover deadline/duplex controls

--- a/integration/std/middleware.go
+++ b/integration/std/middleware.go
@@ -147,7 +147,23 @@ func promoteOptional(w http.ResponseWriter, core *responseWriter) http.ResponseW
 
 type flushTracker struct {
 	*responseWriter
-	http.Flusher
+	flusher http.Flusher
+}
+
+// Flush records the implicit commit before flushing: net/http sends
+// the header (status 200 if unset) on the first Flush, so the tracker
+// must observe it — otherwise a panic after the first flush resolves
+// to 500 against a 200 the client already received.
+func (t *flushTracker) Flush() {
+	t.markFlushed()
+	t.flusher.Flush()
+}
+
+func (rw *responseWriter) markFlushed() {
+	if !rw.wroteHeader {
+		rw.statusCode = http.StatusOK
+		rw.wroteHeader = true
+	}
 }
 
 type hijackTracker struct {
@@ -162,14 +178,24 @@ type pushTracker struct {
 
 type flushHijackTracker struct {
 	*responseWriter
-	http.Flusher
+	flusher http.Flusher
 	http.Hijacker
+}
+
+func (t *flushHijackTracker) Flush() {
+	t.markFlushed()
+	t.flusher.Flush()
 }
 
 type flushPushTracker struct {
 	*responseWriter
-	http.Flusher
+	flusher http.Flusher
 	http.Pusher
+}
+
+func (t *flushPushTracker) Flush() {
+	t.markFlushed()
+	t.flusher.Flush()
 }
 
 type hijackPushTracker struct {
@@ -180,9 +206,14 @@ type hijackPushTracker struct {
 
 type fullTracker struct {
 	*responseWriter
-	http.Flusher
+	flusher http.Flusher
 	http.Hijacker
 	http.Pusher
+}
+
+func (t *fullTracker) Flush() {
+	t.markFlushed()
+	t.flusher.Flush()
 }
 
 // Unwrap lets http.ResponseController discover deadline/duplex controls

--- a/integration/std/middleware_test.go
+++ b/integration/std/middleware_test.go
@@ -445,3 +445,72 @@ func (w *fullOptionalWriter) ReadFrom(src io.Reader) (int64, error) {
 	}
 	return io.Copy(&w.body, src)
 }
+
+// TestMiddlewareFlushCommitsStatus pins the implicit-commit rule: the
+// first Flush sends the header (200 if unset), so the tracker must
+// observe it. A panic after the first flush previously resolved to 500
+// against a 200 the client already received.
+func TestMiddlewareFlushCommitsStatus(t *testing.T) {
+	sink := hc.NewTestSink()
+	mw := Middleware(hc.MustCompile(hc.Config{Sink: sink, SamplingRate: 1}))
+
+	t.Run("panic after flush keeps the committed 200", func(t *testing.T) {
+		sink.Reset()
+		handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.(http.Flusher).Flush()
+			panic("mid-stream")
+		}))
+		rec := httptest.NewRecorder()
+		func() {
+			defer func() { _ = recover() }()
+			handler.ServeHTTP(rec, httptest.NewRequest("GET", "/s", nil))
+		}()
+		if rec.Code != http.StatusOK {
+			t.Fatalf("client saw %d, want 200", rec.Code)
+		}
+		st, _ := sink.Events()[0].Lookup("http.status")
+		o, _ := sink.Events()[0].Lookup("op.outcome")
+		if st != int64(http.StatusOK) || o != string(hc.OutcomePanic) {
+			t.Fatalf("log = status:%v outcome:%v, want 200/panic", st, o)
+		}
+	})
+
+	t.Run("error after flush keeps the committed 200", func(t *testing.T) {
+		sink.Reset()
+		handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.(http.Flusher).Flush()
+			hc.Error(r.Context(), errors.New("post-flush failure"))
+		}))
+		handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/s", nil))
+		st, _ := sink.Events()[0].Lookup("http.status")
+		if st != int64(http.StatusOK) {
+			t.Fatalf("status = %v, want committed 200", st)
+		}
+		// Outcome stays success — outcome is derived from the deferred
+		// error pointer, not the recorded error field (v0 semantics) —
+		// but the structured error must be present and the event kept.
+		if o, _ := sink.Events()[0].Lookup("op.outcome"); o != string(hc.OutcomeSuccess) {
+			t.Fatalf("outcome = %v, want success (error field is metadata)", o)
+		}
+		if _, ok := sink.Events()[0].Lookup("error"); !ok {
+			t.Fatal("error field missing")
+		}
+	})
+
+	t.Run("flush wrappers on all shapes", func(t *testing.T) {
+		// httptest.Recorder implements Flusher only; the other promoted
+		// shapes are compile-checked by the wrapper types themselves.
+		sink.Reset()
+		handler := mw(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			f, ok := w.(http.Flusher)
+			if !ok {
+				t.Fatal("flusher not promoted")
+			}
+			f.Flush()
+		}))
+		handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/s", nil))
+		if st, _ := sink.Events()[0].Lookup("http.status"); st != int64(http.StatusOK) {
+			t.Fatalf("status = %v, want 200 after plain flush", st)
+		}
+	})
+}

--- a/lifecycle_fuzz_test.go
+++ b/lifecycle_fuzz_test.go
@@ -588,11 +588,17 @@ func (m *lifeModel) outcome() Outcome {
 			return OutcomeFailure
 		}
 	}
-	explicit, hasExplicit, code, hasCode, _, _ := m.scan()
+	explicit, hasExplicit, code, hasCode, opCode, hasOpCode := m.scan()
 	if hasExplicit {
 		return explicit
 	}
-	if hasCode && code >= 500 {
+	// The 5xx rule reads the canonical code: http.status for HTTP,
+	// op.code for everything else (mirrors resolveOutcomeV2).
+	if normalizeDomain(m.start) == DomainHTTP {
+		if hasCode && code >= 500 {
+			return OutcomeFailure
+		}
+	} else if hasOpCode && opCode >= 500 {
 		return OutcomeFailure
 	}
 	return OutcomeSuccess
@@ -1138,6 +1144,8 @@ func seedPrograms() []seedProg {
 	add("http-500", p(modeRate1, DomainHTTP, intOp("http.status", 500), endErr(nil)))
 	add("http-404", p(modeRate1, DomainHTTP, intOp("http.status", 404), endErr(nil)))
 	add("job-500-status", p(modeRate1, DomainJob, intOp("http.status", 500), endErr(nil)))
+	add("job-500-opcode", p(modeRate1, DomainJob, intOp("op.code", 500), endErr(nil)))
+	add("job-503-opcode-err", p(modeRate1, DomainJob, intOp("op.code", 503), errOp("boom"), endErr(nil)))
 	return seeds
 }
 

--- a/metadata.go
+++ b/metadata.go
@@ -10,6 +10,15 @@ func structuredErrorField(err error) map[string]any {
 	if err == nil {
 		return nil
 	}
+	// Typed-nil errors (non-nil interface, nil pointer) must not reach
+	// Error()/Unwrap(): they panic on nil dereference and would crash
+	// finalization. fmt renders them safely as "<nil>".
+	if isTypedNilError(err) {
+		return map[string]any{
+			"message": fmt.Sprint(err),
+			"type":    fmt.Sprintf("%T", err),
+		}
+	}
 	field := map[string]any{
 		"message": structuredErrorMessage(err),
 		"type":    fmt.Sprintf("%T", err),
@@ -21,6 +30,16 @@ func structuredErrorField(err error) map[string]any {
 	}
 
 	return field
+}
+
+// isTypedNilError reports whether err is a non-nil interface holding
+// a nil pointer — the value whose Error() call would panic.
+func isTypedNilError(err error) bool {
+	if err == nil {
+		return false
+	}
+	v := reflect.ValueOf(err)
+	return v.Kind() == reflect.Pointer && v.IsNil()
 }
 
 func structuredPanicField(recovered any) map[string]any {

--- a/operation.go
+++ b/operation.go
@@ -353,11 +353,18 @@ func buildSampleInput(ev *event, start OperationStart, outcome Outcome, code int
 	if scan.name != "" {
 		opName = scan.name
 	}
+	// HTTP samplers see http.status; non-HTTP samplers see their
+	// canonical op.code (the README's non-HTTP contract for Code).
+	// StatusCode stays the HTTP-compat view of http.status in both.
+	samplerCode := code
+	if normalizeDomain(start.Domain) != DomainHTTP && scan.hasOpCode {
+		samplerCode = scan.opCode
+	}
 	in := SampleInput{
 		Domain:     normalizeDomain(start.Domain),
 		Operation:  opName,
 		Outcome:    outcome,
-		Code:       code,
+		Code:       samplerCode,
 		StatusCode: code,
 		Method:     scan.method,
 		Path:       scan.path,

--- a/operation.go
+++ b/operation.go
@@ -124,8 +124,21 @@ claimed:
 
 	scan := scanWAL(ev)
 	code := scan.code
-	outcome := resolveOutcomeV2(err, recovered, code, scan.outcome)
-	annotatePostSeal(ev, &op.ref, start, duration, normalizeDomain(start.Domain) == DomainHTTP, scan, outcome)
+	isHTTP := normalizeDomain(start.Domain) == DomainHTTP
+	// The canonical code drives the 5xx outcome rule: http.status for
+	// HTTP, op.code for everything else (a non-HTTP op's http.status is
+	// user data, not canonical) — so a job surfacing failure via
+	// op.code >= 500 resolves failure (and bypasses sampling) exactly
+	// like its HTTP twin, instead of logging a self-contradictory
+	// op.code=503 + op.outcome=success line.
+	outcomeCode := 0
+	if isHTTP {
+		outcomeCode = code
+	} else if scan.hasOpCode {
+		outcomeCode = scan.opCode
+	}
+	outcome := resolveOutcomeV2(err, recovered, outcomeCode, scan.outcome)
+	annotatePostSeal(ev, &op.ref, start, duration, isHTTP, scan, outcome)
 
 	emitted = op.commit(ev, rt, start, outcome, code, duration, now, err, recovered != nil, scan)
 	op.emitted = emitted

--- a/operation_test.go
+++ b/operation_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"sync"
 	"testing"
@@ -999,5 +1000,75 @@ func TestPanicAfterEndRan(t *testing.T) {
 	}
 	if got := sink.events[0].line; bytes.Contains(got, []byte(`"panic"`)) {
 		t.Fatalf("late panic leaked into the event: %s", got)
+	}
+}
+
+// TestNonHTTPFiveHundredOpCodeDrivesFailure pins the coherent canonical
+// code rule: a job surfacing op.code >= 500 resolves failure (and
+// bypasses sampling) like its HTTP twin, not a self-contradictory
+// op.code=503 + op.outcome=success line that healthy-rate sampling can
+// drop. Sub-500 codes stay success.
+func TestNonHTTPFiveHundredOpCodeDrivesFailure(t *testing.T) {
+	samplerCalls := 0
+	rt, ts := testRT(t, func(c *Config) {
+		c.SamplingRate = 0
+		c.Sampler = func(in SampleInput) bool {
+			samplerCalls++
+			return true
+		}
+	})
+	op := Start(context.Background(), rt, OperationStart{Domain: DomainJob, Name: "job"})
+	Add(op.Context(), "op.code", 503)
+	if !op.End(nil) {
+		t.Fatal("5xx op.code dropped at rate 0 (must bypass sampling as a failure)")
+	}
+	ev := ts.Events()[0]
+	if o, _ := ev.Lookup("op.outcome"); o != string(OutcomeFailure) {
+		t.Fatalf("outcome = %v, want failure", o)
+	}
+	if samplerCalls != 0 {
+		t.Fatalf("sampler consulted %d times for a 5xx op.code event", samplerCalls)
+	}
+	if ev.Level() != LevelError {
+		t.Fatalf("level = %v, want error", ev.Level())
+	}
+
+	op2 := Start(context.Background(), rt, OperationStart{Domain: DomainJob, Name: "job"})
+	Add(op2.Context(), "op.code", 404)
+	_ = op2.End(nil)
+	if o, _ := ts.Events()[1].Lookup("op.outcome"); o != string(OutcomeSuccess) {
+		t.Fatalf("4xx op.code outcome = %v, want success (only 5xx imply failure)", o)
+	}
+}
+
+// TestTypedNilErrorsContained pins the containment rule: a typed-nil
+// error (non-nil interface, nil pointer) reaches finalization and
+// encode through every path without its nil-dereference panic.
+func TestTypedNilErrorsContained(t *testing.T) {
+	var pe *os.PathError
+
+	rt, ts := testRT(t, nil)
+	op := Start(context.Background(), rt, OperationStart{Domain: DomainJob, Name: "j"})
+	Error(op.Context(), pe) // hc.Error path
+	_ = op.End(nil)
+	ev := ts.Events()[0]
+	errField, ok := ev.Lookup("error")
+	if !ok {
+		t.Fatal("typed-nil error dropped the field")
+	}
+	m, _ := errField.(map[string]any)
+	if msg, _ := m["message"].(string); msg != "<nil>" {
+		t.Fatalf("error.message = %q, want \"<nil>\"", msg)
+	}
+
+	// KindErr encode path: Add with a typed-nil error value.
+	rec := recOf(LevelInfo, "m", fieldOf("e", pe))
+	line := rec.Encoded()
+	var parsed map[string]any
+	if err := json.Unmarshal(line, &parsed); err != nil {
+		t.Fatalf("line unparseable: %v: %s", err, line)
+	}
+	if parsed["e"] != "<nil>" {
+		t.Fatalf("typed-nil field = %#v, want \"<nil>\"", parsed["e"])
 	}
 }

--- a/operation_test.go
+++ b/operation_test.go
@@ -321,6 +321,44 @@ func TestSampleInputUsesWALOpName(t *testing.T) {
 	}
 }
 
+// TestSampleInputCodeSurfacesOpCode pins the sampler contract: for
+// non-HTTP operations Code carries the canonical op.code (README:
+// "for non-HTTP operations use Domain, Operation, Outcome, and Code"),
+// while StatusCode stays the http.status view. HTTP samplers keep
+// seeing http.status even if a stray op.code was written.
+func TestSampleInputCodeSurfacesOpCode(t *testing.T) {
+	var jobCode, jobStatus, httpCode int
+	rt, _ := testRT(t, func(c *Config) {
+		c.Sampler = func(in SampleInput) bool {
+			switch in.Domain {
+			case DomainJob:
+				jobCode, jobStatus = in.Code, in.StatusCode
+			case DomainHTTP:
+				httpCode = in.Code
+			}
+			return true
+		}
+	})
+
+	op := Start(context.Background(), rt, OperationStart{Domain: DomainJob, Name: "job"})
+	Add(op.Context(), "op.code", 42)
+	_ = op.End(nil)
+	if jobCode != 42 {
+		t.Fatalf("job Code = %d, want 42 (canonical op.code)", jobCode)
+	}
+	if jobStatus != 0 {
+		t.Fatalf("job StatusCode = %d, want 0 (http.status view)", jobStatus)
+	}
+
+	// 2xx, not 5xx: error events bypass the sampler structurally.
+	hop := Start(context.Background(), rt, OperationStart{Domain: DomainHTTP, Name: "request"})
+	Add(hop.Context(), "http.status", 201, "op.code", 7)
+	_ = hop.End(nil)
+	if httpCode != 201 {
+		t.Fatalf("http Code = %d, want 201 (http.status wins on HTTP)", httpCode)
+	}
+}
+
 // TestNonHTTPOpCode pins the canonical-field rule: op.code is non-HTTP
 // only, surfaced from the explicit op.code field the caller wrote.
 func TestNonHTTPOpCode(t *testing.T) {

--- a/record.go
+++ b/record.go
@@ -1,6 +1,7 @@
 package hc
 
 import (
+	"fmt"
 	"sync/atomic"
 	"time"
 
@@ -217,7 +218,13 @@ func appendFieldJSON(dst []byte, f Field) []byte {
 	case KindDuration:
 		return jsonEnc.AppendDuration(dst, time.Duration(f.num), time.Millisecond, false, -1)
 	case KindErr:
-		return jsonEnc.AppendString(dst, f.val.(error).Error())
+		err := f.val.(error)
+		if isTypedNilError(err) {
+			// Typed-nil errors must not reach Error(): nil deref
+			// would crash encode. fmt renders "<nil>" safely.
+			return jsonEnc.AppendString(dst, fmt.Sprint(err))
+		}
+		return jsonEnc.AppendString(dst, err.Error())
 	case KindRaw:
 		return append(dst, f.val.([]byte)...)
 	default:


### PR DESCRIPTION
## Summary

Three commits finishing the v2 hardening campaign: the second logic-audit round (mine + DeepSeek V4 Pro's) with all findings fixed, plus a staticcheck-driven simplification pass.

### 1. `SampleInput.Code` surfaces the canonical `op.code` (non-HTTP)

`buildSampleInput` filled `Code` exclusively from the `http.status` scan — non-HTTP samplers switching on `Code` (exactly what the README instructs) always saw `0`. Pinned by `TestSampleInputCodeSurfacesOpCode`; MIGRATION.md updated.

### 2. DeepSeek V4 Pro logic-audit findings — all verified by repro before fixing

Audited the complete production source (core + integrations + adapters, 3.5k lines). Reviewer verdict: *"no correctness defects in their primary paths."* Four findings:

- **F1 (defect, fixed)** — std middleware: `Flush()` bypassed status capture. net/http commits an implicit 200 on first Flush, so a streaming handler that panicked after its first flush **logged `http.status=500` while the client received 200**. All flush-capable wrappers now record the implicit commit. *(Correction to the reviewer: v0's httpsnoop had no Flush hook either — an inherited wire-lie, not a v2 regression.)* Pinned by `TestMiddlewareFlushCommitsStatus`.
- **F2 (fixed)** — non-HTTP `op.code ≥ 500` resolved `success` and was rate-sampled as healthy: a self-contradictory `op.code=503 + op.outcome=success` line that `KeepErrors` semantics call a failure. The 5xx outcome rule now reads the **canonical code** — `http.status` for HTTP, `op.code` otherwise (a non-HTTP op's `http.status` is user data). Fuzz model + seeds updated (`job-500-opcode`). Pinned by `TestNonHTTPFiveHundredOpCodeDrivesFailure`.
- **F3 (documented)** — domain policy `SamplingRate` silently overrides `LevelSamplingRates`: verified **v0-identical precedence**, documented in README rather than changed.
- **F4 (contained)** — typed-nil errors panicked finalization and all three bridges at `.Error()`. Now contained at all five boundaries, rendering `<nil>` — same ethos as MarshalJSON panic containment. Pinned by `TestTypedNilErrorsContained` + per-adapter tests.

### 3. Simplification pass

staticcheck (`unused`, `S1*`, `ST1*`) silent across all 12 modules. Real win: the four per-wrapper `Flush` methods collapse into one embeddable `flushGuard`. The commit message records the **deliberate keeps** with reasons: wal.go's inline P5 lock discipline, module-boundary duplication in the adapters, the vendored hcjson method set, and the perf micro-structures.

## Validation
- Full root suite + `-race` (goleak gate, model-verified lifecycle properties, ~75 crash tests) ✅
- All 12 modules test + vet ✅ · gofmt ✅ · staticcheck ✅
- Fresh `FuzzEndLifecycle` burst against the updated model ✅

Stacked after #43; independent of #44 (synctest).
