### PR TITLE
test: modernize goroutine launch sites to WaitGroup.Go

### DIFF
--- a/cmd/examples/adapters_wire_test.go
+++ b/cmd/examples/adapters_wire_test.go
@@ -103,7 +103,7 @@ func drivePipeline(t *testing.T, sink gc.Sink, buf *bytes.Buffer, pipeline strin
 	srv.Close() // quiesce handlers before reading the buffer
 
 	out := make([]parsedWire, 0, len(wireCases))
-	for _, ln := range strings.Split(strings.TrimSpace(buf.String()), "\n") {
+	for ln := range strings.SplitSeq(strings.TrimSpace(buf.String()), "\n") {
 		if ln == "" {
 			continue
 		}

--- a/crash_test.go
+++ b/crash_test.go
@@ -2022,11 +2022,9 @@ func TestSynctestConcurrentEndGatedSink(t *testing.T) {
 		var wg sync.WaitGroup
 		first := make([]bool, racers)
 		for i := range racers {
-			wg.Add(1)
-			go func(i int) {
-				defer wg.Done()
+			wg.Go(func() {
 				first[i] = op.End(nil)
-			}(i)
+			})
 		}
 		// The gate usually closes before the winner reaches Write, so
 		// the durable block is scheduling-dependent — the assertions
@@ -2068,9 +2066,7 @@ func TestSynctestArmedWritersAllExit(t *testing.T) {
 		stop := make(chan struct{})
 		var wg sync.WaitGroup
 		for w := range 6 {
-			wg.Add(1)
-			go func(w int) {
-				defer wg.Done()
+			wg.Go(func() {
 				for i := 0; ; i++ {
 					select {
 					case <-stop:
@@ -2079,7 +2075,7 @@ func TestSynctestArmedWritersAllExit(t *testing.T) {
 						Add(op.Context(), fmt.Sprintf("w%d", w), i)
 					}
 				}
-			}(w)
+			})
 		}
 		wg.Add(1)
 		go func() {
@@ -2170,11 +2166,9 @@ func TestSynctestStragglerStormBubble(t *testing.T) {
 			_ = op.End(nil)
 			var wg sync.WaitGroup
 			for s := range 8 {
-				wg.Add(1)
-				go func(s int) {
-					defer wg.Done()
+				wg.Go(func() {
 					Add(op.Context(), "straggler", s)
-				}(s)
+				})
 			}
 			wg.Wait()
 		}

--- a/integration/std/wire_test.go
+++ b/integration/std/wire_test.go
@@ -119,9 +119,7 @@ func TestWireMixedTrafficRealLogger(t *testing.T) {
 	const per = 15
 	var wg sync.WaitGroup
 	for w := range workers {
-		wg.Add(1)
-		go func(w int) {
-			defer wg.Done()
+		wg.Go(func() {
 			for i := range per {
 				id := fmt.Sprintf("w%d-%d", w, i)
 				for _, p := range []string{"/ok/", "/err/", "/panic/", "/stream/", "/kitchen/"} {
@@ -131,7 +129,7 @@ func TestWireMixedTrafficRealLogger(t *testing.T) {
 					}
 				}
 			}
-		}(w)
+		})
 	}
 	wg.Wait()
 	// Client returns precede the server's deferred emissions; Close
@@ -156,7 +154,7 @@ func TestWireMixedTrafficRealLogger(t *testing.T) {
 
 func nonEmptyLines(s string) []string {
 	var out []string
-	for _, ln := range strings.Split(s, "\n") {
+	for ln := range strings.SplitSeq(s, "\n") {
 		if strings.TrimSpace(ln) != "" {
 			out = append(out, ln)
 		}

--- a/wal_test.go
+++ b/wal_test.go
@@ -415,13 +415,11 @@ func TestSealDuringArmedAppend(t *testing.T) {
 		op := Start(context.Background(), rt, OperationStart{Domain: DomainJob, Name: "r"})
 		ctx := op.Context()
 		op.ev.arm() // arm BEFORE End to force the guarded path
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			for i := range 50 {
 				Add(ctx, "armed", i)
 			}
-		}()
+		})
 		op.End(nil)
 		wg.Wait()
 	}
@@ -1911,14 +1909,12 @@ func TestArmedSetterSerialization(t *testing.T) {
 		const writes = 2000
 		var wg sync.WaitGroup
 		for i := range setters {
-			wg.Add(1)
-			go func(i int) {
-				defer wg.Done()
+			wg.Go(func() {
 				for range writes {
 					SetMessage(ctx, fmt.Sprintf("msg-%d", i))
 					SetLevel(ctx, LevelWarn)
 				}
-			}(i)
+			})
 		}
 		// The owner seals while the setters hammer: armed serialization
 		// means every write either lands pre-seal or drops post-seal.


### PR DESCRIPTION
Go 1.25 floor: wg.Go replaces the Add/defer-Done/explicit-param
ritual at the listed sites (synctest gated-sink racers, armed writers,
straggler storm bubble, wire mixed-traffic workers, WAL armed-burst
and setter serialization). Closures capture per-iteration variables
since 1.22. strings.SplitSeq replaces slice-allocating Split in the
wire line iteration.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>