### PR TITLE
test: restore amputated comment context from the consolidation moves

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -1,5 +1,9 @@
 package hc
 
+// Benchmarks for the sampling gate and the record encode/write path —
+// the repo-wide root-module benchmark file (the cross-adapter and host
+// comparisons live in the benches module).
+
 import (
 	"context"
 	"io"

--- a/integration/std/middleware_test.go
+++ b/integration/std/middleware_test.go
@@ -495,6 +495,8 @@ func TestMiddlewareFlushCommitsStatus(t *testing.T) {
 	})
 }
 
+// Consolidated from integration/std/crash_test.go: nil-runtime
+// middleware is a documented passthrough.
 func TestCrashNilRuntimePassthrough(t *testing.T) {
 	mw := Middleware(nil)
 	handler := mw(http.NotFoundHandler())

--- a/property_test.go
+++ b/property_test.go
@@ -528,6 +528,8 @@ func TestEncodedRoundTripProperty(t *testing.T) {
 // appears exactly once with its last value, in last-occurrence order —
 // checked against an independent reference fold, not the encoder's own
 // dedupe code.
+// TestEncodedRoundTripProperty: the encoded canonical line must
+// unmarshal to exactly the record's resolved members.
 //
 // Canonical-key collision follows the logrus rename policy (record.go
 // aliasKey, T5 decision): user fields named "level"/"time"/"message"
@@ -922,12 +924,14 @@ func TestPoolSafetyReplayProperty(t *testing.T) {
 	}
 }
 
+// The lifecycle model's wire oracle.
 //
 // The wire comparison pins the full canonical line: envelope level,
 // every user field at its last-occurrence position with its last value
 // (independent LWW fold), the resolved op.outcome, and the resolved
 // message. The members that depend on the wall clock (time,
 // duration_ms) are excluded.
+// FuzzEndLifecycle scope note.
 //
 // The canonical-key collision policy (user fields named "message"/
 // "time"/"level") is deliberately OUT of this target's key alphabet —

--- a/record_test.go
+++ b/record_test.go
@@ -649,6 +649,8 @@ func TestTestSinkCopiesMutableValues(t *testing.T) {
 	}
 }
 
+// FuzzDedupeFields pins the canonical dedupe: every key emitted once,
+// at its last-occurrence position, with its last value.
 //
 // Canonical-key collisions (user fields named "message"/"time"/"level")
 // follow the logrus rename policy (record.go aliasKey): colliding user

--- a/wal_test.go
+++ b/wal_test.go
@@ -683,6 +683,7 @@ func canaryWrite(stale context.Context) {
 	Error(stale, errors.New("!BUG stale error"))
 }
 
+// Loom-lite oracle note.
 //
 // The one preemption-sensitive fragment is the straggler's append: its
 // single state load happens, then it acts. Between load and act the


### PR DESCRIPTION
The file merges left orphaned contract lists whose subject lines lived
in the deleted file headers: FuzzDedupeFields' oracle intro, the
round-trip and wire-oracle notes in property_test, the loom-lite
oracle note, plus a header for the repo-wide bench file and a
provenance marker on the consolidated nil-runtime passthrough test.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>