### PR TITLE
test: GLM-5.3 / GLM-5.3-Flash skill-audit findings on the v2 hardening PR

### DIFF
--- a/adapter/slog/crash_test.go
+++ b/adapter/slog/crash_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"log/slog"
 	"os"
+	"strings"
 	"testing"
 
 	hc "github.com/happytoolin/happycontext"
@@ -50,4 +51,7 @@ func TestCrashTypedNilErrorField(t *testing.T) {
 	_ = op.End(nil)
 	rec := s.rec
 	New(slog.New(slog.NewTextHandler(&buf, nil))).Write(context.Background(), rec)
+	if !strings.Contains(buf.String(), "<nil>") {
+		t.Fatalf("typed-nil error not rendered as <nil>: %s", buf.String())
+	}
 }

--- a/adapter/zap/crash_test.go
+++ b/adapter/zap/crash_test.go
@@ -4,12 +4,15 @@ package zapadapter
 // containment.
 
 import (
+	"bytes"
 	"context"
 	"os"
+	"strings"
 	"testing"
 
 	hc "github.com/happytoolin/happycontext"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 type recSink struct{ rec *hc.Record }
@@ -47,5 +50,10 @@ func TestCrashTypedNilErrorField(t *testing.T) {
 	hc.Error(op.Context(), pe)
 	_ = op.End(nil)
 	rec := s.rec
-	New(zap.NewExample()).Write(context.Background(), rec)
+	var out bytes.Buffer
+	zl := zap.New(zapcore.NewCore(zapcore.NewJSONEncoder(zapcore.EncoderConfig{TimeKey: "ts", LevelKey: "level", MessageKey: "msg"}), zapcore.Lock(zapcore.AddSync(&out)), zapcore.DebugLevel))
+	New(zl).Write(context.Background(), rec)
+	if !strings.Contains(out.String(), "<nil>") {
+		t.Fatalf("typed-nil error not rendered as <nil>: %s", out.String())
+	}
 }

--- a/adapter/zerolog/crash_test.go
+++ b/adapter/zerolog/crash_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"os"
+	"strings"
 	"testing"
 
 	hc "github.com/happytoolin/happycontext"
@@ -58,4 +59,7 @@ func TestCrashTypedNilErrorField(t *testing.T) {
 	rec := s.rec
 	zl := zerolog.New(&buf)
 	New(&zl).Write(context.Background(), rec)
+	if !strings.Contains(buf.String(), `"<nil>"`) {
+		t.Fatalf("typed-nil error not rendered as <nil>: %s", buf.String())
+	}
 }

--- a/cmd/examples/adapters_wire_test.go
+++ b/cmd/examples/adapters_wire_test.go
@@ -72,25 +72,25 @@ func parseWireLine(t *testing.T, ln, pipeline string) parsedWire {
 	if err := json.Unmarshal([]byte(ln), &m); err != nil {
 		t.Fatalf("%s line unparseable: %v: %s", pipeline, err, ln)
 	}
-	st, _ := m["http.status"].(float64)
-	oc, _ := m["op.outcome"].(string)
-	rt, _ := m["op.name"].(string)
+	st, stOK := m["http.status"].(float64)
+	oc, ocOK := m["op.outcome"].(string)
+	rt, rtOK := m["op.name"].(string)
 	usr, _ := m["wire"].(string)
 	_, hasErr := m["error"]
-	if st == 0 || oc == "" || rt == "" {
-		t.Fatalf("%s: canonical fields missing: %v", pipeline, m)
+	if !stOK || !ocOK || !rtOK {
+		t.Fatalf("%s: canonical fields missing or mistyped: %v", pipeline, m)
 	}
 	return parsedWire{status: int64(st), outcome: oc, route: rt, user: usr, hasErr: hasErr}
 }
 
-// drive fires the wire cases at a real server built on the given real
-// sink, waits for the handlers to drain, and parses the pipeline's
-// emitted lines.
-func drive(t *testing.T, sink gc.Sink, buf *bytes.Buffer, pipeline string) []parsedWire {
+// drivePipeline fires the wire cases at a real server built on the
+// given real sink and parses the pipeline's emitted lines. The
+// explicit Close is load-bearing: client returns precede the server's
+// deferred emissions, and Close waits for outstanding handlers.
+func drivePipeline(t *testing.T, sink gc.Sink, buf *bytes.Buffer, pipeline string) []parsedWire {
 	t.Helper()
 	rt := gc.MustCompile(gc.Config{Sink: sink, SamplingRate: 1})
 	srv := httptest.NewServer(stdhc.Middleware(rt)(wireMux()))
-	defer srv.Close()
 
 	for _, c := range wireCases {
 		resp, err := srv.Client().Get(srv.URL + c.request)
@@ -100,9 +100,9 @@ func drive(t *testing.T, sink gc.Sink, buf *bytes.Buffer, pipeline string) []par
 		_, _ = io.Copy(io.Discard, resp.Body)
 		_ = resp.Body.Close()
 	}
-	srv.Close() // drain outstanding handlers before reading the buffer
+	srv.Close() // quiesce handlers before reading the buffer
 
-	var out []parsedWire
+	out := make([]parsedWire, 0, len(wireCases))
 	for _, ln := range strings.Split(strings.TrimSpace(buf.String()), "\n") {
 		if ln == "" {
 			continue
@@ -114,41 +114,47 @@ func drive(t *testing.T, sink gc.Sink, buf *bytes.Buffer, pipeline string) []par
 
 // TestAdaptersWireParity drives identical real traffic through every
 // real pipeline — first-party JSONSink, slog, zap, zerolog — and
-// asserts they agree on the canonical wire.
+// asserts BOTH the absolute canonical fields per pipeline AND that the
+// bridges agree with the JSONSink reference. Deterministic order
+// (jsonsink is the fixed reference), no map-iteration roulette.
 func TestAdaptersWireParity(t *testing.T) {
-	pipelines := map[string][]parsedWire{}
-
 	var jsonBuf bytes.Buffer
-	pipelines["jsonsink"] = drive(t, gc.NewJSONSink(&jsonBuf), &jsonBuf, "jsonsink")
+	reference := drivePipeline(t, gc.NewJSONSink(&jsonBuf), &jsonBuf, "jsonsink")
 
 	var slogBuf bytes.Buffer
-	pipelines["slog"] = drive(t, sloghc.New(slog.New(slog.NewJSONHandler(&slogBuf, nil))), &slogBuf, "slog")
+	slogEvents := drivePipeline(t, sloghc.New(slog.New(slog.NewJSONHandler(&slogBuf, nil))), &slogBuf, "slog")
 
 	var zapBuf bytes.Buffer
-	zapLogger := zap.New(zapcore.NewCore(zapcore.NewJSONEncoder(zapcore.EncoderConfig{TimeKey: "ts", LevelKey: "level", MessageKey: "msg", EncodeTime: zapcore.EpochTimeEncoder, EncodeLevel: zapcore.LowercaseLevelEncoder}), zapcore.AddSync(&zapBuf), zapcore.DebugLevel))
-	pipelines["zap"] = drive(t, zaphc.New(zapLogger), &zapBuf, "zap")
+	zapLogger := zap.New(zapcore.NewCore(zapcore.NewJSONEncoder(zapcore.EncoderConfig{TimeKey: "ts", LevelKey: "level", MessageKey: "msg", EncodeTime: zapcore.EpochTimeEncoder, EncodeLevel: zapcore.LowercaseLevelEncoder}), zapcore.Lock(zapcore.AddSync(&zapBuf)), zapcore.DebugLevel))
+	zapEvents := drivePipeline(t, zaphc.New(zapLogger), &zapBuf, "zap")
 
 	var zeroBuf bytes.Buffer
 	zl := zerolog.New(&zeroBuf)
-	pipelines["zerolog"] = drive(t, zerologhc.New(&zl), &zeroBuf, "zerolog")
+	zeroEvents := drivePipeline(t, zerologhc.New(&zl), &zeroBuf, "zerolog")
 
-	var reference []parsedWire
-	var refName string
-	for name, evs := range pipelines {
-		if len(evs) != len(wireCases) {
-			t.Fatalf("%s: %d events, want %d", name, len(evs), len(wireCases))
+	pipelines := []struct {
+		name   string
+		events []parsedWire
+	}{
+		{"jsonsink", reference},
+		{"slog", slogEvents},
+		{"zap", zapEvents},
+		{"zerolog", zeroEvents},
+	}
+	for _, pl := range pipelines {
+		if len(pl.events) != len(wireCases) {
+			t.Fatalf("%s: %d events, want %d", pl.name, len(pl.events), len(wireCases))
 		}
-		if reference == nil {
-			reference, refName = evs, name
-			continue
-		}
-		for i, ev := range evs {
+		for i, ev := range pl.events {
+			// Absolute checks for EVERY pipeline — a bridge regressing a
+			// canonical field must fail deterministically, not only when
+			// map iteration happens to make it the non-reference.
 			want := wireCases[i]
 			if ev.status != want.status || ev.outcome != want.outcome || ev.user != want.userField {
-				t.Fatalf("%s[%d] = %+v, want case %+v", name, i, ev, want)
+				t.Fatalf("%s[%d] = %+v, want case %+v", pl.name, i, ev, want)
 			}
 			if ev.route != reference[i].route || ev.hasErr != reference[i].hasErr {
-				t.Fatalf("%s[%d] diverges from %s: %+v vs %+v", name, i, refName, ev, reference[i])
+				t.Fatalf("%s[%d] diverges from jsonsink: %+v vs %+v", pl.name, i, ev, reference[i])
 			}
 		}
 	}

--- a/crash_test.go
+++ b/crash_test.go
@@ -19,6 +19,7 @@ package hc
 //   K  adversarial fuzz targets (values, armed interleavings)
 //   L  armed-mode DST (mixed writers vs single End, arm-vs-seal)
 //   N  testing/synctest bubbles (per-test goroutine hygiene, watchdog)
+//      (M was the ad-hoc live-chaos runs; intentionally not a file here)
 
 import (
 	"context"
@@ -560,6 +561,8 @@ func TestCrashCyclicAnyValue(t *testing.T) {
 }
 
 func TestCrashFloatEdgeValues(t *testing.T) {
+	// Untyped constant -0.0 is +0 (constants carry no sign) — Copysign
+	// is the only way to obtain a real negative zero.
 	negZero := math.Copysign(0, -1)
 	vals := []float64{math.NaN(), math.Inf(1), math.Inf(-1), math.SmallestNonzeroFloat64, math.MaxFloat64, negZero}
 	for _, v := range vals {
@@ -850,6 +853,12 @@ func TestCrashHostileRates(t *testing.T) {
 	inf := math.Inf(1)
 	if _, err := Compile(Config{OperationPolicies: map[Domain]OperationPolicy{"job": {SamplingRate: &inf}}}); err == nil {
 		t.Fatal("+Inf policy rate accepted")
+	}
+	// Nested NaN in the level map: TestCompileSentinels covers only the
+	// global rate and plain out-of-range map values — keep this one
+	// deterministic rather than fuzz-only.
+	if _, err := Compile(Config{LevelSamplingRates: map[Level]float64{LevelInfo: math.NaN()}}); err == nil {
+		t.Fatal("NaN level rate accepted")
 	}
 }
 

--- a/integration/echo/middleware_test.go
+++ b/integration/echo/middleware_test.go
@@ -30,14 +30,14 @@ func TestMiddlewareCapturesRouteAndFields(t *testing.T) {
 	if len(events) != 1 {
 		t.Fatalf("expected 1 event, got %d", len(events))
 	}
-	if intField(events[0], "http.status") != http.StatusAccepted {
-		t.Fatalf("expected status %d, got %v", http.StatusAccepted, intField(events[0], "http.status"))
+	if statusField(events[0], "http.status") != http.StatusAccepted {
+		t.Fatalf("expected status %d, got %v", http.StatusAccepted, statusField(events[0], "http.status"))
 	}
-	if fieldOf(events[0], "http.route") != "/orders/:id" {
-		t.Fatalf("expected route template, got %v", fieldOf(events[0], "http.route"))
+	if fieldValue(events[0], "http.route") != "/orders/:id" {
+		t.Fatalf("expected route template, got %v", fieldValue(events[0], "http.route"))
 	}
-	if fieldOf(events[0], "user_id") != "u_1" {
-		t.Fatalf("expected user_id field, got %v", fieldOf(events[0], "user_id"))
+	if fieldValue(events[0], "user_id") != "u_1" {
+		t.Fatalf("expected user_id field, got %v", fieldValue(events[0], "user_id"))
 	}
 }
 
@@ -82,10 +82,10 @@ func TestMiddlewareErrorAndSamplingBehavior(t *testing.T) {
 	if events[0].Level() != hc.LevelError {
 		t.Fatalf("level = %s, want ERROR", events[0].Level())
 	}
-	if intField(events[0], "http.status") != http.StatusInternalServerError {
-		t.Fatalf("status = %v, want %d", intField(events[0], "http.status"), http.StatusInternalServerError)
+	if statusField(events[0], "http.status") != http.StatusInternalServerError {
+		t.Fatalf("status = %v, want %d", statusField(events[0], "http.status"), http.StatusInternalServerError)
 	}
-	if _, ok := fieldOf(events[0], "error").(map[string]any); !ok {
+	if _, ok := fieldValue(events[0], "error").(map[string]any); !ok {
 		t.Fatalf("expected structured error field")
 	}
 }
@@ -117,13 +117,13 @@ func TestMiddlewarePanicLogsAndPropagates(t *testing.T) {
 	if len(events) != 1 {
 		t.Fatalf("expected 1 event, got %d", len(events))
 	}
-	if fieldOf(events[0], "http.route") != "/panic/:id" {
-		t.Fatalf("route = %v", fieldOf(events[0], "http.route"))
+	if fieldValue(events[0], "http.route") != "/panic/:id" {
+		t.Fatalf("route = %v", fieldValue(events[0], "http.route"))
 	}
-	if intField(events[0], "http.status") != http.StatusInternalServerError {
-		t.Fatalf("status = %v, want %d", intField(events[0], "http.status"), http.StatusInternalServerError)
+	if statusField(events[0], "http.status") != http.StatusInternalServerError {
+		t.Fatalf("status = %v, want %d", statusField(events[0], "http.status"), http.StatusInternalServerError)
 	}
-	if _, ok := fieldOf(events[0], "panic").(map[string]any); !ok {
+	if _, ok := fieldValue(events[0], "panic").(map[string]any); !ok {
 		t.Fatalf("expected panic metadata")
 	}
 }
@@ -144,8 +144,8 @@ func TestMiddlewareEchoHTTPErrorKeepsHTTPStatus(t *testing.T) {
 	if len(events) != 1 {
 		t.Fatalf("expected 1 event, got %d", len(events))
 	}
-	if intField(events[0], "http.status") != http.StatusForbidden {
-		t.Fatalf("status = %v, want %d", intField(events[0], "http.status"), http.StatusForbidden)
+	if statusField(events[0], "http.status") != http.StatusForbidden {
+		t.Fatalf("status = %v, want %d", statusField(events[0], "http.status"), http.StatusForbidden)
 	}
 	if events[0].Level() != hc.LevelError {
 		t.Fatalf("level = %s, want ERROR", events[0].Level())
@@ -199,8 +199,8 @@ func TestMiddlewareLogsStatusFromCustomEchoErrorHandler(t *testing.T) {
 	if len(events) != 1 {
 		t.Fatalf("expected 1 event, got %d", len(events))
 	}
-	if intField(events[0], "http.status") != http.StatusTeapot {
-		t.Fatalf("status = %v, want %d", intField(events[0], "http.status"), http.StatusTeapot)
+	if statusField(events[0], "http.status") != http.StatusTeapot {
+		t.Fatalf("status = %v, want %d", statusField(events[0], "http.status"), http.StatusTeapot)
 	}
 	if events[0].Level() != hc.LevelError {
 		t.Fatalf("level = %s, want ERROR", events[0].Level())
@@ -210,14 +210,15 @@ func TestMiddlewareLogsStatusFromCustomEchoErrorHandler(t *testing.T) {
 // capturedEvent mirrors the v0 test-facing shape (map fields, int
 // numerics) over the v2 TestSink capture, keeping the assertions below
 // unchanged from the v0 suite.
-// Typed field access on captured events (Lookup carries int64; the
-// constants in these tests are ints).
-func fieldOf(ev hc.CapturedEvent, key string) any {
+// Typed field reads on captured events: fieldValue for any value,
+// statusField for the int64 http.status these tests compare against
+// int constants.
+func fieldValue(ev hc.CapturedEvent, key string) any {
 	v, _ := ev.Lookup(key)
 	return v
 }
 
-func intField(ev hc.CapturedEvent, key string) int64 {
+func statusField(ev hc.CapturedEvent, key string) int64 {
 	v, _ := ev.Lookup(key)
 	n, _ := v.(int64)
 	return n

--- a/integration/fiber/middleware_test.go
+++ b/integration/fiber/middleware_test.go
@@ -36,14 +36,14 @@ func TestMiddlewareCapturesRouteAndFields(t *testing.T) {
 	if len(events) != 1 {
 		t.Fatalf("expected 1 event, got %d", len(events))
 	}
-	if intField(events[0], "http.status") != http.StatusNoContent {
-		t.Fatalf("expected status %d, got %v", http.StatusNoContent, intField(events[0], "http.status"))
+	if statusField(events[0], "http.status") != http.StatusNoContent {
+		t.Fatalf("expected status %d, got %v", http.StatusNoContent, statusField(events[0], "http.status"))
 	}
-	if fieldOf(events[0], "http.route") != "/orders/:id" {
-		t.Fatalf("expected route template, got %v", fieldOf(events[0], "http.route"))
+	if fieldValue(events[0], "http.route") != "/orders/:id" {
+		t.Fatalf("expected route template, got %v", fieldValue(events[0], "http.route"))
 	}
-	if fieldOf(events[0], "user_id") != "u_1" {
-		t.Fatalf("expected user_id field, got %v", fieldOf(events[0], "user_id"))
+	if fieldValue(events[0], "user_id") != "u_1" {
+		t.Fatalf("expected user_id field, got %v", fieldValue(events[0], "user_id"))
 	}
 }
 
@@ -92,10 +92,10 @@ func TestMiddlewareErrorAndSamplingBehavior(t *testing.T) {
 	if events[0].Level() != hc.LevelError {
 		t.Fatalf("level = %s, want ERROR", events[0].Level())
 	}
-	if intField(events[0], "http.status") != http.StatusInternalServerError {
-		t.Fatalf("status = %v, want %d", intField(events[0], "http.status"), http.StatusInternalServerError)
+	if statusField(events[0], "http.status") != http.StatusInternalServerError {
+		t.Fatalf("status = %v, want %d", statusField(events[0], "http.status"), http.StatusInternalServerError)
 	}
-	if _, ok := fieldOf(events[0], "error").(map[string]any); !ok {
+	if _, ok := fieldValue(events[0], "error").(map[string]any); !ok {
 		t.Fatalf("expected structured error field")
 	}
 }
@@ -119,13 +119,13 @@ func TestMiddlewarePanicLogsAndPropagates(t *testing.T) {
 	if len(events) != 1 {
 		t.Fatalf("expected 1 event, got %d", len(events))
 	}
-	if fieldOf(events[0], "http.route") != "/panic/:id" {
-		t.Fatalf("route = %v", fieldOf(events[0], "http.route"))
+	if fieldValue(events[0], "http.route") != "/panic/:id" {
+		t.Fatalf("route = %v", fieldValue(events[0], "http.route"))
 	}
-	if intField(events[0], "http.status") != http.StatusInternalServerError {
-		t.Fatalf("status = %v, want %d", intField(events[0], "http.status"), http.StatusInternalServerError)
+	if statusField(events[0], "http.status") != http.StatusInternalServerError {
+		t.Fatalf("status = %v, want %d", statusField(events[0], "http.status"), http.StatusInternalServerError)
 	}
-	if _, ok := fieldOf(events[0], "panic").(map[string]any); !ok {
+	if _, ok := fieldValue(events[0], "panic").(map[string]any); !ok {
 		t.Fatalf("expected panic metadata")
 	}
 }
@@ -148,8 +148,8 @@ func TestMiddlewareFiberErrorKeepsHTTPStatus(t *testing.T) {
 	if len(events) != 1 {
 		t.Fatalf("expected 1 event, got %d", len(events))
 	}
-	if intField(events[0], "http.status") != http.StatusTooManyRequests {
-		t.Fatalf("status = %v, want %d", intField(events[0], "http.status"), http.StatusTooManyRequests)
+	if statusField(events[0], "http.status") != http.StatusTooManyRequests {
+		t.Fatalf("status = %v, want %d", statusField(events[0], "http.status"), http.StatusTooManyRequests)
 	}
 	if events[0].Level() != hc.LevelError {
 		t.Fatalf("level = %s, want ERROR", events[0].Level())
@@ -207,8 +207,8 @@ func TestMiddlewareLogsStatusFromCustomFiberErrorHandler(t *testing.T) {
 	if len(events) != 1 {
 		t.Fatalf("expected 1 event, got %d", len(events))
 	}
-	if intField(events[0], "http.status") != http.StatusTeapot {
-		t.Fatalf("status = %v, want %d", intField(events[0], "http.status"), http.StatusTeapot)
+	if statusField(events[0], "http.status") != http.StatusTeapot {
+		t.Fatalf("status = %v, want %d", statusField(events[0], "http.status"), http.StatusTeapot)
 	}
 	if events[0].Level() != hc.LevelError {
 		t.Fatalf("level = %s, want ERROR", events[0].Level())
@@ -247,7 +247,7 @@ func TestMiddlewareReturnsCustomFiberErrorHandlerFailure(t *testing.T) {
 	if len(events) != 1 {
 		t.Fatalf("expected 1 event, got %d", len(events))
 	}
-	errField, ok := fieldOf(events[0], "error").(map[string]any)
+	errField, ok := fieldValue(events[0], "error").(map[string]any)
 	if !ok {
 		t.Fatal("expected structured error field")
 	}
@@ -259,14 +259,15 @@ func TestMiddlewareReturnsCustomFiberErrorHandlerFailure(t *testing.T) {
 // capturedEvent mirrors the v0 test-facing shape (map fields, int
 // numerics) over the v2 TestSink capture, keeping the assertions below
 // unchanged from the v0 suite.
-// Typed field access on captured events (Lookup carries int64; the
-// constants in these tests are ints).
-func fieldOf(ev hc.CapturedEvent, key string) any {
+// Typed field reads on captured events: fieldValue for any value,
+// statusField for the int64 http.status these tests compare against
+// int constants.
+func fieldValue(ev hc.CapturedEvent, key string) any {
 	v, _ := ev.Lookup(key)
 	return v
 }
 
-func intField(ev hc.CapturedEvent, key string) int64 {
+func statusField(ev hc.CapturedEvent, key string) int64 {
 	v, _ := ev.Lookup(key)
 	n, _ := v.(int64)
 	return n

--- a/integration/fiberv3/middleware_test.go
+++ b/integration/fiberv3/middleware_test.go
@@ -36,14 +36,14 @@ func TestMiddlewareCapturesRouteAndFields(t *testing.T) {
 	if len(events) != 1 {
 		t.Fatalf("expected 1 event, got %d", len(events))
 	}
-	if intField(events[0], "http.status") != http.StatusNoContent {
-		t.Fatalf("expected status %d, got %v", http.StatusNoContent, intField(events[0], "http.status"))
+	if statusField(events[0], "http.status") != http.StatusNoContent {
+		t.Fatalf("expected status %d, got %v", http.StatusNoContent, statusField(events[0], "http.status"))
 	}
-	if fieldOf(events[0], "http.route") != "/orders/:id" {
-		t.Fatalf("expected route template, got %v", fieldOf(events[0], "http.route"))
+	if fieldValue(events[0], "http.route") != "/orders/:id" {
+		t.Fatalf("expected route template, got %v", fieldValue(events[0], "http.route"))
 	}
-	if fieldOf(events[0], "user_id") != "u_1" {
-		t.Fatalf("expected user_id field, got %v", fieldOf(events[0], "user_id"))
+	if fieldValue(events[0], "user_id") != "u_1" {
+		t.Fatalf("expected user_id field, got %v", fieldValue(events[0], "user_id"))
 	}
 }
 
@@ -92,10 +92,10 @@ func TestMiddlewareErrorAndSamplingBehavior(t *testing.T) {
 	if events[0].Level() != hc.LevelError {
 		t.Fatalf("level = %s, want ERROR", events[0].Level())
 	}
-	if intField(events[0], "http.status") != http.StatusInternalServerError {
-		t.Fatalf("status = %v, want %d", intField(events[0], "http.status"), http.StatusInternalServerError)
+	if statusField(events[0], "http.status") != http.StatusInternalServerError {
+		t.Fatalf("status = %v, want %d", statusField(events[0], "http.status"), http.StatusInternalServerError)
 	}
-	if _, ok := fieldOf(events[0], "error").(map[string]any); !ok {
+	if _, ok := fieldValue(events[0], "error").(map[string]any); !ok {
 		t.Fatalf("expected structured error field")
 	}
 }
@@ -119,13 +119,13 @@ func TestMiddlewarePanicLogsAndPropagates(t *testing.T) {
 	if len(events) != 1 {
 		t.Fatalf("expected 1 event, got %d", len(events))
 	}
-	if fieldOf(events[0], "http.route") != "/panic/:id" {
-		t.Fatalf("route = %v", fieldOf(events[0], "http.route"))
+	if fieldValue(events[0], "http.route") != "/panic/:id" {
+		t.Fatalf("route = %v", fieldValue(events[0], "http.route"))
 	}
-	if intField(events[0], "http.status") != http.StatusInternalServerError {
-		t.Fatalf("status = %v, want %d", intField(events[0], "http.status"), http.StatusInternalServerError)
+	if statusField(events[0], "http.status") != http.StatusInternalServerError {
+		t.Fatalf("status = %v, want %d", statusField(events[0], "http.status"), http.StatusInternalServerError)
 	}
-	if _, ok := fieldOf(events[0], "panic").(map[string]any); !ok {
+	if _, ok := fieldValue(events[0], "panic").(map[string]any); !ok {
 		t.Fatalf("expected panic metadata")
 	}
 }
@@ -148,8 +148,8 @@ func TestMiddlewareFiberErrorKeepsHTTPStatus(t *testing.T) {
 	if len(events) != 1 {
 		t.Fatalf("expected 1 event, got %d", len(events))
 	}
-	if intField(events[0], "http.status") != http.StatusTooManyRequests {
-		t.Fatalf("status = %v, want %d", intField(events[0], "http.status"), http.StatusTooManyRequests)
+	if statusField(events[0], "http.status") != http.StatusTooManyRequests {
+		t.Fatalf("status = %v, want %d", statusField(events[0], "http.status"), http.StatusTooManyRequests)
 	}
 	if events[0].Level() != hc.LevelError {
 		t.Fatalf("level = %s, want ERROR", events[0].Level())
@@ -207,8 +207,8 @@ func TestMiddlewareLogsStatusFromCustomFiberErrorHandler(t *testing.T) {
 	if len(events) != 1 {
 		t.Fatalf("expected 1 event, got %d", len(events))
 	}
-	if intField(events[0], "http.status") != http.StatusTeapot {
-		t.Fatalf("status = %v, want %d", intField(events[0], "http.status"), http.StatusTeapot)
+	if statusField(events[0], "http.status") != http.StatusTeapot {
+		t.Fatalf("status = %v, want %d", statusField(events[0], "http.status"), http.StatusTeapot)
 	}
 	if events[0].Level() != hc.LevelError {
 		t.Fatalf("level = %s, want ERROR", events[0].Level())
@@ -247,7 +247,7 @@ func TestMiddlewareReturnsCustomFiberErrorHandlerFailure(t *testing.T) {
 	if len(events) != 1 {
 		t.Fatalf("expected 1 event, got %d", len(events))
 	}
-	errField, ok := fieldOf(events[0], "error").(map[string]any)
+	errField, ok := fieldValue(events[0], "error").(map[string]any)
 	if !ok {
 		t.Fatal("expected structured error field")
 	}
@@ -259,14 +259,15 @@ func TestMiddlewareReturnsCustomFiberErrorHandlerFailure(t *testing.T) {
 // capturedEvent mirrors the v0 test-facing shape (map fields, int
 // numerics) over the v2 TestSink capture, keeping the assertions below
 // unchanged from the v0 suite.
-// Typed field access on captured events (Lookup carries int64; the
-// constants in these tests are ints).
-func fieldOf(ev hc.CapturedEvent, key string) any {
+// Typed field reads on captured events: fieldValue for any value,
+// statusField for the int64 http.status these tests compare against
+// int constants.
+func fieldValue(ev hc.CapturedEvent, key string) any {
 	v, _ := ev.Lookup(key)
 	return v
 }
 
-func intField(ev hc.CapturedEvent, key string) int64 {
+func statusField(ev hc.CapturedEvent, key string) int64 {
 	v, _ := ev.Lookup(key)
 	n, _ := v.(int64)
 	return n

--- a/integration/gin/middleware_test.go
+++ b/integration/gin/middleware_test.go
@@ -32,14 +32,14 @@ func TestMiddlewareCapturesRouteAndFields(t *testing.T) {
 	if len(events) != 1 {
 		t.Fatalf("expected 1 event, got %d", len(events))
 	}
-	if intField(events[0], "http.status") != http.StatusCreated {
-		t.Fatalf("expected status %d, got %v", http.StatusCreated, intField(events[0], "http.status"))
+	if statusField(events[0], "http.status") != http.StatusCreated {
+		t.Fatalf("expected status %d, got %v", http.StatusCreated, statusField(events[0], "http.status"))
 	}
-	if fieldOf(events[0], "http.route") != "/orders/:id" {
-		t.Fatalf("expected route template, got %v", fieldOf(events[0], "http.route"))
+	if fieldValue(events[0], "http.route") != "/orders/:id" {
+		t.Fatalf("expected route template, got %v", fieldValue(events[0], "http.route"))
 	}
-	if fieldOf(events[0], "user_id") != "u_1" {
-		t.Fatalf("expected user_id field, got %v", fieldOf(events[0], "user_id"))
+	if fieldValue(events[0], "user_id") != "u_1" {
+		t.Fatalf("expected user_id field, got %v", fieldValue(events[0], "user_id"))
 	}
 }
 
@@ -87,10 +87,10 @@ func TestMiddlewareErrorAndSamplingBehavior(t *testing.T) {
 	if events[0].Level() != hc.LevelError {
 		t.Fatalf("level = %s, want ERROR", events[0].Level())
 	}
-	if intField(events[0], "http.status") != http.StatusInternalServerError {
-		t.Fatalf("status = %v, want %d", intField(events[0], "http.status"), http.StatusInternalServerError)
+	if statusField(events[0], "http.status") != http.StatusInternalServerError {
+		t.Fatalf("status = %v, want %d", statusField(events[0], "http.status"), http.StatusInternalServerError)
 	}
-	if _, ok := fieldOf(events[0], "error").(map[string]any); !ok {
+	if _, ok := fieldValue(events[0], "error").(map[string]any); !ok {
 		t.Fatalf("expected structured error field")
 	}
 }
@@ -123,13 +123,13 @@ func TestMiddlewarePanicLogsAndPropagates(t *testing.T) {
 	if len(events) != 1 {
 		t.Fatalf("expected 1 event, got %d", len(events))
 	}
-	if fieldOf(events[0], "http.route") != "/panic/:id" {
-		t.Fatalf("route = %v", fieldOf(events[0], "http.route"))
+	if fieldValue(events[0], "http.route") != "/panic/:id" {
+		t.Fatalf("route = %v", fieldValue(events[0], "http.route"))
 	}
-	if intField(events[0], "http.status") != http.StatusInternalServerError {
-		t.Fatalf("status = %v, want %d", intField(events[0], "http.status"), http.StatusInternalServerError)
+	if statusField(events[0], "http.status") != http.StatusInternalServerError {
+		t.Fatalf("status = %v, want %d", statusField(events[0], "http.status"), http.StatusInternalServerError)
 	}
-	if _, ok := fieldOf(events[0], "panic").(map[string]any); !ok {
+	if _, ok := fieldValue(events[0], "panic").(map[string]any); !ok {
 		t.Fatalf("expected panic metadata")
 	}
 }
@@ -154,8 +154,8 @@ func TestMiddlewareLogsNoRouteWithoutTemplate(t *testing.T) {
 	if _, ok := events[0].Lookup("http.route"); ok {
 		t.Fatalf("did not expect route template for unmatched route")
 	}
-	if intField(events[0], "http.status") != http.StatusNotFound {
-		t.Fatalf("status = %v, want %d", intField(events[0], "http.status"), http.StatusNotFound)
+	if statusField(events[0], "http.status") != http.StatusNotFound {
+		t.Fatalf("status = %v, want %d", statusField(events[0], "http.status"), http.StatusNotFound)
 	}
 }
 
@@ -177,8 +177,8 @@ func TestMiddlewareGinErrorKeepsCommittedStatus(t *testing.T) {
 	if len(events) != 1 {
 		t.Fatalf("expected 1 event, got %d", len(events))
 	}
-	if intField(events[0], "http.status") != http.StatusTooManyRequests {
-		t.Fatalf("status = %v, want %d", intField(events[0], "http.status"), http.StatusTooManyRequests)
+	if statusField(events[0], "http.status") != http.StatusTooManyRequests {
+		t.Fatalf("status = %v, want %d", statusField(events[0], "http.status"), http.StatusTooManyRequests)
 	}
 	if events[0].Level() != hc.LevelError {
 		t.Fatalf("level = %s, want ERROR", events[0].Level())
@@ -203,7 +203,7 @@ func TestMiddlewareGinErrorUsesUnderlyingErrorMetadata(t *testing.T) {
 	if len(events) != 1 {
 		t.Fatalf("expected 1 event, got %d", len(events))
 	}
-	errField, ok := fieldOf(events[0], "error").(map[string]any)
+	errField, ok := fieldValue(events[0], "error").(map[string]any)
 	if !ok {
 		t.Fatalf("expected structured error field")
 	}
@@ -218,14 +218,15 @@ func TestMiddlewareGinErrorUsesUnderlyingErrorMetadata(t *testing.T) {
 // capturedEvent mirrors the v0 test-facing shape (map fields, int
 // numerics) over the v2 TestSink capture, keeping the assertions below
 // unchanged from the v0 suite.
-// Typed field access on captured events (Lookup carries int64; the
-// constants in these tests are ints).
-func fieldOf(ev hc.CapturedEvent, key string) any {
+// Typed field reads on captured events: fieldValue for any value,
+// statusField for the int64 http.status these tests compare against
+// int constants.
+func fieldValue(ev hc.CapturedEvent, key string) any {
 	v, _ := ev.Lookup(key)
 	return v
 }
 
-func intField(ev hc.CapturedEvent, key string) int64 {
+func statusField(ev hc.CapturedEvent, key string) int64 {
 	v, _ := ev.Lookup(key)
 	n, _ := v.(int64)
 	return n

--- a/integration/std/middleware_test.go
+++ b/integration/std/middleware_test.go
@@ -40,11 +40,11 @@ func TestMiddlewareDelegatesToCoreAndLogs(t *testing.T) {
 	if events[0].Message() != "done" {
 		t.Fatalf("expected message done, got %q", events[0].Message())
 	}
-	if intField(events[0], "http.status") != http.StatusAccepted {
-		t.Fatalf("expected status %d, got %v", http.StatusAccepted, intField(events[0], "http.status"))
+	if statusField(events[0], "http.status") != http.StatusAccepted {
+		t.Fatalf("expected status %d, got %v", http.StatusAccepted, statusField(events[0], "http.status"))
 	}
-	if fieldOf(events[0], "example") != "std-integration" {
-		t.Fatalf("expected example field, got %v", fieldOf(events[0], "example"))
+	if fieldValue(events[0], "example") != "std-integration" {
+		t.Fatalf("expected example field, got %v", fieldValue(events[0], "example"))
 	}
 }
 
@@ -71,8 +71,8 @@ func TestMiddlewareAppliesCustomMessageFromHandlerContext(t *testing.T) {
 	if events[0].Message() != "order shipped" {
 		t.Fatalf("expected message %q, got %q", "order shipped", events[0].Message())
 	}
-	if intField(events[0], "http.status") != http.StatusAccepted {
-		t.Fatalf("expected status %d, got %v", http.StatusAccepted, intField(events[0], "http.status"))
+	if statusField(events[0], "http.status") != http.StatusAccepted {
+		t.Fatalf("expected status %d, got %v", http.StatusAccepted, statusField(events[0], "http.status"))
 	}
 }
 
@@ -108,10 +108,10 @@ func TestMiddlewarePanicPropagatesAndLogsError(t *testing.T) {
 	if events[0].Level() != hc.LevelError {
 		t.Fatalf("expected error level, got %s", events[0].Level())
 	}
-	if intField(events[0], "http.status") != http.StatusInternalServerError {
-		t.Fatalf("expected status 500, got %v", intField(events[0], "http.status"))
+	if statusField(events[0], "http.status") != http.StatusInternalServerError {
+		t.Fatalf("expected status 500, got %v", statusField(events[0], "http.status"))
 	}
-	if _, ok := fieldOf(events[0], "panic").(map[string]any); !ok {
+	if _, ok := fieldValue(events[0], "panic").(map[string]any); !ok {
 		t.Fatalf("expected panic field in event")
 	}
 }
@@ -139,8 +139,8 @@ func TestMiddlewareWriteHeaderTwiceLogsFirstCommittedStatus(t *testing.T) {
 	if len(events) != 1 {
 		t.Fatalf("expected 1 event, got %d", len(events))
 	}
-	if intField(events[0], "http.status") != http.StatusCreated {
-		t.Fatalf("expected logged status %d, got %v", http.StatusCreated, intField(events[0], "http.status"))
+	if statusField(events[0], "http.status") != http.StatusCreated {
+		t.Fatalf("expected logged status %d, got %v", http.StatusCreated, statusField(events[0], "http.status"))
 	}
 }
 
@@ -181,8 +181,8 @@ func TestMiddlewarePanicAfterCommittedStatusKeepsCommittedStatus(t *testing.T) {
 	if events[0].Level() != hc.LevelError {
 		t.Fatalf("expected error level, got %s", events[0].Level())
 	}
-	if intField(events[0], "http.status") != http.StatusCreated {
-		t.Fatalf("expected logged status %d, got %v", http.StatusCreated, intField(events[0], "http.status"))
+	if statusField(events[0], "http.status") != http.StatusCreated {
+		t.Fatalf("expected logged status %d, got %v", http.StatusCreated, statusField(events[0], "http.status"))
 	}
 }
 
@@ -211,11 +211,11 @@ func TestMiddlewareSetsRouteFromRequestPattern(t *testing.T) {
 	if len(events) != 1 {
 		t.Fatalf("expected 1 event, got %d", len(events))
 	}
-	route, ok := fieldOf(events[0], "http.route").(string)
+	route, ok := fieldValue(events[0], "http.route").(string)
 	if !ok || route == "" {
-		t.Fatalf("expected route template, got %#v", fieldOf(events[0], "http.route"))
+		t.Fatalf("expected route template, got %#v", fieldValue(events[0], "http.route"))
 	}
-	if name, _ := fieldOf(events[0], "op.name").(string); name != route {
+	if name, _ := fieldValue(events[0], "op.name").(string); name != route {
 		t.Fatalf("wire op.name = %q, want route %q", name, route)
 	}
 	if sampledOp != route {
@@ -295,8 +295,8 @@ func TestMiddlewareWriteSetsStatusCode(t *testing.T) {
 	if len(events) != 1 {
 		t.Fatalf("expected 1 event, got %d", len(events))
 	}
-	if intField(events[0], "http.status") != http.StatusOK {
-		t.Fatalf("expected status 200, got %v", intField(events[0], "http.status"))
+	if statusField(events[0], "http.status") != http.StatusOK {
+		t.Fatalf("expected status 200, got %v", statusField(events[0], "http.status"))
 	}
 }
 
@@ -325,8 +325,8 @@ func TestMiddlewareReadFromSetsStatusCode(t *testing.T) {
 	if len(events) != 1 {
 		t.Fatalf("expected 1 event, got %d", len(events))
 	}
-	if intField(events[0], "http.status") != http.StatusOK {
-		t.Fatalf("expected status 200, got %v", intField(events[0], "http.status"))
+	if statusField(events[0], "http.status") != http.StatusOK {
+		t.Fatalf("expected status 200, got %v", statusField(events[0], "http.status"))
 	}
 }
 
@@ -361,14 +361,15 @@ func TestMiddlewareSamplingDropForHealthyRequest(t *testing.T) {
 // capturedEvent mirrors the v0 test-facing shape (map fields, int
 // numerics) over the v2 TestSink capture, keeping the assertions below
 // unchanged from the v0 suite.
-// Typed field access on captured events (Lookup carries int64; the
-// constants in these tests are ints).
-func fieldOf(ev hc.CapturedEvent, key string) any {
+// Typed field reads on captured events: fieldValue for any value,
+// statusField for the int64 http.status these tests compare against
+// int constants.
+func fieldValue(ev hc.CapturedEvent, key string) any {
 	v, _ := ev.Lookup(key)
 	return v
 }
 
-func intField(ev hc.CapturedEvent, key string) int64 {
+func statusField(ev hc.CapturedEvent, key string) int64 {
 	v, _ := ev.Lookup(key)
 	n, _ := v.(int64)
 	return n

--- a/integration/std/wire_test.go
+++ b/integration/std/wire_test.go
@@ -21,7 +21,7 @@ import (
 
 // mustWireLine parses one emitted JSON line and asserts the canonical
 // envelope every consumer relies on.
-func mustWireLine(t *testing.T, ln string) map[string]any {
+func parseWireLine(t *testing.T, ln string) map[string]any {
 	t.Helper()
 	var m map[string]any
 	if err := json.Unmarshal([]byte(ln), &m); err != nil {
@@ -32,8 +32,12 @@ func mustWireLine(t *testing.T, ln string) map[string]any {
 			t.Fatalf("canonical key %q missing: %s", k, ln)
 		}
 	}
-	outcome := m["op.outcome"].(string)
-	status := int(m["http.status"].(float64))
+	outcome, ocOK := m["op.outcome"].(string)
+	statusF, stOK := m["http.status"].(float64)
+	if !ocOK || !stOK {
+		t.Fatalf("canonical envelope mistyped: %s", ln)
+	}
+	status := int(statusF)
 	switch outcome {
 	case "panic":
 		if _, ok := m["panic"].(map[string]any); !ok {
@@ -58,9 +62,10 @@ func mustWireLine(t *testing.T, ln string) map[string]any {
 
 // TestWireMixedTrafficRealLogger drives concurrent mixed traffic —
 // success, error, panic, streaming-flush, kitchen-sink — through the
-// real middleware and the real slog JSON pipeline (one shared logger,
-// exactly the production shape); every emitted line must parse, carry
-// the full canonical envelope, and be internally coherent.
+// real middleware and the first-party JSONSink (one shared sink, the
+// production shape; the slog/zap/zerolog equivalents live in
+// cmd/examples); every emitted line must parse, carry the full
+// canonical envelope, and be internally coherent.
 func TestWireMixedTrafficRealLogger(t *testing.T) {
 	var buf bytes.Buffer
 	// One JSONSink, mutex-serialized by the sink itself: the shared
@@ -139,7 +144,7 @@ func TestWireMixedTrafficRealLogger(t *testing.T) {
 	}
 	outcomes := map[string]int{}
 	for _, ln := range lines {
-		m := mustWireLine(t, ln)
+		m := parseWireLine(t, ln)
 		outcomes[m["op.outcome"].(string)]++
 	}
 	// Exact mix: every /err is failure, every /panic is panic, the
@@ -178,19 +183,23 @@ func TestWireRouteAndOperationShareTheTemplate(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 	srv := httptest.NewServer(Middleware(rt)(mux))
-	defer srv.Close()
 
 	resp, err := srv.Client().Get(srv.URL + "/orders/o_42")
 	if err != nil {
 		t.Fatal(err)
 	}
 	_ = resp.Body.Close()
+	// Quiesce before reading shared state: client returns precede the
+	// server's deferred emission, and this test reads buf and sampled
+	// directly (the buffering that makes this safe today is a net/http
+	// implementation detail — Close makes it explicit).
+	srv.Close()
 
 	lines := nonEmptyLines(buf.String())
 	if len(lines) != 1 {
 		t.Fatalf("lines = %d", len(lines))
 	}
-	m := mustWireLine(t, lines[0])
+	m := parseWireLine(t, lines[0])
 	// req.Pattern carries the method for method-matched patterns; the
 	// invariant is that all three views agree on the same template.
 	const want = "GET /orders/{id}"

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -569,6 +569,8 @@ func TestFanoutSinkOrder(t *testing.T) {
 	}
 }
 
+// FuzzCompileConfig fuzzes hc.Compile with extreme configurations; the
+// oracle checks the documented contract:
 //
 //  1. Compile never panics.
 //  2. err != nil ⇒ the error wraps one of the three sentinels

--- a/wal_test.go
+++ b/wal_test.go
@@ -1613,7 +1613,6 @@ func TestStragglerInjectionMatrix(t *testing.T) {
 	}
 	for _, phase := range phases {
 		for _, armed := range []bool{false, true} {
-			phase, armed := phase, armed
 			t.Run(fmt.Sprintf("phase=%s armed=%v", phase, armed), func(t *testing.T) {
 				live := phase.live()
 
@@ -1869,7 +1868,6 @@ func TestStragglerArmedBurst(t *testing.T) {
 func TestStragglerSealedErrorNoLatch(t *testing.T) {
 	for _, armed := range []bool{false, true} {
 		for _, phase := range []matrixPhase{phasePreScan, phasePrePostSeal, phasePreCommit} {
-			phase, armed := phase, armed
 			t.Run(fmt.Sprintf("phase=%s armed=%v", phase, armed), func(t *testing.T) {
 				sink := &matrixSink{}
 				rt := MustCompile(Config{Sink: sink, SamplingRate: 0}) // healthy drops


### PR DESCRIPTION
## Summary

Post-merge skill audit of #48: the v2 hardening PR run through the newly added **golang-\* skills** as review personas — heavy domains (`golang-testing`, `golang-concurrency`, `golang-safety`) on **GLM-5.3**, style domains (`golang-code-style`, `golang-naming`, `golang-lint`, `golang-modernize`) on **GLM-5.3-Flash**. Both verdicts: zero defects, high-quality PR — but each found things the DeepSeek audits missed.

### Real catches applied

- **Parity roulette (GLM-5.3, should-fix)** — `TestAdaptersWireParity`'s reference pipeline `continue`d before the absolute canonical-field checks, so whichever of the four pipelines iterated first got `status`/`outcome`/user-field validated only transitively — a bridge regression slipped through ~25% of runs depending on map order. Every pipeline now gets absolute checks; jsonsink is the fixed deterministic reference; the zap core gained `zapcore.Lock` (the flash pass's `AddSync`-is-unlocked footgun).
- **Latent race (GLM-5.3, flake-risk)** — `TestWireRouteAndOperationShareTheTemplate` read shared sink state without a quiescence barrier; its safety rested on a net/http buffering detail one handler edit from racing. Now Close-then-read like its siblings.
- **Coverage over-claim (both models, cross-verified)** — the `TestCrashHostileRates` trim claimed `TestCompileSentinels` pinned NaN; it never covered *nested* NaN in the level map. Deterministic case restored.
- **Silent data loss hole (GLM-5.3)** — the typed-nil adapter tests asserted only "no panic"; a bridge silently *dropping* the field passed. They now pin the `<nil>` rendering.
- Plus the mechanical batch: `drivePipeline` rename + dead defer, `mustWireLine`→`parseWireLine` (Must\* means panic), `fieldValue`/`statusField` renames across the five integration suites, Copysign sites documented against future "simplification", dead loop-var shadows removed, the amputated `FuzzCompileConfig` intro restored, the roster notes where M went, comma-ok type assertions in the wire helpers.

### Model-caught-by-lint (the honest footnote)
GLM-Flash suggested collapsing seven `//lint:ignore SA1012` directives into one function-level directive. staticcheck rejected it — directives are line-scoped — and the lint gate caught the model's claim before it landed. Reverted; per-line directives restored.

## Validation
Full root suite + `-race`, all 12 modules test + vet, gofmt/gofumpt/staticcheck clean.
