### PR TITLE
ci: gate and night-fuzz the crash fuzz targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,3 +123,5 @@ jobs:
           go test . -run '^$' -fuzz '^FuzzEndLifecycle$' -fuzztime 60s
           go test . -run '^$' -fuzz '^FuzzDedupeFields$' -fuzztime 60s
           go test . -run '^$' -fuzz '^FuzzCompileConfig$' -fuzztime 60s
+          go test . -run '^$' -fuzz '^FuzzCrashAdversarialValues$' -fuzztime 60s
+          go test . -run '^$' -fuzz '^FuzzCrashArmedInterleavings$' -fuzztime 60s

--- a/.github/workflows/nightly-fuzz.yml
+++ b/.github/workflows/nightly-fuzz.yml
@@ -38,7 +38,7 @@ jobs:
           set +e
           mkdir -p /tmp/fuzz
           echo "core fuzz failures:" > /tmp/fuzz/core-failures
-          for target in FuzzRecordEncodedDedupe FuzzEndLifecycle FuzzDedupeFields FuzzCompileConfig; do
+          for target in FuzzRecordEncodedDedupe FuzzEndLifecycle FuzzDedupeFields FuzzCompileConfig FuzzCrashAdversarialValues FuzzCrashArmedInterleavings; do
             echo "=== $target ==="
             if go test . -run '^$' -fuzz "^$target$" -fuzztime 10m; then
               echo "PASS $target"


### PR DESCRIPTION
FuzzCrashAdversarialValues and FuzzCrashArmedInterleavings only ran
their seed corpora in CI — the 60s ci.yml gate and the 10m nightly
runs never executed them.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>