### PR TITLE
v2 overnight: GLM audit fixes, fuzz-CI gap, modernization, comment archaeology

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,3 +123,5 @@ jobs:
           go test . -run '^$' -fuzz '^FuzzEndLifecycle$' -fuzztime 60s
           go test . -run '^$' -fuzz '^FuzzDedupeFields$' -fuzztime 60s
           go test . -run '^$' -fuzz '^FuzzCompileConfig$' -fuzztime 60s
+          go test . -run '^$' -fuzz '^FuzzCrashAdversarialValues$' -fuzztime 60s
+          go test . -run '^$' -fuzz '^FuzzCrashArmedInterleavings$' -fuzztime 60s

--- a/.github/workflows/nightly-fuzz.yml
+++ b/.github/workflows/nightly-fuzz.yml
@@ -38,7 +38,7 @@ jobs:
           set +e
           mkdir -p /tmp/fuzz
           echo "core fuzz failures:" > /tmp/fuzz/core-failures
-          for target in FuzzRecordEncodedDedupe FuzzEndLifecycle FuzzDedupeFields FuzzCompileConfig; do
+          for target in FuzzRecordEncodedDedupe FuzzEndLifecycle FuzzDedupeFields FuzzCompileConfig FuzzCrashAdversarialValues FuzzCrashArmedInterleavings; do
             echo "=== $target ==="
             if go test . -run '^$' -fuzz "^$target$" -fuzztime 10m; then
               echo "PASS $target"

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -53,7 +53,7 @@ panic capture.
 | `hc.Add(ctx, k, v)` returning `bool` | same call, returns nothing (silent no-op without an event — the `slog` helper idiom) |
 | `hc.EventFields(e)` / `EventMessage` / `EventHasMessage` / `EventHasError` / `EventStartTime` | gone; sinks receive `*hc.Record` (`Fields()`, `Lookup`, `Message()`, `Level()`); samplers receive `SampleInput.Fields()`/`Lookup`. HTTP `SampleInput.Operation` is the last-write `op.name` (the route template), not the Start name `"request"`. Non-HTTP `SampleInput.Code` surfaces the canonical `op.code` (`StatusCode` stays the `http.status` view); HTTP `Code` remains `http.status`. |
 | `hc.NewContext(ctx)` / `hc.FromContext(ctx)` | gone (internal) |
-| `hc.AddRaw(ctx, k, raw)` | `hc.AddRawJSON(ctx, k, raw)` |
+| `hc.AddRaw(ctx, k, raw)` | gone; pass `json.RawMessage` to `hc.Add` — it embeds verbatim through the regular path with bridge parity |
 | — | `hc.SetLevel(ctx, level)` unchanged in shape; `GetLevel` removed |
 
 ## Levels
@@ -133,7 +133,7 @@ panics also **bypass sampling structurally** — before any custom
 `BeginOperation`, `FinishOperation`, `OperationFinish`, `StartOperation`,
 `Commit`, `GetLevel`, `LevelRank`, `MergeLevelWithFloor`, `EventFields`,
 `EventMessage`, `EventHasMessage`, `EventHasError`, `EventStartTime`,
-`NewContext`, `FromContext`, `NormalizeConfig`, `AddRaw`, plus the
+`NewContext`, `FromContext`, `NormalizeConfig`, `AddRaw`/`AddRawJSON` (kind `KindRaw` and `Field.Raw()` went with them), plus the
 `Event` type itself, `SinkOptions`/`NewWithOptions` in the bridges, and
 `operation/common.NormalizeConfig`-style helpers that moved into
 `Compile`.

--- a/V2_DESIGN.md
+++ b/V2_DESIGN.md
@@ -376,6 +376,30 @@ destination drains** (`adapter/datadog`, `adapter/posthog`, …) — in
 Go the collector/agent owns that job, and stdout-plus-agent is the
 12-factor norm evlog's Node-only world lacks.
 
+## 7a. Post-implementation amendments (2026-09-06)
+
+Changes made during implementation review that supersede §2/§5/§6:
+
+20. **The raw-JSON surface is removed** (`AddRawJSON`, `KindRaw`,
+    `Field.Raw()`), superseding amendment 18's rename. Pre-encoded JSON
+    travels as `json.RawMessage` through regular `Add`: its
+    `MarshalJSON` contract embeds the bytes verbatim in the canonical
+    line AND renders identically through every bridge (all hosts honor
+    `MarshalJSON`), so the second public path existed only to skip a
+    type assertion. A plain `[]byte` through `Add` stays base64 — the
+    `encoding/json` contract, matched by slog/zap/zerolog.
+21. **Sentinel error strings dropped their `"hc: "` prefix** (they
+    double-prefixed under the documented `fmt.Errorf("hc: …: %w")`
+    wrapping). The prefix convention itself — amendment 17 — is
+    unchanged; only the sentinel literals moved.
+22. **`Field.WireKey()` joined the public API** (wire-only aliasing
+    view: user keys colliding with the envelope render as
+    `fields.*`), needed by bridges that emit flat JSON.
+23. **`SampleInput.Code` surfaces the canonical code**: `http.status`
+    for HTTP, `op.code` otherwise; the 5xx outcome rule follows the
+    same canonical split, so non-HTTP 5xx codes resolve failure and
+    bypass sampling like their HTTP twins.
+
 ## 8. Decisions ledger
 
 Every question raised during design, and its final answer.

--- a/adapter/slog/crash_test.go
+++ b/adapter/slog/crash_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"log/slog"
 	"os"
+	"strings"
 	"testing"
 
 	hc "github.com/happytoolin/happycontext"
@@ -50,4 +51,7 @@ func TestCrashTypedNilErrorField(t *testing.T) {
 	_ = op.End(nil)
 	rec := s.rec
 	New(slog.New(slog.NewTextHandler(&buf, nil))).Write(context.Background(), rec)
+	if !strings.Contains(buf.String(), "<nil>") {
+		t.Fatalf("typed-nil error not rendered as <nil>: %s", buf.String())
+	}
 }

--- a/adapter/slog/sink.go
+++ b/adapter/slog/sink.go
@@ -122,6 +122,9 @@ func attrOf(f hc.Field) slog.Attr {
 // forward emission order — the same duplicate resolution the core
 // encoder applies (linear scan for narrow events, backward seen-set
 // collection for wide ones).
+// The 24 crossover matches hc's dedupeScanLimit so bridges and the
+// canonical line resolve duplicates identically (cross-module
+// contract, pinned by the golden parity tests).
 func lastOccurrences(fields []hc.Field) []int {
 	if len(fields) <= 24 {
 		var stack [24]int // allocation-free narrow path

--- a/adapter/slog/sink.go
+++ b/adapter/slog/sink.go
@@ -88,9 +88,6 @@ func attrOf(f hc.Field) slog.Attr {
 	if err, ok := f.Err(); ok {
 		return slog.String(f.Key(), errMessage(err))
 	}
-	if raw, ok := f.Raw(); ok {
-		return slog.Any(f.Key(), raw)
-	}
 	if str, ok := f.Str(); ok {
 		return slog.String(f.Key(), str)
 	}

--- a/adapter/slog/sink_test.go
+++ b/adapter/slog/sink_test.go
@@ -2,6 +2,7 @@ package slogadapter
 
 import (
 	"context"
+	"encoding/json"
 	"log/slog"
 	"testing"
 
@@ -137,7 +138,7 @@ func TestSinkErrorAndRawWireFidelity(t *testing.T) {
 	rt := hc.MustCompile(hc.Config{Sink: New(slog.New(h)), SamplingRate: 1})
 	op := hc.Start(context.Background(), rt, hc.OperationStart{Domain: hc.DomainJob, Name: "t"})
 	hc.Add(op.Context(), "e", errBoom{})
-	hc.AddRawJSON(op.Context(), "meta", []byte(`{"raw":true}`))
+	hc.Add(op.Context(), "meta", json.RawMessage(`{"raw":true}`))
 	op.End(nil)
 
 	if got := h.records[0].Attrs["e"]; got != "boom" {

--- a/adapter/zap/crash_test.go
+++ b/adapter/zap/crash_test.go
@@ -4,12 +4,15 @@ package zapadapter
 // containment.
 
 import (
+	"bytes"
 	"context"
 	"os"
+	"strings"
 	"testing"
 
 	hc "github.com/happytoolin/happycontext"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 type recSink struct{ rec *hc.Record }
@@ -47,5 +50,10 @@ func TestCrashTypedNilErrorField(t *testing.T) {
 	hc.Error(op.Context(), pe)
 	_ = op.End(nil)
 	rec := s.rec
-	New(zap.NewExample()).Write(context.Background(), rec)
+	var out bytes.Buffer
+	zl := zap.New(zapcore.NewCore(zapcore.NewJSONEncoder(zapcore.EncoderConfig{TimeKey: "ts", LevelKey: "level", MessageKey: "msg"}), zapcore.Lock(zapcore.AddSync(&out)), zapcore.DebugLevel))
+	New(zl).Write(context.Background(), rec)
+	if !strings.Contains(out.String(), "<nil>") {
+		t.Fatalf("typed-nil error not rendered as <nil>: %s", out.String())
+	}
 }

--- a/adapter/zap/sink.go
+++ b/adapter/zap/sink.go
@@ -27,11 +27,11 @@ func New(l *zap.Logger) *Sink {
 // Write implements hc.Sink: the record's fields are appended in
 // insertion order (last-write-wins duplicates resolved) as typed zap
 // fields.
-func (z *Sink) Write(ctx context.Context, rec *hc.Record) {
-	if z == nil || z.logger == nil || rec == nil {
+func (s *Sink) Write(ctx context.Context, rec *hc.Record) {
+	if s == nil || s.logger == nil || rec == nil {
 		return
 	}
-	checked := z.check(rec.Level(), rec.Message())
+	checked := s.check(rec.Level(), rec.Message())
 	if checked == nil {
 		return
 	}
@@ -85,16 +85,16 @@ func fieldOf(f hc.Field) zap.Field {
 	return zap.Any(f.Key(), f.Any())
 }
 
-func (z *Sink) check(level hc.Level, message string) *zapcore.CheckedEntry {
+func (s *Sink) check(level hc.Level, message string) *zapcore.CheckedEntry {
 	switch level {
 	case hc.LevelDebug:
-		return z.logger.Check(zapcore.DebugLevel, message)
+		return s.logger.Check(zapcore.DebugLevel, message)
 	case hc.LevelWarn:
-		return z.logger.Check(zapcore.WarnLevel, message)
+		return s.logger.Check(zapcore.WarnLevel, message)
 	case hc.LevelError:
-		return z.logger.Check(zapcore.ErrorLevel, message)
+		return s.logger.Check(zapcore.ErrorLevel, message)
 	default:
-		return z.logger.Check(zapcore.InfoLevel, message)
+		return s.logger.Check(zapcore.InfoLevel, message)
 	}
 }
 
@@ -102,6 +102,9 @@ func (z *Sink) check(level hc.Level, message string) *zapcore.CheckedEntry {
 // forward emission order — the same duplicate resolution the core
 // encoder applies (linear scan for narrow events, backward seen-set
 // collection for wide ones).
+// The 24 crossover matches hc's dedupeScanLimit so bridges and the
+// canonical line resolve duplicates identically (cross-module
+// contract, pinned by the golden parity tests).
 func lastOccurrences(fields []hc.Field) []int {
 	if len(fields) <= 24 {
 		var stack [24]int // allocation-free narrow path

--- a/adapter/zap/sink.go
+++ b/adapter/zap/sink.go
@@ -55,9 +55,6 @@ func fieldOf(f hc.Field) zap.Field {
 	if err, ok := f.Err(); ok {
 		return zap.String(f.Key(), errMessage(err))
 	}
-	if raw, ok := f.Raw(); ok {
-		return zap.Any(f.Key(), raw)
-	}
 	if str, ok := f.Str(); ok {
 		return zap.String(f.Key(), str)
 	}

--- a/adapter/zap/sink_test.go
+++ b/adapter/zap/sink_test.go
@@ -2,6 +2,7 @@ package zapadapter
 
 import (
 	"context"
+	"encoding/json"
 	"strconv"
 	"sync"
 	"testing"
@@ -119,7 +120,7 @@ func TestSinkFloat32AndRawWireFidelity(t *testing.T) {
 	rt := hc.MustCompile(hc.Config{Sink: New(zap.New(core)), SamplingRate: 1})
 	op := hc.Start(context.Background(), rt, hc.OperationStart{Domain: hc.DomainJob, Name: "t"})
 	hc.Add(op.Context(), "f", float32(0.1))
-	hc.AddRawJSON(op.Context(), "meta", []byte(`{"raw":true}`))
+	hc.Add(op.Context(), "meta", json.RawMessage(`{"raw":true}`))
 	op.End(nil)
 
 	ctxMap := logs.All()[0].ContextMap()

--- a/adapter/zerolog/crash_test.go
+++ b/adapter/zerolog/crash_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"os"
+	"strings"
 	"testing"
 
 	hc "github.com/happytoolin/happycontext"
@@ -58,4 +59,7 @@ func TestCrashTypedNilErrorField(t *testing.T) {
 	rec := s.rec
 	zl := zerolog.New(&buf)
 	New(&zl).Write(context.Background(), rec)
+	if !strings.Contains(buf.String(), `"<nil>"`) {
+		t.Fatalf("typed-nil error not rendered as <nil>: %s", buf.String())
+	}
 }

--- a/adapter/zerolog/sink.go
+++ b/adapter/zerolog/sink.go
@@ -257,9 +257,6 @@ func appendField(event *zerolog.Event, f hc.Field) *zerolog.Event {
 	if err, ok := f.Err(); ok {
 		return event.Str(key, errMessage(err))
 	}
-	if raw, ok := f.Raw(); ok {
-		return event.RawJSON(key, raw)
-	}
 	return event.Interface(key, f.Any())
 }
 

--- a/adapter/zerolog/sink.go
+++ b/adapter/zerolog/sink.go
@@ -63,7 +63,7 @@ func checkLoggerLayout() {
 // rec.Encoded() is byte-for-byte the event they should emit; loggers
 // built with With()/Hook()/Sample() augment every event and take the
 // typed path. The view is re-read on every Write, so mutating
-// *z.logger between writes is observed.
+// *s.logger between writes is observed.
 //
 // A logger whose only augmentation is the Timestamp() hook counts as
 // plain: the canonical line already carries the timestamp those hooks
@@ -143,7 +143,7 @@ func defaultFieldNames() bool {
 // zerolog.ErrorHandler; custom member-name globals and augmented
 // loggers are rejected (defaultFieldNames, plain) and take the typed
 // path.
-func (z *Sink) writeEncoded(view *loggerView, rec *hc.Record) bool {
+func (s *Sink) writeEncoded(view *loggerView, rec *hc.Record) bool {
 	if !view.plain() || !view.enabled(rec.Level()) || !defaultFieldNames() {
 		return false
 	}
@@ -162,16 +162,16 @@ func (z *Sink) writeEncoded(view *loggerView, rec *hc.Record) bool {
 // carry zerolog context/hooks/samplers fall back to the typed path:
 // the record's fields are appended in insertion order (last-write-wins
 // duplicates resolved) through zerolog's typed constructors.
-func (z *Sink) Write(ctx context.Context, rec *hc.Record) {
-	if z == nil || z.logger == nil || rec == nil {
+func (s *Sink) Write(ctx context.Context, rec *hc.Record) {
+	if s == nil || s.logger == nil || rec == nil {
 		return
 	}
-	view := (*loggerView)(unsafe.Pointer(z.logger))
-	if z.writeEncoded(view, rec) {
+	view := (*loggerView)(unsafe.Pointer(s.logger))
+	if s.writeEncoded(view, rec) {
 		return
 	}
 
-	event := z.eventFor(rec.Level())
+	event := s.eventFor(rec.Level())
 	if !event.Enabled() {
 		return
 	}
@@ -194,16 +194,16 @@ func (z *Sink) Write(ctx context.Context, rec *hc.Record) {
 	event.Msg(rec.Message())
 }
 
-func (z *Sink) eventFor(level hc.Level) *zerolog.Event {
+func (s *Sink) eventFor(level hc.Level) *zerolog.Event {
 	switch level {
 	case hc.LevelDebug:
-		return z.logger.Debug()
+		return s.logger.Debug()
 	case hc.LevelWarn:
-		return z.logger.Warn()
+		return s.logger.Warn()
 	case hc.LevelError:
-		return z.logger.Error()
+		return s.logger.Error()
 	default:
-		return z.logger.Info()
+		return s.logger.Info()
 	}
 }
 
@@ -267,6 +267,9 @@ func appendField(event *zerolog.Event, f hc.Field) *zerolog.Event {
 // forward emission order — the same duplicate resolution the core
 // encoder applies (allocation-free scan for narrow events, backward
 // seen-set collection for wide ones).
+// The 24 crossover matches hc's dedupeScanLimit so bridges and the
+// canonical line resolve duplicates identically (cross-module
+// contract, pinned by the golden parity tests).
 func lastOccurrences(fields []hc.Field) []int {
 	if len(fields) <= 24 {
 		var stack [24]int // allocation-free narrow path

--- a/adapter/zerolog/sink_test.go
+++ b/adapter/zerolog/sink_test.go
@@ -97,7 +97,7 @@ func TestSinkTypedFieldsAndDedupe(t *testing.T) {
 	emit(t, &buf, func(ctx context.Context) {
 		hc.Add(ctx, "s", "v", "i", 7, "b", true, "t", now, "d", 1500*time.Millisecond)
 		hc.Add(ctx, "k", "first", "k", "second")
-		hc.AddRawJSON(ctx, "meta", []byte(`{"raw":true}`))
+		hc.Add(ctx, "meta", json.RawMessage(`{"raw":true}`))
 	})
 
 	payload := lastPayload(t, &buf)

--- a/bench_test.go
+++ b/bench_test.go
@@ -1,5 +1,9 @@
 package hc
 
+// Benchmarks for the sampling gate and the record encode/write path —
+// the repo-wide root-module benchmark file (the cross-adapter and host
+// comparisons live in the benches module).
+
 import (
 	"context"
 	"io"

--- a/benches/golden_bridge_test.go
+++ b/benches/golden_bridge_test.go
@@ -37,7 +37,7 @@ func TestGoldenZerologBridgeParity(t *testing.T) {
 			hc.Add(ctx, "uni", "héllo ☃ 🍜", "nul", "x\x00y", "del", "d\x7f")
 		}, nil},
 		{"raw_json", func(ctx context.Context) {
-			hc.AddRawJSON(ctx, "meta", []byte(`{"nested":true,"n":1}`))
+			hc.Add(ctx, "meta", json.RawMessage(`{"nested":true,"n":1}`))
 		}, nil},
 		{"any_fallback", func(ctx context.Context) {
 			hc.Add(ctx, "obj", map[string]any{"a": 1}, "sl", []any{1, "x"}, "nil", nil)

--- a/cmd/examples/adapters_wire_test.go
+++ b/cmd/examples/adapters_wire_test.go
@@ -103,7 +103,7 @@ func drivePipeline(t *testing.T, sink gc.Sink, buf *bytes.Buffer, pipeline strin
 	srv.Close() // quiesce handlers before reading the buffer
 
 	out := make([]parsedWire, 0, len(wireCases))
-	for _, ln := range strings.Split(strings.TrimSpace(buf.String()), "\n") {
+	for ln := range strings.SplitSeq(strings.TrimSpace(buf.String()), "\n") {
 		if ln == "" {
 			continue
 		}

--- a/cmd/examples/adapters_wire_test.go
+++ b/cmd/examples/adapters_wire_test.go
@@ -72,25 +72,25 @@ func parseWireLine(t *testing.T, ln, pipeline string) parsedWire {
 	if err := json.Unmarshal([]byte(ln), &m); err != nil {
 		t.Fatalf("%s line unparseable: %v: %s", pipeline, err, ln)
 	}
-	st, _ := m["http.status"].(float64)
-	oc, _ := m["op.outcome"].(string)
-	rt, _ := m["op.name"].(string)
+	st, stOK := m["http.status"].(float64)
+	oc, ocOK := m["op.outcome"].(string)
+	rt, rtOK := m["op.name"].(string)
 	usr, _ := m["wire"].(string)
 	_, hasErr := m["error"]
-	if st == 0 || oc == "" || rt == "" {
-		t.Fatalf("%s: canonical fields missing: %v", pipeline, m)
+	if !stOK || !ocOK || !rtOK {
+		t.Fatalf("%s: canonical fields missing or mistyped: %v", pipeline, m)
 	}
 	return parsedWire{status: int64(st), outcome: oc, route: rt, user: usr, hasErr: hasErr}
 }
 
-// drive fires the wire cases at a real server built on the given real
-// sink, waits for the handlers to drain, and parses the pipeline's
-// emitted lines.
-func drive(t *testing.T, sink gc.Sink, buf *bytes.Buffer, pipeline string) []parsedWire {
+// drivePipeline fires the wire cases at a real server built on the
+// given real sink and parses the pipeline's emitted lines. The
+// explicit Close is load-bearing: client returns precede the server's
+// deferred emissions, and Close waits for outstanding handlers.
+func drivePipeline(t *testing.T, sink gc.Sink, buf *bytes.Buffer, pipeline string) []parsedWire {
 	t.Helper()
 	rt := gc.MustCompile(gc.Config{Sink: sink, SamplingRate: 1})
 	srv := httptest.NewServer(stdhc.Middleware(rt)(wireMux()))
-	defer srv.Close()
 
 	for _, c := range wireCases {
 		resp, err := srv.Client().Get(srv.URL + c.request)
@@ -100,9 +100,9 @@ func drive(t *testing.T, sink gc.Sink, buf *bytes.Buffer, pipeline string) []par
 		_, _ = io.Copy(io.Discard, resp.Body)
 		_ = resp.Body.Close()
 	}
-	srv.Close() // drain outstanding handlers before reading the buffer
+	srv.Close() // quiesce handlers before reading the buffer
 
-	var out []parsedWire
+	out := make([]parsedWire, 0, len(wireCases))
 	for _, ln := range strings.Split(strings.TrimSpace(buf.String()), "\n") {
 		if ln == "" {
 			continue
@@ -114,41 +114,47 @@ func drive(t *testing.T, sink gc.Sink, buf *bytes.Buffer, pipeline string) []par
 
 // TestAdaptersWireParity drives identical real traffic through every
 // real pipeline — first-party JSONSink, slog, zap, zerolog — and
-// asserts they agree on the canonical wire.
+// asserts BOTH the absolute canonical fields per pipeline AND that the
+// bridges agree with the JSONSink reference. Deterministic order
+// (jsonsink is the fixed reference), no map-iteration roulette.
 func TestAdaptersWireParity(t *testing.T) {
-	pipelines := map[string][]parsedWire{}
-
 	var jsonBuf bytes.Buffer
-	pipelines["jsonsink"] = drive(t, gc.NewJSONSink(&jsonBuf), &jsonBuf, "jsonsink")
+	reference := drivePipeline(t, gc.NewJSONSink(&jsonBuf), &jsonBuf, "jsonsink")
 
 	var slogBuf bytes.Buffer
-	pipelines["slog"] = drive(t, sloghc.New(slog.New(slog.NewJSONHandler(&slogBuf, nil))), &slogBuf, "slog")
+	slogEvents := drivePipeline(t, sloghc.New(slog.New(slog.NewJSONHandler(&slogBuf, nil))), &slogBuf, "slog")
 
 	var zapBuf bytes.Buffer
-	zapLogger := zap.New(zapcore.NewCore(zapcore.NewJSONEncoder(zapcore.EncoderConfig{TimeKey: "ts", LevelKey: "level", MessageKey: "msg", EncodeTime: zapcore.EpochTimeEncoder, EncodeLevel: zapcore.LowercaseLevelEncoder}), zapcore.AddSync(&zapBuf), zapcore.DebugLevel))
-	pipelines["zap"] = drive(t, zaphc.New(zapLogger), &zapBuf, "zap")
+	zapLogger := zap.New(zapcore.NewCore(zapcore.NewJSONEncoder(zapcore.EncoderConfig{TimeKey: "ts", LevelKey: "level", MessageKey: "msg", EncodeTime: zapcore.EpochTimeEncoder, EncodeLevel: zapcore.LowercaseLevelEncoder}), zapcore.Lock(zapcore.AddSync(&zapBuf)), zapcore.DebugLevel))
+	zapEvents := drivePipeline(t, zaphc.New(zapLogger), &zapBuf, "zap")
 
 	var zeroBuf bytes.Buffer
 	zl := zerolog.New(&zeroBuf)
-	pipelines["zerolog"] = drive(t, zerologhc.New(&zl), &zeroBuf, "zerolog")
+	zeroEvents := drivePipeline(t, zerologhc.New(&zl), &zeroBuf, "zerolog")
 
-	var reference []parsedWire
-	var refName string
-	for name, evs := range pipelines {
-		if len(evs) != len(wireCases) {
-			t.Fatalf("%s: %d events, want %d", name, len(evs), len(wireCases))
+	pipelines := []struct {
+		name   string
+		events []parsedWire
+	}{
+		{"jsonsink", reference},
+		{"slog", slogEvents},
+		{"zap", zapEvents},
+		{"zerolog", zeroEvents},
+	}
+	for _, pl := range pipelines {
+		if len(pl.events) != len(wireCases) {
+			t.Fatalf("%s: %d events, want %d", pl.name, len(pl.events), len(wireCases))
 		}
-		if reference == nil {
-			reference, refName = evs, name
-			continue
-		}
-		for i, ev := range evs {
+		for i, ev := range pl.events {
+			// Absolute checks for EVERY pipeline — a bridge regressing a
+			// canonical field must fail deterministically, not only when
+			// map iteration happens to make it the non-reference.
 			want := wireCases[i]
 			if ev.status != want.status || ev.outcome != want.outcome || ev.user != want.userField {
-				t.Fatalf("%s[%d] = %+v, want case %+v", name, i, ev, want)
+				t.Fatalf("%s[%d] = %+v, want case %+v", pl.name, i, ev, want)
 			}
 			if ev.route != reference[i].route || ev.hasErr != reference[i].hasErr {
-				t.Fatalf("%s[%d] diverges from %s: %+v vs %+v", name, i, refName, ev, reference[i])
+				t.Fatalf("%s[%d] diverges from jsonsink: %+v vs %+v", pl.name, i, ev, reference[i])
 			}
 		}
 	}

--- a/cmd/examples/adapters_wire_test.go
+++ b/cmd/examples/adapters_wire_test.go
@@ -91,6 +91,7 @@ func drivePipeline(t *testing.T, sink gc.Sink, buf *bytes.Buffer, pipeline strin
 	t.Helper()
 	rt := gc.MustCompile(gc.Config{Sink: sink, SamplingRate: 1})
 	srv := httptest.NewServer(stdhc.Middleware(rt)(wireMux()))
+	defer srv.Close() // safety net for early fatals; Close is idempotent
 
 	for _, c := range wireCases {
 		resp, err := srv.Client().Get(srv.URL + c.request)

--- a/crash_test.go
+++ b/crash_test.go
@@ -2022,11 +2022,9 @@ func TestSynctestConcurrentEndGatedSink(t *testing.T) {
 		var wg sync.WaitGroup
 		first := make([]bool, racers)
 		for i := range racers {
-			wg.Add(1)
-			go func(i int) {
-				defer wg.Done()
+			wg.Go(func() {
 				first[i] = op.End(nil)
-			}(i)
+			})
 		}
 		// The gate usually closes before the winner reaches Write, so
 		// the durable block is scheduling-dependent — the assertions
@@ -2068,9 +2066,7 @@ func TestSynctestArmedWritersAllExit(t *testing.T) {
 		stop := make(chan struct{})
 		var wg sync.WaitGroup
 		for w := range 6 {
-			wg.Add(1)
-			go func(w int) {
-				defer wg.Done()
+			wg.Go(func() {
 				for i := 0; ; i++ {
 					select {
 					case <-stop:
@@ -2079,7 +2075,7 @@ func TestSynctestArmedWritersAllExit(t *testing.T) {
 						Add(op.Context(), fmt.Sprintf("w%d", w), i)
 					}
 				}
-			}(w)
+			})
 		}
 		wg.Add(1)
 		go func() {
@@ -2170,11 +2166,9 @@ func TestSynctestStragglerStormBubble(t *testing.T) {
 			_ = op.End(nil)
 			var wg sync.WaitGroup
 			for s := range 8 {
-				wg.Add(1)
-				go func(s int) {
-					defer wg.Done()
+				wg.Go(func() {
 					Add(op.Context(), "straggler", s)
-				}(s)
+				})
 			}
 			wg.Wait()
 		}

--- a/crash_test.go
+++ b/crash_test.go
@@ -342,9 +342,7 @@ func TestCrashStragglerStormArmed(t *testing.T) {
 	const perWorker = 40
 	var wg sync.WaitGroup
 	for w := range workers {
-		wg.Add(1)
-		go func(w int) {
-			defer wg.Done()
+		wg.Go(func() {
 			for i := range perWorker {
 				op := Start(context.Background(), rt, OperationStart{Domain: DomainHTTP, Name: "request"})
 				op.ev.arm()
@@ -352,7 +350,8 @@ func TestCrashStragglerStormArmed(t *testing.T) {
 				_ = op.End(nil)
 				Add(op.Context(), "straggler", 1)
 			}
-		}(w)
+
+		})
 	}
 	wg.Wait()
 	evs := ts.Events()
@@ -412,9 +411,7 @@ func TestCrashSharedRuntimeAllDomains(t *testing.T) {
 	domains := []Domain{DomainHTTP, DomainJob, DomainMessage, DomainCLI, "custom"}
 	var wg sync.WaitGroup
 	for d := range domains {
-		wg.Add(1)
-		go func(d int) {
-			defer wg.Done()
+		wg.Go(func() {
 			for i := range 50 {
 				op := Start(context.Background(), rt, OperationStart{Domain: domains[d], Name: "x"})
 				Add(op.Context(), "i", i)
@@ -423,7 +420,8 @@ func TestCrashSharedRuntimeAllDomains(t *testing.T) {
 				}
 				_ = op.End(nil)
 			}
-		}(d)
+
+		})
 	}
 	wg.Wait()
 	evs := ts.Events()
@@ -444,11 +442,10 @@ func TestCrashConcurrentEndSlowSink(t *testing.T) {
 	res := make([]bool, racers)
 	var wg sync.WaitGroup
 	for i := range racers {
-		wg.Add(1)
-		go func(i int) {
-			defer wg.Done()
+		wg.Go(func() {
 			res[i] = op.End(nil)
-		}(i)
+
+		})
 	}
 	wg.Wait()
 	for i, r := range res {
@@ -1390,11 +1387,10 @@ func TestCrashConcurrentEndDistinctErrPtrs(t *testing.T) {
 		}
 		var wg sync.WaitGroup
 		for i := range errs {
-			wg.Add(1)
-			go func(i int) {
-				defer wg.Done()
+			wg.Go(func() {
 				_ = op.End(errs[i])
-			}(i)
+
+			})
 		}
 		wg.Wait()
 		evs := ts.Events()
@@ -1516,13 +1512,12 @@ func TestCrashConcurrentEncoded(t *testing.T) {
 	var wg sync.WaitGroup
 	lines := make([][]byte, n)
 	for g := range n {
-		wg.Add(1)
-		go func(g int) {
-			defer wg.Done()
+		wg.Go(func() {
 			for range iters {
 				lines[g] = rec.Encoded()
 			}
-		}(g)
+
+		})
 	}
 	wg.Wait()
 	for g := 1; g < n; g++ {
@@ -1585,11 +1580,10 @@ type fanoutSink struct {
 func (f *fanoutSink) Write(ctx context.Context, rec *Record) {
 	var wg sync.WaitGroup
 	for _, s := range f.inner {
-		wg.Add(1)
-		go func(s Sink) {
-			defer wg.Done()
+		wg.Go(func() {
 			s.Write(ctx, rec)
-		}(s)
+
+		})
 	}
 	wg.Wait()
 }
@@ -1602,15 +1596,14 @@ func TestCrashFanoutSinks(t *testing.T) {
 
 	var wg sync.WaitGroup
 	for w := range 8 {
-		wg.Add(1)
-		go func(w int) {
-			defer wg.Done()
+		wg.Go(func() {
 			for i := range 25 {
 				op := Start(context.Background(), rt, OperationStart{Domain: DomainHTTP, Name: "request"})
 				Add(op.Context(), "w", w, "i", i)
 				_ = op.End(nil)
 			}
-		}(w)
+
+		})
 	}
 	wg.Wait()
 
@@ -1672,9 +1665,7 @@ func TestCrashArmedMixedWritersSingleEnd(t *testing.T) {
 		stop := make(chan struct{})
 
 		for w := range 6 {
-			wg.Add(1)
-			go func(w int) {
-				defer wg.Done()
+			wg.Go(func() {
 				for i := 0; ; i++ {
 					select {
 					case <-stop:
@@ -1683,12 +1674,11 @@ func TestCrashArmedMixedWritersSingleEnd(t *testing.T) {
 					}
 					Add(op.Context(), fmt.Sprintf("w%d", w), i)
 				}
-			}(w)
+
+			})
 		}
 		for s := range 3 {
-			wg.Add(1)
-			go func(s int) {
-				defer wg.Done()
+			wg.Go(func() {
 				for i := 0; ; i++ {
 					select {
 					case <-stop:
@@ -1704,12 +1694,11 @@ func TestCrashArmedMixedWritersSingleEnd(t *testing.T) {
 						SetMessage(op.Context(), fmt.Sprintf("m-%d", i))
 					}
 				}
-			}(s)
+
+			})
 		}
 		// Watchdog-style snapshotter.
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			for {
 				select {
 				case <-stop:
@@ -1718,7 +1707,8 @@ func TestCrashArmedMixedWritersSingleEnd(t *testing.T) {
 					_ = op.ev.snapshotFields()
 				}
 			}
-		}()
+
+		})
 
 		_ = op.End(nil)
 		close(stop)
@@ -1745,9 +1735,7 @@ func TestCrashArmRacingSeal(t *testing.T) {
 
 		stop := make(chan struct{})
 		var wg sync.WaitGroup
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			for {
 				select {
 				case <-stop:
@@ -1756,7 +1744,8 @@ func TestCrashArmRacingSeal(t *testing.T) {
 					op.ev.arm()
 				}
 			}
-		}()
+
+		})
 		_ = op.End(nil)
 		close(stop)
 		wg.Wait()
@@ -1778,11 +1767,10 @@ func TestCrashArmedErrorVsSeal(t *testing.T) {
 		op.ev.arm()
 
 		var wg sync.WaitGroup
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			Error(op.Context(), fmt.Errorf("racing-%d", round))
-		}()
+
+		})
 		_ = op.End(nil)
 		wg.Wait()
 
@@ -1819,9 +1807,7 @@ func TestCrashSnapshotVsPostSealAppends(t *testing.T) {
 
 	stop := make(chan struct{})
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		for {
 			select {
 			case <-stop:
@@ -1830,7 +1816,7 @@ func TestCrashSnapshotVsPostSealAppends(t *testing.T) {
 				_ = op.ev.snapshotFields()
 			}
 		}
-	}()
+	})
 	Add(op.Context(), "k", "v")
 	_ = op.End(nil)
 	close(stop)
@@ -2077,9 +2063,7 @@ func TestSynctestArmedWritersAllExit(t *testing.T) {
 				}
 			})
 		}
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			for {
 				select {
 				case <-stop:
@@ -2088,7 +2072,8 @@ func TestSynctestArmedWritersAllExit(t *testing.T) {
 					_ = op.ev.snapshotFields()
 				}
 			}
-		}()
+
+		})
 		Add(op.Context(), "owner", "final")
 		_ = op.End(nil)
 		close(stop)

--- a/crash_test.go
+++ b/crash_test.go
@@ -350,7 +350,6 @@ func TestCrashStragglerStormArmed(t *testing.T) {
 				_ = op.End(nil)
 				Add(op.Context(), "straggler", 1)
 			}
-
 		})
 	}
 	wg.Wait()
@@ -420,7 +419,6 @@ func TestCrashSharedRuntimeAllDomains(t *testing.T) {
 				}
 				_ = op.End(nil)
 			}
-
 		})
 	}
 	wg.Wait()
@@ -444,7 +442,6 @@ func TestCrashConcurrentEndSlowSink(t *testing.T) {
 	for i := range racers {
 		wg.Go(func() {
 			res[i] = op.End(nil)
-
 		})
 	}
 	wg.Wait()
@@ -1389,7 +1386,6 @@ func TestCrashConcurrentEndDistinctErrPtrs(t *testing.T) {
 		for i := range errs {
 			wg.Go(func() {
 				_ = op.End(errs[i])
-
 			})
 		}
 		wg.Wait()
@@ -1516,7 +1512,6 @@ func TestCrashConcurrentEncoded(t *testing.T) {
 			for range iters {
 				lines[g] = rec.Encoded()
 			}
-
 		})
 	}
 	wg.Wait()
@@ -1582,7 +1577,6 @@ func (f *fanoutSink) Write(ctx context.Context, rec *Record) {
 	for _, s := range f.inner {
 		wg.Go(func() {
 			s.Write(ctx, rec)
-
 		})
 	}
 	wg.Wait()
@@ -1602,7 +1596,6 @@ func TestCrashFanoutSinks(t *testing.T) {
 				Add(op.Context(), "w", w, "i", i)
 				_ = op.End(nil)
 			}
-
 		})
 	}
 	wg.Wait()
@@ -1674,7 +1667,6 @@ func TestCrashArmedMixedWritersSingleEnd(t *testing.T) {
 					}
 					Add(op.Context(), fmt.Sprintf("w%d", w), i)
 				}
-
 			})
 		}
 		for s := range 3 {
@@ -1694,7 +1686,6 @@ func TestCrashArmedMixedWritersSingleEnd(t *testing.T) {
 						SetMessage(op.Context(), fmt.Sprintf("m-%d", i))
 					}
 				}
-
 			})
 		}
 		// Watchdog-style snapshotter.
@@ -1707,7 +1698,6 @@ func TestCrashArmedMixedWritersSingleEnd(t *testing.T) {
 					_ = op.ev.snapshotFields()
 				}
 			}
-
 		})
 
 		_ = op.End(nil)
@@ -1744,7 +1734,6 @@ func TestCrashArmRacingSeal(t *testing.T) {
 					op.ev.arm()
 				}
 			}
-
 		})
 		_ = op.End(nil)
 		close(stop)
@@ -1769,7 +1758,6 @@ func TestCrashArmedErrorVsSeal(t *testing.T) {
 		var wg sync.WaitGroup
 		wg.Go(func() {
 			Error(op.Context(), fmt.Errorf("racing-%d", round))
-
 		})
 		_ = op.End(nil)
 		wg.Wait()
@@ -2072,7 +2060,6 @@ func TestSynctestArmedWritersAllExit(t *testing.T) {
 					_ = op.ev.snapshotFields()
 				}
 			}
-
 		})
 		Add(op.Context(), "owner", "final")
 		_ = op.End(nil)
@@ -2176,4 +2163,73 @@ func snapshotLookup(fields []Field, key string) (any, bool) {
 		}
 	}
 	return nil, false
+}
+
+// TestCrashWrappedTypedNilContained pins the containment against
+// %w-wrapped typed-nils: isTypedNilError inspects only the outermost
+// error, so the wrap chain's inner nil deref used to panic inside End
+// AFTER its recover — losing the event and masking any in-flight
+// panic. safeErrorMessage fences it (found by the GLM-5.3 core audit).
+type wrappedNilErr struct{ msg string }
+
+func (e *wrappedNilErr) Error() string { return e.msg }
+
+func TestCrashWrappedTypedNilContained(t *testing.T) {
+	var pe *wrappedNilErr
+	rt, ts := testRT(t, nil)
+	op := Start(context.Background(), rt, OperationStart{Domain: DomainJob, Name: "j"})
+	Error(op.Context(), fmt.Errorf("job failed: %w", pe))
+	Add(op.Context(), "e2", fmt.Errorf("join: %w", pe))
+	if !op.End(nil) {
+		t.Fatal("wrapped typed-nil dropped the event")
+	}
+	if len(ts.Events()) != 1 {
+		t.Fatalf("events = %d", len(ts.Events()))
+	}
+	rec := recOf(LevelInfo, "m", ts.Events()[0].Fields()...)
+	if !json.Valid(rec.Encoded()) {
+		t.Fatalf("line invalid: %s", rec.Encoded())
+	}
+}
+
+// TestCrashPanickingErrorContained fences arbitrary panicking Error()
+// implementations through the error-metainfo path.
+type boomErr struct{}
+
+func (boomErr) Error() string { panic("boom") }
+
+func TestCrashPanickingErrorContained(t *testing.T) {
+	rt, ts := testRT(t, nil)
+	op := Start(context.Background(), rt, OperationStart{Domain: DomainJob, Name: "j"})
+	Error(op.Context(), boomErr{})
+	if !op.End(nil) || len(ts.Events()) != 1 {
+		t.Fatal("panicking Error() implementation lost the event")
+	}
+	rec := recOf(LevelInfo, "m", ts.Events()[0].Fields()...)
+	if !json.Valid(rec.Encoded()) {
+		t.Fatalf("line invalid: %s", rec.Encoded())
+	}
+}
+
+// TestCrashEmptyRawJSONNoop pins the nil/empty AddRawJSON contract: a
+// zero-length blob is skipped, not emitted as a bare "key": member
+// (which corrupted the canonical line).
+func TestCrashEmptyRawJSONNoop(t *testing.T) {
+	rt, ts := testRT(t, nil)
+	op := Start(context.Background(), rt, OperationStart{Domain: DomainJob, Name: "j"})
+	AddRawJSON(op.Context(), "blob", nil)
+	AddRawJSON(op.Context(), "empty", []byte{})
+	Add(op.Context(), "after", 1)
+	_ = op.End(nil)
+	rec := recOf(LevelInfo, "m", ts.Events()[0].Fields()...)
+	line := string(rec.Encoded())
+	if !json.Valid(rec.Encoded()) {
+		t.Fatalf("line invalid: %s", line)
+	}
+	if strings.Contains(line, "\"blob\":,") || strings.Contains(line, "\"empty\":,") {
+		t.Fatalf("bare member emitted: %s", line)
+	}
+	if v, _ := ts.Events()[0].Lookup("after"); v != int64(1) {
+		t.Fatalf("sibling lost: %v", v)
+	}
 }

--- a/crash_test.go
+++ b/crash_test.go
@@ -573,38 +573,6 @@ func TestCrashFloatEdgeValues(t *testing.T) {
 	}
 }
 
-func TestCrashRawJSONInjection(t *testing.T) {
-	// Contract: AddRawJSON appends verbatim, no sanitization. Pin that
-	// invalid blobs produce an unparseable line WITHOUT panicking —
-	// the caller owned those bytes. (KindRaw fields constructed
-	// directly: recOf's fieldOf would type a []byte as KindAny, which
-	// the encoder renders base64 — itself worth pinning.)
-	rec := recOf(LevelInfo, "m", Field{key: "raw", kind: KindRaw, val: []byte(`{"broken":`)})
-	if rec.Encoded() == nil {
-		t.Fatal("encode returned nil")
-	}
-	if json.Valid(rec.Encoded()) {
-		t.Fatalf("invalid raw unexpectedly produced valid JSON: %s", rec.Encoded())
-	}
-	rec2 := recOf(LevelInfo, "m", Field{key: "raw", kind: KindRaw, val: []byte(`}}}}} early-close`)})
-	if rec2.Encoded() == nil {
-		t.Fatal("encode returned nil")
-	}
-	// A plain []byte through Add renders base64 (json.Marshal shape).
-	recB64 := recOf(LevelInfo, "m", fieldOf("bytes", []byte(`{"ok":[1,2]}`)))
-	mb := mustParseLine(t, recB64.Encoded())
-	if s, _ := mb["bytes"].(string); s != "eyJvayI6WzEsMl19" {
-		t.Fatalf("[]byte not base64: %#v", mb["bytes"])
-	}
-	// Valid raw still embeds verbatim.
-	rec3 := recOf(LevelInfo, "m", Field{key: "raw", kind: KindRaw, val: []byte(`{"ok":[1,2]}`)})
-	m := mustParseLine(t, rec3.Encoded())
-	raw, _ := m["raw"].(map[string]any)
-	if raw == nil || raw["ok"] == nil {
-		t.Fatalf("valid raw JSON not embedded: %s", rec3.Encoded())
-	}
-}
-
 func TestCrashExtremeFieldCounts(t *testing.T) {
 	for _, n := range []int{0, 1, 23, 24, 25, 1023, 1024, 1025, 5000} {
 		fields := make([]Field, n)
@@ -912,9 +880,6 @@ func TestCrashNilReceiversAndArgs(t *testing.T) {
 	//lint:ignore SA1012 nil contexts are this test's charter
 	Add(nil, "k", "v")
 	Add(context.Background(), "k", "v")
-	//lint:ignore SA1012 nil contexts are this test's charter
-	AddRawJSON(nil, "k", []byte(`{}`))
-	AddRawJSON(context.Background(), "k", nil)
 	//lint:ignore SA1012 nil contexts are this test's charter
 	Error(nil, nil)
 	Error(context.Background(), nil)
@@ -1464,28 +1429,6 @@ func TestCrashStartOnCanceledContext(t *testing.T) {
 	Add(op.Context(), "k", "v")
 	if !op.End(nil) || len(ts.Events()) != 1 {
 		t.Fatal("canceled parent context broke the lifecycle")
-	}
-}
-
-// AddRawJSON keeps the caller's []byte by reference: mutating the blob
-// between Add and End is visible on the wire (torn JSON, silently).
-// Pin the lifetime contract: encode before you reuse the buffer.
-func TestCrashRawJSONBlobLifetime(t *testing.T) {
-	rt, ts := testRT(t, nil)
-	op := Start(context.Background(), rt, OperationStart{Domain: DomainJob, Name: "j"})
-	blob := []byte(`{"v":1}`)
-	AddRawJSON(op.Context(), "raw", blob)
-	blob[5] = '9' // caller mutates before End
-	_ = op.End(nil)
-
-	ev := ts.Events()[0]
-	raw, ok := ev.Lookup("raw")
-	if !ok {
-		t.Fatal("raw field missing")
-	}
-	b, _ := raw.([]byte)
-	if string(b) != `{"v":9}` {
-		t.Fatalf("raw blob was copied at Add time: %q (lifetime contract is by-reference)", b)
 	}
 }
 
@@ -2208,28 +2151,5 @@ func TestCrashPanickingErrorContained(t *testing.T) {
 	rec := recOf(LevelInfo, "m", ts.Events()[0].Fields()...)
 	if !json.Valid(rec.Encoded()) {
 		t.Fatalf("line invalid: %s", rec.Encoded())
-	}
-}
-
-// TestCrashEmptyRawJSONNoop pins the nil/empty AddRawJSON contract: a
-// zero-length blob is skipped, not emitted as a bare "key": member
-// (which corrupted the canonical line).
-func TestCrashEmptyRawJSONNoop(t *testing.T) {
-	rt, ts := testRT(t, nil)
-	op := Start(context.Background(), rt, OperationStart{Domain: DomainJob, Name: "j"})
-	AddRawJSON(op.Context(), "blob", nil)
-	AddRawJSON(op.Context(), "empty", []byte{})
-	Add(op.Context(), "after", 1)
-	_ = op.End(nil)
-	rec := recOf(LevelInfo, "m", ts.Events()[0].Fields()...)
-	line := string(rec.Encoded())
-	if !json.Valid(rec.Encoded()) {
-		t.Fatalf("line invalid: %s", line)
-	}
-	if strings.Contains(line, "\"blob\":,") || strings.Contains(line, "\"empty\":,") {
-		t.Fatalf("bare member emitted: %s", line)
-	}
-	if v, _ := ts.Events()[0].Lookup("after"); v != int64(1) {
-		t.Fatalf("sibling lost: %v", v)
 	}
 }

--- a/crash_test.go
+++ b/crash_test.go
@@ -19,6 +19,7 @@ package hc
 //   K  adversarial fuzz targets (values, armed interleavings)
 //   L  armed-mode DST (mixed writers vs single End, arm-vs-seal)
 //   N  testing/synctest bubbles (per-test goroutine hygiene, watchdog)
+//      (M was the ad-hoc live-chaos runs; intentionally not a file here)
 
 import (
 	"context"
@@ -560,6 +561,8 @@ func TestCrashCyclicAnyValue(t *testing.T) {
 }
 
 func TestCrashFloatEdgeValues(t *testing.T) {
+	// Untyped constant -0.0 is +0 (constants carry no sign) — Copysign
+	// is the only way to obtain a real negative zero.
 	negZero := math.Copysign(0, -1)
 	vals := []float64{math.NaN(), math.Inf(1), math.Inf(-1), math.SmallestNonzeroFloat64, math.MaxFloat64, negZero}
 	for _, v := range vals {
@@ -850,6 +853,12 @@ func TestCrashHostileRates(t *testing.T) {
 	inf := math.Inf(1)
 	if _, err := Compile(Config{OperationPolicies: map[Domain]OperationPolicy{"job": {SamplingRate: &inf}}}); err == nil {
 		t.Fatal("+Inf policy rate accepted")
+	}
+	// Nested NaN in the level map: TestCompileSentinels covers only the
+	// global rate and plain out-of-range map values — keep this one
+	// deterministic rather than fuzz-only.
+	if _, err := Compile(Config{LevelSamplingRates: map[Level]float64{LevelInfo: math.NaN()}}); err == nil {
+		t.Fatal("NaN level rate accepted")
 	}
 }
 

--- a/example_test.go
+++ b/example_test.go
@@ -60,7 +60,7 @@ func ExampleCompile() {
 	}
 	hc.Start(context.Background(), rt, hc.OperationStart{Domain: hc.DomainJob, Name: "j"}).End(nil)
 	// Output:
-	// hc: sampling rate 1.5: hc: invalid rate
+	// hc: sampling rate 1.5: invalid rate
 	// true
 	// INFO operation_completed op.domain="job" op.name="j" op.outcome="success"
 }

--- a/example_test.go
+++ b/example_test.go
@@ -94,11 +94,11 @@ func ExampleStart() {
 		defer op.End(&err) // direct defer: captures errors and panics
 
 		hc.Add(op.Context(), "rows", 42, "source", "queue")
-		hc.AddRawJSON(op.Context(), "meta", []byte(`{"batch":true}`))
+		hc.Add(op.Context(), "meta", json.RawMessage(`{"batch":true}`))
 		return errors.New("row 17 failed")
 	}()
 	// Output:
-	// ERROR operation_completed error={"message":"row 17 failed","type":"*errors.errorString"} meta="eyJiYXRjaCI6dHJ1ZX0=" op.attempt=2 op.domain="job" op.id="job_1" op.max_attempts=3 op.name="import" op.outcome="failure" rows=42 source="queue"
+	// ERROR operation_completed error={"message":"row 17 failed","type":"*errors.errorString"} meta={"batch":true} op.attempt=2 op.domain="job" op.id="job_1" op.max_attempts=3 op.name="import" op.outcome="failure" rows=42 source="queue"
 }
 
 // ExampleOperation_End demonstrates the deferred idiom and the

--- a/field.go
+++ b/field.go
@@ -186,12 +186,6 @@ func fieldOf(key string, value any) Field {
 func fieldStr(key, value string) Field     { return Field{key: key, kind: KindString, str: value} }
 func fieldInt64(key string, v int64) Field { return Field{key: key, kind: KindInt, num: v} }
 
-// fieldAny returns a KindAny field (used for the canonical structured
-// error/panic maps).
-func fieldAny(key string, value any) Field {
-	return Field{key: key, kind: KindAny, val: value}
-}
-
 // valueOf converts a Field back to an any, mirroring the v0 map-based
 // values (used by Lookup and the TestSink).
 func valueOf(f Field) any {

--- a/field.go
+++ b/field.go
@@ -20,7 +20,6 @@ const (
 	KindTime
 	KindDuration
 	KindErr
-	KindRaw
 	KindAny
 )
 
@@ -36,7 +35,7 @@ type Field struct {
 	b   bool    // KindBool
 	str string  // KindString
 	t   time.Time
-	val any // KindErr (error), KindRaw ([]byte), KindAny
+	val any // KindErr (error), KindAny
 }
 
 // Key returns the field key as written on the WAL (unaliased).
@@ -117,18 +116,8 @@ func (f Field) Err() (err error, ok bool) {
 	return nil, false
 }
 
-// Raw returns the pre-encoded JSON bytes for raw kinds.
-func (f Field) Raw() (raw []byte, ok bool) {
-	if f.kind == KindRaw {
-		if b, isBytes := f.val.([]byte); isBytes {
-			return b, true
-		}
-	}
-	return nil, false
-}
-
 // Any returns the value for any-kinds. It never boxes: typed kinds
-// (including error and raw) return nil — use Err() and Raw().
+// (including error) return nil — use Err().
 func (f Field) Any() any {
 	if f.kind == KindAny {
 		return f.val
@@ -206,7 +195,7 @@ func valueOf(f Field) any {
 		return f.t
 	case KindDuration:
 		return time.Duration(f.num)
-	case KindErr, KindRaw, KindAny:
+	case KindErr, KindAny:
 		return f.val
 	default:
 		return nil

--- a/hc.go
+++ b/hc.go
@@ -40,29 +40,6 @@ func Add(ctx context.Context, key string, value any, kv ...any) {
 	ref.ev.addKV(ref, key, value, kv...)
 }
 
-// AddRawJSON attaches pre-encoded JSON under key without re-escaping;
-// the escape scan is skipped entirely for blobs the caller already
-// encoded once.
-// A nil or empty blob is a no-op: appending zero bytes would leave a
-// bare "key": member and corrupt the canonical line.
-//
-// For validated embedding through the regular path, pass
-// json.RawMessage to Add instead: it is a []byte that asserts
-// JSON-ness via its MarshalJSON contract, so Add embeds it verbatim
-// AND every bridge (slog/zap/zerolog, which all honor MarshalJSON)
-// renders it identically — AddRawJSON is the zero-parse fast lane
-// where the caller alone guarantees validity. A plain []byte through
-// Add is deliberately base64 (the encoding/json contract for binary
-// data, matched by all three host loggers).
-func AddRawJSON(ctx context.Context, key string, raw []byte) {
-	if len(raw) == 0 {
-		return
-	}
-	if ref := eventFromContext(ctx); ref != nil {
-		ref.ev.setRaw(ref, key, raw)
-	}
-}
-
 // Error records err on the request's event as the structured canonical
 // error field.
 func Error(ctx context.Context, err error) {

--- a/hc.go
+++ b/hc.go
@@ -45,6 +45,15 @@ func Add(ctx context.Context, key string, value any, kv ...any) {
 // encoded once.
 // A nil or empty blob is a no-op: appending zero bytes would leave a
 // bare "key": member and corrupt the canonical line.
+//
+// For validated embedding through the regular path, pass
+// json.RawMessage to Add instead: it is a []byte that asserts
+// JSON-ness via its MarshalJSON contract, so Add embeds it verbatim
+// AND every bridge (slog/zap/zerolog, which all honor MarshalJSON)
+// renders it identically — AddRawJSON is the zero-parse fast lane
+// where the caller alone guarantees validity. A plain []byte through
+// Add is deliberately base64 (the encoding/json contract for binary
+// data, matched by all three host loggers).
 func AddRawJSON(ctx context.Context, key string, raw []byte) {
 	if len(raw) == 0 {
 		return

--- a/hc.go
+++ b/hc.go
@@ -23,6 +23,11 @@ func eventFromContext(ctx context.Context) *walRef {
 //
 // Additional pairs may be passed variadically: Add(ctx, "a", 1, "b", 2).
 // Every pair key must be a string; malformed tails are skipped.
+//
+// The request goroutine is the sole writer: passing the enriched
+// context to child goroutines is fine, but hc.Add from a child
+// goroutine racing the request's own writes is a data race — fan
+// results back over a channel and Add them on the request goroutine.
 func Add(ctx context.Context, key string, value any, kv ...any) {
 	ref := eventFromContext(ctx)
 	if ref == nil {
@@ -38,7 +43,12 @@ func Add(ctx context.Context, key string, value any, kv ...any) {
 // AddRawJSON attaches pre-encoded JSON under key without re-escaping;
 // the escape scan is skipped entirely for blobs the caller already
 // encoded once.
+// A nil or empty blob is a no-op: appending zero bytes would leave a
+// bare "key": member and corrupt the canonical line.
 func AddRawJSON(ctx context.Context, key string, raw []byte) {
+	if len(raw) == 0 {
+		return
+	}
 	if ref := eventFromContext(ctx); ref != nil {
 		ref.ev.setRaw(ref, key, raw)
 	}

--- a/integration/echo/middleware_test.go
+++ b/integration/echo/middleware_test.go
@@ -30,14 +30,14 @@ func TestMiddlewareCapturesRouteAndFields(t *testing.T) {
 	if len(events) != 1 {
 		t.Fatalf("expected 1 event, got %d", len(events))
 	}
-	if intField(events[0], "http.status") != http.StatusAccepted {
-		t.Fatalf("expected status %d, got %v", http.StatusAccepted, intField(events[0], "http.status"))
+	if statusField(events[0], "http.status") != http.StatusAccepted {
+		t.Fatalf("expected status %d, got %v", http.StatusAccepted, statusField(events[0], "http.status"))
 	}
-	if fieldOf(events[0], "http.route") != "/orders/:id" {
-		t.Fatalf("expected route template, got %v", fieldOf(events[0], "http.route"))
+	if fieldValue(events[0], "http.route") != "/orders/:id" {
+		t.Fatalf("expected route template, got %v", fieldValue(events[0], "http.route"))
 	}
-	if fieldOf(events[0], "user_id") != "u_1" {
-		t.Fatalf("expected user_id field, got %v", fieldOf(events[0], "user_id"))
+	if fieldValue(events[0], "user_id") != "u_1" {
+		t.Fatalf("expected user_id field, got %v", fieldValue(events[0], "user_id"))
 	}
 }
 
@@ -82,10 +82,10 @@ func TestMiddlewareErrorAndSamplingBehavior(t *testing.T) {
 	if events[0].Level() != hc.LevelError {
 		t.Fatalf("level = %s, want ERROR", events[0].Level())
 	}
-	if intField(events[0], "http.status") != http.StatusInternalServerError {
-		t.Fatalf("status = %v, want %d", intField(events[0], "http.status"), http.StatusInternalServerError)
+	if statusField(events[0], "http.status") != http.StatusInternalServerError {
+		t.Fatalf("status = %v, want %d", statusField(events[0], "http.status"), http.StatusInternalServerError)
 	}
-	if _, ok := fieldOf(events[0], "error").(map[string]any); !ok {
+	if _, ok := fieldValue(events[0], "error").(map[string]any); !ok {
 		t.Fatalf("expected structured error field")
 	}
 }
@@ -117,13 +117,13 @@ func TestMiddlewarePanicLogsAndPropagates(t *testing.T) {
 	if len(events) != 1 {
 		t.Fatalf("expected 1 event, got %d", len(events))
 	}
-	if fieldOf(events[0], "http.route") != "/panic/:id" {
-		t.Fatalf("route = %v", fieldOf(events[0], "http.route"))
+	if fieldValue(events[0], "http.route") != "/panic/:id" {
+		t.Fatalf("route = %v", fieldValue(events[0], "http.route"))
 	}
-	if intField(events[0], "http.status") != http.StatusInternalServerError {
-		t.Fatalf("status = %v, want %d", intField(events[0], "http.status"), http.StatusInternalServerError)
+	if statusField(events[0], "http.status") != http.StatusInternalServerError {
+		t.Fatalf("status = %v, want %d", statusField(events[0], "http.status"), http.StatusInternalServerError)
 	}
-	if _, ok := fieldOf(events[0], "panic").(map[string]any); !ok {
+	if _, ok := fieldValue(events[0], "panic").(map[string]any); !ok {
 		t.Fatalf("expected panic metadata")
 	}
 }
@@ -144,8 +144,8 @@ func TestMiddlewareEchoHTTPErrorKeepsHTTPStatus(t *testing.T) {
 	if len(events) != 1 {
 		t.Fatalf("expected 1 event, got %d", len(events))
 	}
-	if intField(events[0], "http.status") != http.StatusForbidden {
-		t.Fatalf("status = %v, want %d", intField(events[0], "http.status"), http.StatusForbidden)
+	if statusField(events[0], "http.status") != http.StatusForbidden {
+		t.Fatalf("status = %v, want %d", statusField(events[0], "http.status"), http.StatusForbidden)
 	}
 	if events[0].Level() != hc.LevelError {
 		t.Fatalf("level = %s, want ERROR", events[0].Level())
@@ -199,8 +199,8 @@ func TestMiddlewareLogsStatusFromCustomEchoErrorHandler(t *testing.T) {
 	if len(events) != 1 {
 		t.Fatalf("expected 1 event, got %d", len(events))
 	}
-	if intField(events[0], "http.status") != http.StatusTeapot {
-		t.Fatalf("status = %v, want %d", intField(events[0], "http.status"), http.StatusTeapot)
+	if statusField(events[0], "http.status") != http.StatusTeapot {
+		t.Fatalf("status = %v, want %d", statusField(events[0], "http.status"), http.StatusTeapot)
 	}
 	if events[0].Level() != hc.LevelError {
 		t.Fatalf("level = %s, want ERROR", events[0].Level())
@@ -210,14 +210,15 @@ func TestMiddlewareLogsStatusFromCustomEchoErrorHandler(t *testing.T) {
 // capturedEvent mirrors the v0 test-facing shape (map fields, int
 // numerics) over the v2 TestSink capture, keeping the assertions below
 // unchanged from the v0 suite.
-// Typed field access on captured events (Lookup carries int64; the
-// constants in these tests are ints).
-func fieldOf(ev hc.CapturedEvent, key string) any {
+// Typed field reads on captured events: fieldValue for any value,
+// statusField for the int64 http.status these tests compare against
+// int constants.
+func fieldValue(ev hc.CapturedEvent, key string) any {
 	v, _ := ev.Lookup(key)
 	return v
 }
 
-func intField(ev hc.CapturedEvent, key string) int64 {
+func statusField(ev hc.CapturedEvent, key string) int64 {
 	v, _ := ev.Lookup(key)
 	n, _ := v.(int64)
 	return n

--- a/integration/fiber/middleware_test.go
+++ b/integration/fiber/middleware_test.go
@@ -36,14 +36,14 @@ func TestMiddlewareCapturesRouteAndFields(t *testing.T) {
 	if len(events) != 1 {
 		t.Fatalf("expected 1 event, got %d", len(events))
 	}
-	if intField(events[0], "http.status") != http.StatusNoContent {
-		t.Fatalf("expected status %d, got %v", http.StatusNoContent, intField(events[0], "http.status"))
+	if statusField(events[0], "http.status") != http.StatusNoContent {
+		t.Fatalf("expected status %d, got %v", http.StatusNoContent, statusField(events[0], "http.status"))
 	}
-	if fieldOf(events[0], "http.route") != "/orders/:id" {
-		t.Fatalf("expected route template, got %v", fieldOf(events[0], "http.route"))
+	if fieldValue(events[0], "http.route") != "/orders/:id" {
+		t.Fatalf("expected route template, got %v", fieldValue(events[0], "http.route"))
 	}
-	if fieldOf(events[0], "user_id") != "u_1" {
-		t.Fatalf("expected user_id field, got %v", fieldOf(events[0], "user_id"))
+	if fieldValue(events[0], "user_id") != "u_1" {
+		t.Fatalf("expected user_id field, got %v", fieldValue(events[0], "user_id"))
 	}
 }
 
@@ -92,10 +92,10 @@ func TestMiddlewareErrorAndSamplingBehavior(t *testing.T) {
 	if events[0].Level() != hc.LevelError {
 		t.Fatalf("level = %s, want ERROR", events[0].Level())
 	}
-	if intField(events[0], "http.status") != http.StatusInternalServerError {
-		t.Fatalf("status = %v, want %d", intField(events[0], "http.status"), http.StatusInternalServerError)
+	if statusField(events[0], "http.status") != http.StatusInternalServerError {
+		t.Fatalf("status = %v, want %d", statusField(events[0], "http.status"), http.StatusInternalServerError)
 	}
-	if _, ok := fieldOf(events[0], "error").(map[string]any); !ok {
+	if _, ok := fieldValue(events[0], "error").(map[string]any); !ok {
 		t.Fatalf("expected structured error field")
 	}
 }
@@ -119,13 +119,13 @@ func TestMiddlewarePanicLogsAndPropagates(t *testing.T) {
 	if len(events) != 1 {
 		t.Fatalf("expected 1 event, got %d", len(events))
 	}
-	if fieldOf(events[0], "http.route") != "/panic/:id" {
-		t.Fatalf("route = %v", fieldOf(events[0], "http.route"))
+	if fieldValue(events[0], "http.route") != "/panic/:id" {
+		t.Fatalf("route = %v", fieldValue(events[0], "http.route"))
 	}
-	if intField(events[0], "http.status") != http.StatusInternalServerError {
-		t.Fatalf("status = %v, want %d", intField(events[0], "http.status"), http.StatusInternalServerError)
+	if statusField(events[0], "http.status") != http.StatusInternalServerError {
+		t.Fatalf("status = %v, want %d", statusField(events[0], "http.status"), http.StatusInternalServerError)
 	}
-	if _, ok := fieldOf(events[0], "panic").(map[string]any); !ok {
+	if _, ok := fieldValue(events[0], "panic").(map[string]any); !ok {
 		t.Fatalf("expected panic metadata")
 	}
 }
@@ -148,8 +148,8 @@ func TestMiddlewareFiberErrorKeepsHTTPStatus(t *testing.T) {
 	if len(events) != 1 {
 		t.Fatalf("expected 1 event, got %d", len(events))
 	}
-	if intField(events[0], "http.status") != http.StatusTooManyRequests {
-		t.Fatalf("status = %v, want %d", intField(events[0], "http.status"), http.StatusTooManyRequests)
+	if statusField(events[0], "http.status") != http.StatusTooManyRequests {
+		t.Fatalf("status = %v, want %d", statusField(events[0], "http.status"), http.StatusTooManyRequests)
 	}
 	if events[0].Level() != hc.LevelError {
 		t.Fatalf("level = %s, want ERROR", events[0].Level())
@@ -207,8 +207,8 @@ func TestMiddlewareLogsStatusFromCustomFiberErrorHandler(t *testing.T) {
 	if len(events) != 1 {
 		t.Fatalf("expected 1 event, got %d", len(events))
 	}
-	if intField(events[0], "http.status") != http.StatusTeapot {
-		t.Fatalf("status = %v, want %d", intField(events[0], "http.status"), http.StatusTeapot)
+	if statusField(events[0], "http.status") != http.StatusTeapot {
+		t.Fatalf("status = %v, want %d", statusField(events[0], "http.status"), http.StatusTeapot)
 	}
 	if events[0].Level() != hc.LevelError {
 		t.Fatalf("level = %s, want ERROR", events[0].Level())
@@ -247,7 +247,7 @@ func TestMiddlewareReturnsCustomFiberErrorHandlerFailure(t *testing.T) {
 	if len(events) != 1 {
 		t.Fatalf("expected 1 event, got %d", len(events))
 	}
-	errField, ok := fieldOf(events[0], "error").(map[string]any)
+	errField, ok := fieldValue(events[0], "error").(map[string]any)
 	if !ok {
 		t.Fatal("expected structured error field")
 	}
@@ -259,14 +259,15 @@ func TestMiddlewareReturnsCustomFiberErrorHandlerFailure(t *testing.T) {
 // capturedEvent mirrors the v0 test-facing shape (map fields, int
 // numerics) over the v2 TestSink capture, keeping the assertions below
 // unchanged from the v0 suite.
-// Typed field access on captured events (Lookup carries int64; the
-// constants in these tests are ints).
-func fieldOf(ev hc.CapturedEvent, key string) any {
+// Typed field reads on captured events: fieldValue for any value,
+// statusField for the int64 http.status these tests compare against
+// int constants.
+func fieldValue(ev hc.CapturedEvent, key string) any {
 	v, _ := ev.Lookup(key)
 	return v
 }
 
-func intField(ev hc.CapturedEvent, key string) int64 {
+func statusField(ev hc.CapturedEvent, key string) int64 {
 	v, _ := ev.Lookup(key)
 	n, _ := v.(int64)
 	return n

--- a/integration/fiberv3/middleware_test.go
+++ b/integration/fiberv3/middleware_test.go
@@ -36,14 +36,14 @@ func TestMiddlewareCapturesRouteAndFields(t *testing.T) {
 	if len(events) != 1 {
 		t.Fatalf("expected 1 event, got %d", len(events))
 	}
-	if intField(events[0], "http.status") != http.StatusNoContent {
-		t.Fatalf("expected status %d, got %v", http.StatusNoContent, intField(events[0], "http.status"))
+	if statusField(events[0], "http.status") != http.StatusNoContent {
+		t.Fatalf("expected status %d, got %v", http.StatusNoContent, statusField(events[0], "http.status"))
 	}
-	if fieldOf(events[0], "http.route") != "/orders/:id" {
-		t.Fatalf("expected route template, got %v", fieldOf(events[0], "http.route"))
+	if fieldValue(events[0], "http.route") != "/orders/:id" {
+		t.Fatalf("expected route template, got %v", fieldValue(events[0], "http.route"))
 	}
-	if fieldOf(events[0], "user_id") != "u_1" {
-		t.Fatalf("expected user_id field, got %v", fieldOf(events[0], "user_id"))
+	if fieldValue(events[0], "user_id") != "u_1" {
+		t.Fatalf("expected user_id field, got %v", fieldValue(events[0], "user_id"))
 	}
 }
 
@@ -92,10 +92,10 @@ func TestMiddlewareErrorAndSamplingBehavior(t *testing.T) {
 	if events[0].Level() != hc.LevelError {
 		t.Fatalf("level = %s, want ERROR", events[0].Level())
 	}
-	if intField(events[0], "http.status") != http.StatusInternalServerError {
-		t.Fatalf("status = %v, want %d", intField(events[0], "http.status"), http.StatusInternalServerError)
+	if statusField(events[0], "http.status") != http.StatusInternalServerError {
+		t.Fatalf("status = %v, want %d", statusField(events[0], "http.status"), http.StatusInternalServerError)
 	}
-	if _, ok := fieldOf(events[0], "error").(map[string]any); !ok {
+	if _, ok := fieldValue(events[0], "error").(map[string]any); !ok {
 		t.Fatalf("expected structured error field")
 	}
 }
@@ -119,13 +119,13 @@ func TestMiddlewarePanicLogsAndPropagates(t *testing.T) {
 	if len(events) != 1 {
 		t.Fatalf("expected 1 event, got %d", len(events))
 	}
-	if fieldOf(events[0], "http.route") != "/panic/:id" {
-		t.Fatalf("route = %v", fieldOf(events[0], "http.route"))
+	if fieldValue(events[0], "http.route") != "/panic/:id" {
+		t.Fatalf("route = %v", fieldValue(events[0], "http.route"))
 	}
-	if intField(events[0], "http.status") != http.StatusInternalServerError {
-		t.Fatalf("status = %v, want %d", intField(events[0], "http.status"), http.StatusInternalServerError)
+	if statusField(events[0], "http.status") != http.StatusInternalServerError {
+		t.Fatalf("status = %v, want %d", statusField(events[0], "http.status"), http.StatusInternalServerError)
 	}
-	if _, ok := fieldOf(events[0], "panic").(map[string]any); !ok {
+	if _, ok := fieldValue(events[0], "panic").(map[string]any); !ok {
 		t.Fatalf("expected panic metadata")
 	}
 }
@@ -148,8 +148,8 @@ func TestMiddlewareFiberErrorKeepsHTTPStatus(t *testing.T) {
 	if len(events) != 1 {
 		t.Fatalf("expected 1 event, got %d", len(events))
 	}
-	if intField(events[0], "http.status") != http.StatusTooManyRequests {
-		t.Fatalf("status = %v, want %d", intField(events[0], "http.status"), http.StatusTooManyRequests)
+	if statusField(events[0], "http.status") != http.StatusTooManyRequests {
+		t.Fatalf("status = %v, want %d", statusField(events[0], "http.status"), http.StatusTooManyRequests)
 	}
 	if events[0].Level() != hc.LevelError {
 		t.Fatalf("level = %s, want ERROR", events[0].Level())
@@ -207,8 +207,8 @@ func TestMiddlewareLogsStatusFromCustomFiberErrorHandler(t *testing.T) {
 	if len(events) != 1 {
 		t.Fatalf("expected 1 event, got %d", len(events))
 	}
-	if intField(events[0], "http.status") != http.StatusTeapot {
-		t.Fatalf("status = %v, want %d", intField(events[0], "http.status"), http.StatusTeapot)
+	if statusField(events[0], "http.status") != http.StatusTeapot {
+		t.Fatalf("status = %v, want %d", statusField(events[0], "http.status"), http.StatusTeapot)
 	}
 	if events[0].Level() != hc.LevelError {
 		t.Fatalf("level = %s, want ERROR", events[0].Level())
@@ -247,7 +247,7 @@ func TestMiddlewareReturnsCustomFiberErrorHandlerFailure(t *testing.T) {
 	if len(events) != 1 {
 		t.Fatalf("expected 1 event, got %d", len(events))
 	}
-	errField, ok := fieldOf(events[0], "error").(map[string]any)
+	errField, ok := fieldValue(events[0], "error").(map[string]any)
 	if !ok {
 		t.Fatal("expected structured error field")
 	}
@@ -259,14 +259,15 @@ func TestMiddlewareReturnsCustomFiberErrorHandlerFailure(t *testing.T) {
 // capturedEvent mirrors the v0 test-facing shape (map fields, int
 // numerics) over the v2 TestSink capture, keeping the assertions below
 // unchanged from the v0 suite.
-// Typed field access on captured events (Lookup carries int64; the
-// constants in these tests are ints).
-func fieldOf(ev hc.CapturedEvent, key string) any {
+// Typed field reads on captured events: fieldValue for any value,
+// statusField for the int64 http.status these tests compare against
+// int constants.
+func fieldValue(ev hc.CapturedEvent, key string) any {
 	v, _ := ev.Lookup(key)
 	return v
 }
 
-func intField(ev hc.CapturedEvent, key string) int64 {
+func statusField(ev hc.CapturedEvent, key string) int64 {
 	v, _ := ev.Lookup(key)
 	n, _ := v.(int64)
 	return n

--- a/integration/gin/middleware_test.go
+++ b/integration/gin/middleware_test.go
@@ -32,14 +32,14 @@ func TestMiddlewareCapturesRouteAndFields(t *testing.T) {
 	if len(events) != 1 {
 		t.Fatalf("expected 1 event, got %d", len(events))
 	}
-	if intField(events[0], "http.status") != http.StatusCreated {
-		t.Fatalf("expected status %d, got %v", http.StatusCreated, intField(events[0], "http.status"))
+	if statusField(events[0], "http.status") != http.StatusCreated {
+		t.Fatalf("expected status %d, got %v", http.StatusCreated, statusField(events[0], "http.status"))
 	}
-	if fieldOf(events[0], "http.route") != "/orders/:id" {
-		t.Fatalf("expected route template, got %v", fieldOf(events[0], "http.route"))
+	if fieldValue(events[0], "http.route") != "/orders/:id" {
+		t.Fatalf("expected route template, got %v", fieldValue(events[0], "http.route"))
 	}
-	if fieldOf(events[0], "user_id") != "u_1" {
-		t.Fatalf("expected user_id field, got %v", fieldOf(events[0], "user_id"))
+	if fieldValue(events[0], "user_id") != "u_1" {
+		t.Fatalf("expected user_id field, got %v", fieldValue(events[0], "user_id"))
 	}
 }
 
@@ -87,10 +87,10 @@ func TestMiddlewareErrorAndSamplingBehavior(t *testing.T) {
 	if events[0].Level() != hc.LevelError {
 		t.Fatalf("level = %s, want ERROR", events[0].Level())
 	}
-	if intField(events[0], "http.status") != http.StatusInternalServerError {
-		t.Fatalf("status = %v, want %d", intField(events[0], "http.status"), http.StatusInternalServerError)
+	if statusField(events[0], "http.status") != http.StatusInternalServerError {
+		t.Fatalf("status = %v, want %d", statusField(events[0], "http.status"), http.StatusInternalServerError)
 	}
-	if _, ok := fieldOf(events[0], "error").(map[string]any); !ok {
+	if _, ok := fieldValue(events[0], "error").(map[string]any); !ok {
 		t.Fatalf("expected structured error field")
 	}
 }
@@ -123,13 +123,13 @@ func TestMiddlewarePanicLogsAndPropagates(t *testing.T) {
 	if len(events) != 1 {
 		t.Fatalf("expected 1 event, got %d", len(events))
 	}
-	if fieldOf(events[0], "http.route") != "/panic/:id" {
-		t.Fatalf("route = %v", fieldOf(events[0], "http.route"))
+	if fieldValue(events[0], "http.route") != "/panic/:id" {
+		t.Fatalf("route = %v", fieldValue(events[0], "http.route"))
 	}
-	if intField(events[0], "http.status") != http.StatusInternalServerError {
-		t.Fatalf("status = %v, want %d", intField(events[0], "http.status"), http.StatusInternalServerError)
+	if statusField(events[0], "http.status") != http.StatusInternalServerError {
+		t.Fatalf("status = %v, want %d", statusField(events[0], "http.status"), http.StatusInternalServerError)
 	}
-	if _, ok := fieldOf(events[0], "panic").(map[string]any); !ok {
+	if _, ok := fieldValue(events[0], "panic").(map[string]any); !ok {
 		t.Fatalf("expected panic metadata")
 	}
 }
@@ -154,8 +154,8 @@ func TestMiddlewareLogsNoRouteWithoutTemplate(t *testing.T) {
 	if _, ok := events[0].Lookup("http.route"); ok {
 		t.Fatalf("did not expect route template for unmatched route")
 	}
-	if intField(events[0], "http.status") != http.StatusNotFound {
-		t.Fatalf("status = %v, want %d", intField(events[0], "http.status"), http.StatusNotFound)
+	if statusField(events[0], "http.status") != http.StatusNotFound {
+		t.Fatalf("status = %v, want %d", statusField(events[0], "http.status"), http.StatusNotFound)
 	}
 }
 
@@ -177,8 +177,8 @@ func TestMiddlewareGinErrorKeepsCommittedStatus(t *testing.T) {
 	if len(events) != 1 {
 		t.Fatalf("expected 1 event, got %d", len(events))
 	}
-	if intField(events[0], "http.status") != http.StatusTooManyRequests {
-		t.Fatalf("status = %v, want %d", intField(events[0], "http.status"), http.StatusTooManyRequests)
+	if statusField(events[0], "http.status") != http.StatusTooManyRequests {
+		t.Fatalf("status = %v, want %d", statusField(events[0], "http.status"), http.StatusTooManyRequests)
 	}
 	if events[0].Level() != hc.LevelError {
 		t.Fatalf("level = %s, want ERROR", events[0].Level())
@@ -203,7 +203,7 @@ func TestMiddlewareGinErrorUsesUnderlyingErrorMetadata(t *testing.T) {
 	if len(events) != 1 {
 		t.Fatalf("expected 1 event, got %d", len(events))
 	}
-	errField, ok := fieldOf(events[0], "error").(map[string]any)
+	errField, ok := fieldValue(events[0], "error").(map[string]any)
 	if !ok {
 		t.Fatalf("expected structured error field")
 	}
@@ -218,14 +218,15 @@ func TestMiddlewareGinErrorUsesUnderlyingErrorMetadata(t *testing.T) {
 // capturedEvent mirrors the v0 test-facing shape (map fields, int
 // numerics) over the v2 TestSink capture, keeping the assertions below
 // unchanged from the v0 suite.
-// Typed field access on captured events (Lookup carries int64; the
-// constants in these tests are ints).
-func fieldOf(ev hc.CapturedEvent, key string) any {
+// Typed field reads on captured events: fieldValue for any value,
+// statusField for the int64 http.status these tests compare against
+// int constants.
+func fieldValue(ev hc.CapturedEvent, key string) any {
 	v, _ := ev.Lookup(key)
 	return v
 }
 
-func intField(ev hc.CapturedEvent, key string) int64 {
+func statusField(ev hc.CapturedEvent, key string) int64 {
 	v, _ := ev.Lookup(key)
 	n, _ := v.(int64)
 	return n

--- a/integration/std/concurrent_test.go
+++ b/integration/std/concurrent_test.go
@@ -41,9 +41,7 @@ func TestMiddlewareConcurrentStatusIntegrity(t *testing.T) {
 
 	var wg sync.WaitGroup
 	for g := range 8 {
-		wg.Add(1)
-		go func(g int) {
-			defer wg.Done()
+		wg.Go(func() {
 			for i := range 100 {
 				code := []string{"201", "404", "500", ""}[(g+i)%4]
 				req := httptest.NewRequest(http.MethodGet, "/x?code="+code, nil).WithContext(context.Background())
@@ -54,7 +52,8 @@ func TestMiddlewareConcurrentStatusIntegrity(t *testing.T) {
 					return
 				}
 			}
-		}(g)
+
+		})
 	}
 	wg.Wait()
 

--- a/integration/std/concurrent_test.go
+++ b/integration/std/concurrent_test.go
@@ -52,7 +52,6 @@ func TestMiddlewareConcurrentStatusIntegrity(t *testing.T) {
 					return
 				}
 			}
-
 		})
 	}
 	wg.Wait()

--- a/integration/std/middleware_test.go
+++ b/integration/std/middleware_test.go
@@ -495,6 +495,8 @@ func TestMiddlewareFlushCommitsStatus(t *testing.T) {
 	})
 }
 
+// Consolidated from integration/std/crash_test.go: nil-runtime
+// middleware is a documented passthrough.
 func TestCrashNilRuntimePassthrough(t *testing.T) {
 	mw := Middleware(nil)
 	handler := mw(http.NotFoundHandler())

--- a/integration/std/middleware_test.go
+++ b/integration/std/middleware_test.go
@@ -40,11 +40,11 @@ func TestMiddlewareDelegatesToCoreAndLogs(t *testing.T) {
 	if events[0].Message() != "done" {
 		t.Fatalf("expected message done, got %q", events[0].Message())
 	}
-	if intField(events[0], "http.status") != http.StatusAccepted {
-		t.Fatalf("expected status %d, got %v", http.StatusAccepted, intField(events[0], "http.status"))
+	if statusField(events[0], "http.status") != http.StatusAccepted {
+		t.Fatalf("expected status %d, got %v", http.StatusAccepted, statusField(events[0], "http.status"))
 	}
-	if fieldOf(events[0], "example") != "std-integration" {
-		t.Fatalf("expected example field, got %v", fieldOf(events[0], "example"))
+	if fieldValue(events[0], "example") != "std-integration" {
+		t.Fatalf("expected example field, got %v", fieldValue(events[0], "example"))
 	}
 }
 
@@ -71,8 +71,8 @@ func TestMiddlewareAppliesCustomMessageFromHandlerContext(t *testing.T) {
 	if events[0].Message() != "order shipped" {
 		t.Fatalf("expected message %q, got %q", "order shipped", events[0].Message())
 	}
-	if intField(events[0], "http.status") != http.StatusAccepted {
-		t.Fatalf("expected status %d, got %v", http.StatusAccepted, intField(events[0], "http.status"))
+	if statusField(events[0], "http.status") != http.StatusAccepted {
+		t.Fatalf("expected status %d, got %v", http.StatusAccepted, statusField(events[0], "http.status"))
 	}
 }
 
@@ -108,10 +108,10 @@ func TestMiddlewarePanicPropagatesAndLogsError(t *testing.T) {
 	if events[0].Level() != hc.LevelError {
 		t.Fatalf("expected error level, got %s", events[0].Level())
 	}
-	if intField(events[0], "http.status") != http.StatusInternalServerError {
-		t.Fatalf("expected status 500, got %v", intField(events[0], "http.status"))
+	if statusField(events[0], "http.status") != http.StatusInternalServerError {
+		t.Fatalf("expected status 500, got %v", statusField(events[0], "http.status"))
 	}
-	if _, ok := fieldOf(events[0], "panic").(map[string]any); !ok {
+	if _, ok := fieldValue(events[0], "panic").(map[string]any); !ok {
 		t.Fatalf("expected panic field in event")
 	}
 }
@@ -139,8 +139,8 @@ func TestMiddlewareWriteHeaderTwiceLogsFirstCommittedStatus(t *testing.T) {
 	if len(events) != 1 {
 		t.Fatalf("expected 1 event, got %d", len(events))
 	}
-	if intField(events[0], "http.status") != http.StatusCreated {
-		t.Fatalf("expected logged status %d, got %v", http.StatusCreated, intField(events[0], "http.status"))
+	if statusField(events[0], "http.status") != http.StatusCreated {
+		t.Fatalf("expected logged status %d, got %v", http.StatusCreated, statusField(events[0], "http.status"))
 	}
 }
 
@@ -181,8 +181,8 @@ func TestMiddlewarePanicAfterCommittedStatusKeepsCommittedStatus(t *testing.T) {
 	if events[0].Level() != hc.LevelError {
 		t.Fatalf("expected error level, got %s", events[0].Level())
 	}
-	if intField(events[0], "http.status") != http.StatusCreated {
-		t.Fatalf("expected logged status %d, got %v", http.StatusCreated, intField(events[0], "http.status"))
+	if statusField(events[0], "http.status") != http.StatusCreated {
+		t.Fatalf("expected logged status %d, got %v", http.StatusCreated, statusField(events[0], "http.status"))
 	}
 }
 
@@ -211,11 +211,11 @@ func TestMiddlewareSetsRouteFromRequestPattern(t *testing.T) {
 	if len(events) != 1 {
 		t.Fatalf("expected 1 event, got %d", len(events))
 	}
-	route, ok := fieldOf(events[0], "http.route").(string)
+	route, ok := fieldValue(events[0], "http.route").(string)
 	if !ok || route == "" {
-		t.Fatalf("expected route template, got %#v", fieldOf(events[0], "http.route"))
+		t.Fatalf("expected route template, got %#v", fieldValue(events[0], "http.route"))
 	}
-	if name, _ := fieldOf(events[0], "op.name").(string); name != route {
+	if name, _ := fieldValue(events[0], "op.name").(string); name != route {
 		t.Fatalf("wire op.name = %q, want route %q", name, route)
 	}
 	if sampledOp != route {
@@ -295,8 +295,8 @@ func TestMiddlewareWriteSetsStatusCode(t *testing.T) {
 	if len(events) != 1 {
 		t.Fatalf("expected 1 event, got %d", len(events))
 	}
-	if intField(events[0], "http.status") != http.StatusOK {
-		t.Fatalf("expected status 200, got %v", intField(events[0], "http.status"))
+	if statusField(events[0], "http.status") != http.StatusOK {
+		t.Fatalf("expected status 200, got %v", statusField(events[0], "http.status"))
 	}
 }
 
@@ -325,8 +325,8 @@ func TestMiddlewareReadFromSetsStatusCode(t *testing.T) {
 	if len(events) != 1 {
 		t.Fatalf("expected 1 event, got %d", len(events))
 	}
-	if intField(events[0], "http.status") != http.StatusOK {
-		t.Fatalf("expected status 200, got %v", intField(events[0], "http.status"))
+	if statusField(events[0], "http.status") != http.StatusOK {
+		t.Fatalf("expected status 200, got %v", statusField(events[0], "http.status"))
 	}
 }
 
@@ -361,14 +361,15 @@ func TestMiddlewareSamplingDropForHealthyRequest(t *testing.T) {
 // capturedEvent mirrors the v0 test-facing shape (map fields, int
 // numerics) over the v2 TestSink capture, keeping the assertions below
 // unchanged from the v0 suite.
-// Typed field access on captured events (Lookup carries int64; the
-// constants in these tests are ints).
-func fieldOf(ev hc.CapturedEvent, key string) any {
+// Typed field reads on captured events: fieldValue for any value,
+// statusField for the int64 http.status these tests compare against
+// int constants.
+func fieldValue(ev hc.CapturedEvent, key string) any {
 	v, _ := ev.Lookup(key)
 	return v
 }
 
-func intField(ev hc.CapturedEvent, key string) int64 {
+func statusField(ev hc.CapturedEvent, key string) int64 {
 	v, _ := ev.Lookup(key)
 	n, _ := v.(int64)
 	return n

--- a/integration/std/wire_test.go
+++ b/integration/std/wire_test.go
@@ -119,9 +119,7 @@ func TestWireMixedTrafficRealLogger(t *testing.T) {
 	const per = 15
 	var wg sync.WaitGroup
 	for w := range workers {
-		wg.Add(1)
-		go func(w int) {
-			defer wg.Done()
+		wg.Go(func() {
 			for i := range per {
 				id := fmt.Sprintf("w%d-%d", w, i)
 				for _, p := range []string{"/ok/", "/err/", "/panic/", "/stream/", "/kitchen/"} {
@@ -131,7 +129,7 @@ func TestWireMixedTrafficRealLogger(t *testing.T) {
 					}
 				}
 			}
-		}(w)
+		})
 	}
 	wg.Wait()
 	// Client returns precede the server's deferred emissions; Close
@@ -156,7 +154,7 @@ func TestWireMixedTrafficRealLogger(t *testing.T) {
 
 func nonEmptyLines(s string) []string {
 	var out []string
-	for _, ln := range strings.Split(s, "\n") {
+	for ln := range strings.SplitSeq(s, "\n") {
 		if strings.TrimSpace(ln) != "" {
 			out = append(out, ln)
 		}

--- a/integration/std/wire_test.go
+++ b/integration/std/wire_test.go
@@ -21,7 +21,7 @@ import (
 
 // mustWireLine parses one emitted JSON line and asserts the canonical
 // envelope every consumer relies on.
-func mustWireLine(t *testing.T, ln string) map[string]any {
+func parseWireLine(t *testing.T, ln string) map[string]any {
 	t.Helper()
 	var m map[string]any
 	if err := json.Unmarshal([]byte(ln), &m); err != nil {
@@ -32,8 +32,12 @@ func mustWireLine(t *testing.T, ln string) map[string]any {
 			t.Fatalf("canonical key %q missing: %s", k, ln)
 		}
 	}
-	outcome := m["op.outcome"].(string)
-	status := int(m["http.status"].(float64))
+	outcome, ocOK := m["op.outcome"].(string)
+	statusF, stOK := m["http.status"].(float64)
+	if !ocOK || !stOK {
+		t.Fatalf("canonical envelope mistyped: %s", ln)
+	}
+	status := int(statusF)
 	switch outcome {
 	case "panic":
 		if _, ok := m["panic"].(map[string]any); !ok {
@@ -58,9 +62,10 @@ func mustWireLine(t *testing.T, ln string) map[string]any {
 
 // TestWireMixedTrafficRealLogger drives concurrent mixed traffic —
 // success, error, panic, streaming-flush, kitchen-sink — through the
-// real middleware and the real slog JSON pipeline (one shared logger,
-// exactly the production shape); every emitted line must parse, carry
-// the full canonical envelope, and be internally coherent.
+// real middleware and the first-party JSONSink (one shared sink, the
+// production shape; the slog/zap/zerolog equivalents live in
+// cmd/examples); every emitted line must parse, carry the full
+// canonical envelope, and be internally coherent.
 func TestWireMixedTrafficRealLogger(t *testing.T) {
 	var buf bytes.Buffer
 	// One JSONSink, mutex-serialized by the sink itself: the shared
@@ -139,7 +144,7 @@ func TestWireMixedTrafficRealLogger(t *testing.T) {
 	}
 	outcomes := map[string]int{}
 	for _, ln := range lines {
-		m := mustWireLine(t, ln)
+		m := parseWireLine(t, ln)
 		outcomes[m["op.outcome"].(string)]++
 	}
 	// Exact mix: every /err is failure, every /panic is panic, the
@@ -178,19 +183,23 @@ func TestWireRouteAndOperationShareTheTemplate(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 	srv := httptest.NewServer(Middleware(rt)(mux))
-	defer srv.Close()
 
 	resp, err := srv.Client().Get(srv.URL + "/orders/o_42")
 	if err != nil {
 		t.Fatal(err)
 	}
 	_ = resp.Body.Close()
+	// Quiesce before reading shared state: client returns precede the
+	// server's deferred emission, and this test reads buf and sampled
+	// directly (the buffering that makes this safe today is a net/http
+	// implementation detail — Close makes it explicit).
+	srv.Close()
 
 	lines := nonEmptyLines(buf.String())
 	if len(lines) != 1 {
 		t.Fatalf("lines = %d", len(lines))
 	}
-	m := mustWireLine(t, lines[0])
+	m := parseWireLine(t, lines[0])
 	// req.Pattern carries the method for method-matched patterns; the
 	// invariant is that all three views agree on the same template.
 	const want = "GET /orders/{id}"

--- a/integration/worker/worker.go
+++ b/integration/worker/worker.go
@@ -22,11 +22,15 @@ type JobMeta struct {
 
 // Start initializes a worker operation handle. rt comes from
 // hc.Compile/MustCompile; a nil *hc.Runtime runs the operation with no
-// emission. End the operation with the deferred-error idiom:
+// emission. End the operation with the deferred-error idiom — and
+// switch to the operation context, or every hc.Add below is a silent
+// no-op (the original ctx carries no WAL):
 //
-//	func run(ctx context.Context) (err error) {
+//	func run(ctx context.Context, rt *hc.Runtime) (err error) {
 //		op := workerhc.Start(ctx, rt, meta)
+//		ctx = op.Context()
 //		defer op.End(&err)
+//		hc.Add(ctx, "rows", 42)
 //		...
 //	}
 func Start(ctx context.Context, rt *hc.Runtime, meta JobMeta) *hc.Operation {

--- a/level.go
+++ b/level.go
@@ -6,10 +6,10 @@ package hc
 type Level int
 
 const (
-	LevelDebug Level = -4
-	LevelInfo  Level = 0
+	LevelDebug Level = -4 // lower on the wire: "debug"
+	LevelInfo  Level = 0  // the success default
 	LevelWarn  Level = 4
-	LevelError Level = 8
+	LevelError Level = 8 // the failure and panic default
 )
 
 // String renders the classic level names.

--- a/metadata.go
+++ b/metadata.go
@@ -58,6 +58,26 @@ func structuredErrorMessage(err error) string {
 		return message
 	}
 
+	return safeErrorMessage(err)
+}
+
+// safeErrorMessage extracts err's message without ever panicking:
+// typed-nil receivers and wrapped typed-nils (whose Error() nil-derefs)
+// and arbitrary panicking Error() implementations are all contained —
+// the same fence the encoder puts around user MarshalJSON. fmt.Sprint
+// recovers Error()-panics itself, so it is the fallback rendering.
+func safeErrorMessage(err error) (msg string) {
+	if err == nil {
+		return ""
+	}
+	if isTypedNilError(err) {
+		return fmt.Sprint(err) // renders "<nil>"
+	}
+	defer func() {
+		if recover() != nil {
+			msg = fmt.Sprint(err)
+		}
+	}()
 	return err.Error()
 }
 
@@ -74,7 +94,7 @@ func deepestUnwrappedError(err error) error {
 			}
 			seen[current] = struct{}{}
 		}
-		next := errors.Unwrap(current)
+		next := safeUnwrap(current)
 		if next == nil {
 			return current
 		}
@@ -103,6 +123,15 @@ func isComparableError(err error) bool {
 	return reflect.TypeOf(err).Comparable()
 }
 
+// frameworkStyleErrorMessage recognizes framework-shaped errors — any
+// error whose struct (possibly behind a pointer) has exported Code
+// (integer) and Message (string or fmt.Stringer) fields, the
+// echo.HTTPError and fiber.Error shape — and surfaces Message as the
+// canonical error.message instead of the wrapper's own Error() text.
+// This is deliberate wire behavior (v0 parity): framework errors log
+// the human message, not the wrapper text. Reflection is guarded
+// (invalid, nil, and unexported values are skipped); String() calls
+// are panic-fenced.
 func frameworkStyleErrorMessage(err error) (string, bool) {
 	value := reflect.ValueOf(err)
 	if !value.IsValid() {
@@ -160,7 +189,7 @@ func messageValue(field reflect.Value) (any, bool) {
 		}
 		return v, true
 	case fmt.Stringer:
-		text := v.String()
+		text := safeString(v)
 		if text == "" {
 			return nil, false
 		}
@@ -183,4 +212,26 @@ func isIntKind(kind reflect.Kind) bool {
 	default:
 		return false
 	}
+}
+
+// safeString calls s.String with the same panic fence safeErrorMessage
+// applies to Error.
+func safeString(s fmt.Stringer) (text string) {
+	defer func() {
+		if recover() != nil {
+			text = fmt.Sprint(s)
+		}
+	}()
+	return s.String()
+}
+
+// safeUnwrap fences errors.Unwrap: wrappers with state-reading Unwrap
+// methods panic on typed-nil receivers.
+func safeUnwrap(err error) (next error) {
+	defer func() {
+		if recover() != nil {
+			next = nil
+		}
+	}()
+	return errors.Unwrap(err)
 }

--- a/operation.go
+++ b/operation.go
@@ -77,9 +77,8 @@ func (op *Operation) Context() context.Context {
 // End MUST be deferred directly (defer op.End(&err)) — the closure form
 // silently disables panic capture. Reentrant use is not supported: a
 // second End from inside a sink's Write deadlocks on the one-shot
-// claim. Concurrent first calls are safe (characterized by
-// TestConcurrentEndCharacterization): exactly one wins, the rest
-// return its published result.
+// claim. Concurrent first calls are safe: exactly one wins the claim
+// and commits; the others wait and return the published result.
 func (op *Operation) End(errp *error) (emitted bool) {
 	if op == nil {
 		return false
@@ -115,8 +114,7 @@ claimed:
 
 	// The owner's final writes, then SEAL before any WAL read: from
 	// here on the event is immutable, so stragglers cannot race the
-	// scan, the record handed to sinks, or the encode (amendment 20's
-	// threat model is the sink-read window, which this closes).
+	// scan, the record handed to sinks, or the encode .
 	now := time.Now() // one clock read: completion stamp + duration base
 	duration := now.Sub(ev.startedAt)
 	annotateOperationFailures(ev, &op.ref, err, recovered)
@@ -238,7 +236,7 @@ func (op *Operation) commit(ev *event, rt *Runtime, start OperationStart, outcom
 	// The keep-everything fast path (rate == 1.0, no sampler, no level
 	// rates, no policies): healthy events can never be dropped, so the
 	// gate is skipped entirely. Error/panic events bypass the gate
-	// structurally (amendment 4), so the flag only short-circuits the
+	// structurally, so the flag only short-circuits the
 	// healthy branch.
 	if !rt.alwaysKeep {
 		if !in.HasError {
@@ -253,15 +251,11 @@ func (op *Operation) commit(ev *event, rt *Runtime, start OperationStart, outcom
 	}
 
 	msg := resolveEventMessage(rt.message, start.Domain, ev.msg)
-	// Reset the lazy-encode cache: the record is embedded, so a stale
-	// atomic pointer from a previous generation would otherwise serve
-	// old bytes if the operation were ever committed again.
 	rec := &op.record
 	rec.level = level
 	rec.msg = msg
 	rec.fields = ev.fields
 	rec.completedAt = now
-	rec.encoded.Store(nil)
 	rt.emit(op.ctx, rec)
 	return true
 }

--- a/operation_test.go
+++ b/operation_test.go
@@ -606,7 +606,6 @@ func concurrentEnd(t *testing.T, rate float64, n int) ([]bool, int) {
 			}
 			mu.Unlock()
 			results[i] = op.End(nil)
-
 		})
 	}
 	mu.Lock()
@@ -684,7 +683,6 @@ func TestConcurrentEndArmed(t *testing.T) {
 					Add(ctx, "async", i) // guarded append racing the seal
 					results[i] = false
 				}
-
 			})
 		}
 		mu.Lock()
@@ -730,7 +728,6 @@ func TestConcurrentEndErrorPointer(t *testing.T) {
 			wg.Go(func() {
 				err := fmt.Errorf("caller-%d", i)
 				results[i] = op.End(&err)
-
 			})
 		}
 		wg.Wait()
@@ -1067,5 +1064,51 @@ func TestTypedNilErrorsContained(t *testing.T) {
 	}
 	if parsed["e"] != "<nil>" {
 		t.Fatalf("typed-nil field = %#v, want \"<nil>\"", parsed["e"])
+	}
+}
+
+// TestPanicWireShapeParity pins the two hand-maintained copies of the
+// canonical panic shape against each other: integration/common's
+// public PanicField/FinalizeRequest path (middleware-recovered
+// panics) and the core's own End path. They live in different
+// packages by design; this test fails if either drifts.
+func TestPanicWireShapeParity(t *testing.T) {
+	rt, ts := testRT(t, nil)
+	recovered := any("wire-parity boom")
+
+	// Core path: End's own panic handling.
+	func() {
+		defer func() { _ = recover() }()
+		op := Start(context.Background(), rt, OperationStart{Domain: DomainJob, Name: "core"})
+		defer op.End(nil)
+		panic(recovered)
+	}()
+
+	// common path: middleware-style recover + explicit writes + End(nil).
+	op2 := Start(context.Background(), rt, OperationStart{Domain: DomainJob, Name: "common"})
+	Add(op2.Context(), "panic", structuredPanicField(recovered))
+	Error(op2.Context(), fmt.Errorf("panic: %v", recovered))
+	Add(op2.Context(), "op.outcome", string(OutcomePanic))
+	_ = op2.End(nil)
+
+	evs := ts.Events()
+	if len(evs) != 2 {
+		t.Fatalf("events = %d, want 2", len(evs))
+	}
+	for _, key := range []string{"panic", "error", "op.outcome"} {
+		a, okA := evs[0].Lookup(key)
+		b, okB := evs[1].Lookup(key)
+		if okA != okB {
+			t.Fatalf("key %q: core=%v common=%v", key, okA, okB)
+		}
+		if !okA {
+			t.Fatalf("key %q missing", key)
+		}
+		if fmt.Sprint(a) != fmt.Sprint(b) {
+			t.Fatalf("key %q diverges: core=%v common=%v", key, a, b)
+		}
+	}
+	if evs[0].Level() != evs[1].Level() || evs[0].Level() != LevelError {
+		t.Fatalf("levels = %v/%v, want error/error", evs[0].Level(), evs[1].Level())
 	}
 }

--- a/operation_test.go
+++ b/operation_test.go
@@ -597,9 +597,7 @@ func concurrentEnd(t *testing.T, rate float64, n int) ([]bool, int) {
 	released, ready := false, 0
 	var wg sync.WaitGroup
 	for i := range n {
-		wg.Add(1)
-		go func(i int) {
-			defer wg.Done()
+		wg.Go(func() {
 			mu.Lock()
 			ready++
 			start.Broadcast()
@@ -608,7 +606,8 @@ func concurrentEnd(t *testing.T, rate float64, n int) ([]bool, int) {
 			}
 			mu.Unlock()
 			results[i] = op.End(nil)
-		}(i)
+
+		})
 	}
 	mu.Lock()
 	for ready != n {
@@ -671,9 +670,7 @@ func TestConcurrentEndArmed(t *testing.T) {
 		var wg sync.WaitGroup
 		results := make([]bool, n)
 		for i := range n {
-			wg.Add(1)
-			go func(i int) {
-				defer wg.Done()
+			wg.Go(func() {
 				mu.Lock()
 				ready++
 				start.Broadcast()
@@ -687,7 +684,8 @@ func TestConcurrentEndArmed(t *testing.T) {
 					Add(ctx, "async", i) // guarded append racing the seal
 					results[i] = false
 				}
-			}(i)
+
+			})
 		}
 		mu.Lock()
 		for ready != n {
@@ -729,12 +727,11 @@ func TestConcurrentEndErrorPointer(t *testing.T) {
 		results := make([]bool, 8)
 		var wg sync.WaitGroup
 		for i := range 8 {
-			wg.Add(1)
-			go func(i int) {
-				defer wg.Done()
+			wg.Go(func() {
 				err := fmt.Errorf("caller-%d", i)
 				results[i] = op.End(&err)
-			}(i)
+
+			})
 		}
 		wg.Wait()
 		if len(ts.Events()) != 1 {

--- a/operation_test.go
+++ b/operation_test.go
@@ -440,35 +440,10 @@ func TestAddNoEventNoop(t *testing.T) {
 	Add(context.Background(), "k", 1) // no panic
 	//lint:ignore SA1012 intentional: pin the nil-context no-op contract
 	Add(nil, "k", 1)
-	AddRawJSON(context.Background(), "k", []byte(`{}`))
 	Error(context.Background(), errors.New("x"))
 	SetMessage(context.Background(), "m")
 	SetRoute(context.Background(), "/r")
 	SetLevel(context.Background(), LevelWarn)
-}
-
-func TestAddRawJSONField(t *testing.T) {
-	rt, ts := testRT(t, nil)
-	op := Start(context.Background(), rt, OperationStart{})
-	AddRawJSON(op.Context(), "meta", []byte(`{"nested":true}`))
-	op.End(nil)
-	ev := ts.Events()[0]
-	var found *Field
-	for _, cand := range ev.Fields() {
-		if cand.Key() == "meta" {
-			f := cand
-			found = &f
-		}
-	}
-	if found == nil || found.Kind() != KindRaw {
-		if found == nil {
-			t.Fatal("raw field missing")
-		}
-		t.Fatalf("kind = %v", found.Kind())
-	}
-	if raw, ok := found.Raw(); !ok || string(raw) != `{"nested":true}` {
-		t.Fatalf("raw = %v", raw)
-	}
 }
 
 func TestLevelSamplingRates(t *testing.T) {
@@ -1110,5 +1085,32 @@ func TestPanicWireShapeParity(t *testing.T) {
 	}
 	if evs[0].Level() != evs[1].Level() || evs[0].Level() != LevelError {
 		t.Fatalf("levels = %v/%v, want error/error", evs[0].Level(), evs[1].Level())
+	}
+}
+
+// TestAddJSONRawMessage pins the supported raw-JSON path: json.RawMessage
+// through regular Add embeds verbatim on the canonical line (its
+// MarshalJSON contract), no re-marshaling of the decoded value.
+func TestAddJSONRawMessage(t *testing.T) {
+	rt, ts := testRT(t, nil)
+	op := Start(context.Background(), rt, OperationStart{Domain: DomainJob, Name: "j"})
+	Add(op.Context(), "meta", json.RawMessage(`{"batch":true}`), "sib", 1)
+	if !op.End(nil) {
+		t.Fatal("event dropped")
+	}
+	ev := ts.Events()[0]
+	v, ok := ev.Lookup("meta")
+	b, isBytes := v.(json.RawMessage)
+	if !ok || !isBytes || string(b) != `{"batch":true}` {
+		t.Fatalf("meta = %#v, want the verbatim RawMessage", v)
+	}
+	rec := recOf(LevelInfo, "m", ev.Fields()...)
+	var m map[string]any
+	if err := json.Unmarshal(rec.Encoded(), &m); err != nil {
+		t.Fatalf("line unparseable: %v: %s", err, rec.Encoded())
+	}
+	nested, _ := m["meta"].(map[string]any)
+	if nested["batch"] != true || m["sib"] != float64(1) {
+		t.Fatalf("line = %s", rec.Encoded())
 	}
 }

--- a/property_test.go
+++ b/property_test.go
@@ -528,6 +528,8 @@ func TestEncodedRoundTripProperty(t *testing.T) {
 // appears exactly once with its last value, in last-occurrence order —
 // checked against an independent reference fold, not the encoder's own
 // dedupe code.
+// TestEncodedRoundTripProperty: the encoded canonical line must
+// unmarshal to exactly the record's resolved members.
 //
 // Canonical-key collision follows the logrus rename policy (record.go
 // aliasKey, T5 decision): user fields named "level"/"time"/"message"
@@ -922,12 +924,14 @@ func TestPoolSafetyReplayProperty(t *testing.T) {
 	}
 }
 
+// The lifecycle model's wire oracle.
 //
 // The wire comparison pins the full canonical line: envelope level,
 // every user field at its last-occurrence position with its last value
 // (independent LWW fold), the resolved op.outcome, and the resolved
 // message. The members that depend on the wall clock (time,
 // duration_ms) are excluded.
+// FuzzEndLifecycle scope note.
 //
 // The canonical-key collision policy (user fields named "message"/
 // "time"/"level") is deliberately OUT of this target's key alphabet —

--- a/property_test.go
+++ b/property_test.go
@@ -139,38 +139,8 @@ func rtFieldValue(rng *rand.Rand, kind FieldKind) any {
 		default:
 			return fmt.Errorf("wrapped: %w", errors.New("inner"))
 		}
-	case KindRaw:
-		// raw embeds verbatim: the blobs must stay valid JSON or the
-		// whole line breaks (the caller's contract).
-		switch rng.IntN(5) {
-		case 0:
-			return []byte(fmt.Sprintf(`{"n":%d}`, rng.IntN(1e6)))
-		case 1:
-			return []byte(`{"nested":{"deep":[1,true,null]}}`)
-		case 2:
-			return []byte(fmt.Sprintf(`{"s":"v%d"}`, rng.IntN(100)))
-		case 3:
-			return []byte(`[1,2,3]`)
-		default:
-			return []byte(`null`)
-		}
-	case KindAny:
-		switch rng.IntN(6) {
-		case 0:
-			return nil
-		case 1:
-			return "str"
-		case 2:
-			return int64(rng.IntN(1000))
-		case 3:
-			return []any{int64(1), "x", true, nil}
-		case 4:
-			return map[string]any{"a": int64(1), "b": "two", "c": []any{false}}
-		default:
-			return map[string]any{"nested": map[string]any{"k": fmt.Sprintf("v%d", rng.IntN(10))}}
-		}
 	default:
-		return "unreachable"
+		return nil
 	}
 }
 
@@ -234,7 +204,6 @@ func TestFieldRoundTripProperty(t *testing.T) {
 		{KindTime, "time"},
 		{KindDuration, "duration"},
 		{KindErr, "err"},
-		{KindRaw, "raw"},
 		{KindAny, "any"},
 	}
 	for _, k := range kinds {
@@ -243,22 +212,7 @@ func TestFieldRoundTripProperty(t *testing.T) {
 			const n = 3000
 			for i := range n {
 				val := rtFieldValue(rng, k.kind)
-				var r *Record
-				if k.kind == KindRaw {
-					blob := val.([]byte)
-					r = recOf(LevelInfo, "m", Field{key: "k", kind: KindRaw, val: blob})
-					line := r.Encoded()
-					_, members := decodeLineStrict(t, line)
-					if len(members) != 4 || members[1].key != "k" {
-						t.Fatalf("iter %d: unexpected wire members %v", i, memberKeys(members))
-					}
-					// raw embeds verbatim: byte equality with the blob
-					if !bytes.Equal(members[1].val, blob) {
-						t.Fatalf("iter %d: raw wire %s != blob %s", i, members[1].val, blob)
-					}
-					continue
-				}
-				r = recOf(LevelInfo, "m", fieldOf("k", val))
+				r := recOf(LevelInfo, "m", fieldOf("k", val))
 				line := r.Encoded()
 				_, members := decodeLineStrict(t, line)
 				if len(members) != 4 { // level, k, time, message
@@ -402,13 +356,6 @@ func TestEncodedRoundTripAllKinds(t *testing.T) {
 				}
 			}
 		})
-	}
-
-	// raw fields are embedded verbatim
-	r := recOf(LevelInfo, "m", Field{key: "raw", kind: KindRaw, val: []byte(`{"pre":true}`)})
-	got, _ := decodeLineStrict(t, r.Encoded())
-	if string(got["raw"]) != `{"pre":true}` {
-		t.Fatalf("raw field = %s", got["raw"])
 	}
 }
 
@@ -963,7 +910,6 @@ type lifeOpKind uint8
 const (
 	opAdd    lifeOpKind = iota // typed value from the table
 	opAddStr                   // raw string value from the stream (may be invalid UTF-8)
-	opAddRaw                   // AddRawJSON with a valid-JSON table blob
 	opAddVar                   // variadic Add with (possibly malformed) kv tails
 	opErr                      // hc.Error with a generated message
 	opSetMsg
@@ -997,7 +943,7 @@ type lifeOp struct {
 	key  string
 	val  any // typed value for opAdd, string for opAddStr/opSetMsg/opSetRoute,
 	// error for opErr/opEndErr, Level for opSetLevel, panic payload for opEndPanic
-	raw   []byte   // for opAddRaw (the JSON blob); for opEndPanic: nil or the co-delivered error message
+	raw   []byte   // for opEndPanic: nil or the co-delivered error message
 	pairs []kvPair // for opAddVar: extra (key, value) pairs after the leading one
 }
 
@@ -1068,13 +1014,6 @@ var progTimes = []time.Time{
 
 var progDurUnits = []time.Duration{time.Nanosecond, time.Microsecond, time.Millisecond, time.Second}
 
-// progRawTbl entries are all valid JSON so the encoded line stays
-// parseable (AddRawJSON embeds verbatim; invalid blobs are the
-// caller's contract breach, exercised in the unit tests).
-var progRawTbl = []string{
-	`{"n":0}`, `{"b":true}`, `{"s":"x"}`, `null`, `[1,2]`, `{"nested":{"k":"v"}}`, `["a","b"]`,
-}
-
 // maxProgOps caps decoded streams (width seeds need up to ~82 appends).
 const maxProgOps = 100
 
@@ -1100,10 +1039,6 @@ func decodeProgram(b []byte) lifeProgram {
 			key := progKeys[int(c.next())%len(progKeys)]
 			n := int(c.next() % 17)
 			ops = append(ops, lifeOp{kind: opAddStr, key: key, val: string(c.window(n))})
-		case opAddRaw:
-			key := progKeys[int(c.next())%len(progKeys)]
-			raw := progRawTbl[int(c.next())%len(progRawTbl)]
-			ops = append(ops, lifeOp{kind: opAddRaw, key: key, raw: []byte(raw)})
 		case opAddVar:
 			// One leading pair plus 0-4 extra pairs; extra keys may be
 			// empty strings or non-strings (malformed tails the public
@@ -1293,8 +1228,6 @@ func executeProgramOn(prog lifeProgram, op *Operation) {
 		switch o.kind {
 		case opAdd, opAddStr:
 			Add(ctx, o.key, o.val)
-		case opAddRaw:
-			AddRawJSON(ctx, o.key, o.raw)
 		case opAddVar:
 			kv := make([]any, 0, len(o.pairs)*2)
 			for _, p := range o.pairs {
@@ -1376,8 +1309,6 @@ func buildModel(prog lifeProgram) *lifeModel {
 		switch o.kind {
 		case opAdd, opAddStr:
 			m.append(fieldOf(o.key, o.val))
-		case opAddRaw:
-			m.append(Field{key: o.key, kind: KindRaw, val: o.raw})
 		case opAddVar:
 			m.append(fieldOf(o.key, o.val))
 			for _, p := range o.pairs {
@@ -1715,11 +1646,6 @@ func checkFieldWire(f Field, raw []byte) error {
 			return fmt.Errorf("err %q: wire %q != %q", f.key, s, want)
 		}
 		return nil
-	case KindRaw:
-		if want := string(f.val.([]byte)); string(raw) != want {
-			return fmt.Errorf("raw %q: wire %s != modeled %s", f.key, raw, want)
-		}
-		return nil
 	case KindAny:
 		var modelV, wireV any
 		modelBytes, err := json.Marshal(f.val)
@@ -1941,7 +1867,6 @@ func seedPrograms() []seedProg {
 	p := func(mode lifeMode, start Domain, ops ...lifeOp) lifeProgram {
 		return lifeProgram{mode: mode, start: start, ops: ops}
 	}
-	raw := func(s string) []byte { return []byte(s) }
 	endErr := func(err error) lifeOp { return lifeOp{kind: opEndErr, val: err} } // err stays a typed error (nil-safe)
 	endPanic := func(payload any, errp error) lifeOp {
 		return lifeOp{kind: opEndPanic, val: payload, raw: errBytes(errp)}
@@ -2018,7 +1943,6 @@ func seedPrograms() []seedProg {
 		anyOp("op.name", progTimes[0]),
 		anyOp("op.id", 42*time.Millisecond),
 		errOp("err-9"),
-		lifeOp{kind: opAddRaw, key: "http.route", raw: raw(`{"nested":{"k":"v"}}`)},
 		anyOp("http.method", map[string]any{"v": "x"}),
 		lifeOp{kind: opSetMsg, val: "custom"},
 		endErr(context.Canceled)))
@@ -2177,9 +2101,6 @@ func encodeProgram(prog lifeProgram) []byte {
 			s := o.val.(string)
 			b = append(b, keyByte(o.key), byte(len(s)))
 			b = append(b, s...)
-		case opAddRaw:
-			idx := indexOf(progRawTbl, string(o.raw))
-			b = append(b, keyByte(o.key), byte(idx))
 		case opAddVar:
 			b = append(b, keyByte(o.key))
 			encodeValue(&b, o.val)

--- a/property_test.go
+++ b/property_test.go
@@ -2349,3 +2349,9 @@ func keyByte(k string) byte {
 	}
 	return 0
 }
+
+// fieldAny constructs a KindAny field (test-only; production uses
+// event.appendAny for the canonical structured maps).
+func fieldAny(key string, value any) Field {
+	return Field{key: key, kind: KindAny, val: value}
+}

--- a/record.go
+++ b/record.go
@@ -1,7 +1,6 @@
 package hc
 
 import (
-	"fmt"
 	"sync/atomic"
 	"time"
 
@@ -41,8 +40,14 @@ func (r *Record) Fields() []Field { return r.fields }
 
 // Lookup returns the last value written under key.
 func (r *Record) Lookup(key string) (any, bool) {
-	for i := len(r.fields) - 1; i >= 0; i-- {
-		if f := r.fields[i]; f.key == key {
+	return lookupField(r.fields, key)
+}
+
+// lookupField is the single last-write-wins backward scan shared by
+// Record.Lookup, CapturedEvent.Lookup, and the event's live lookup.
+func lookupField(fields []Field, key string) (any, bool) {
+	for i := len(fields) - 1; i >= 0; i-- {
+		if f := fields[i]; f.key == key {
 			return valueOf(f), true
 		}
 	}
@@ -131,7 +136,10 @@ func aliasFields(fields []Field) []Field {
 }
 
 // dedupeScanLimit sets the crossover between the allocation-free
-// last-occurrence scan and the seen-set path for wide events.
+// last-occurrence scan and the seen-set path for wide events. It is a
+// cross-module contract: the adapters' lastOccurrences narrow path
+// uses the same literal 24 so bridges and the canonical line resolve
+// duplicates identically (pinned by the golden parity tests).
 const dedupeScanLimit = 24
 
 // appendDedupedFields emits each key once — its last value, at its last
@@ -218,13 +226,9 @@ func appendFieldJSON(dst []byte, f Field) []byte {
 	case KindDuration:
 		return jsonEnc.AppendDuration(dst, time.Duration(f.num), time.Millisecond, false, -1)
 	case KindErr:
-		err := f.val.(error)
-		if isTypedNilError(err) {
-			// Typed-nil errors must not reach Error(): nil deref
-			// would crash encode. fmt renders "<nil>" safely.
-			return jsonEnc.AppendString(dst, fmt.Sprint(err))
-		}
-		return jsonEnc.AppendString(dst, err.Error())
+		// safeErrorMessage fences typed-nils (direct or %w-wrapped)
+		// and panicking Error() implementations.
+		return jsonEnc.AppendString(dst, safeErrorMessage(f.val.(error)))
 	case KindRaw:
 		return append(dst, f.val.([]byte)...)
 	default:

--- a/record.go
+++ b/record.go
@@ -229,8 +229,6 @@ func appendFieldJSON(dst []byte, f Field) []byte {
 		// safeErrorMessage fences typed-nils (direct or %w-wrapped)
 		// and panicking Error() implementations.
 		return jsonEnc.AppendString(dst, safeErrorMessage(f.val.(error)))
-	case KindRaw:
-		return append(dst, f.val.([]byte)...)
 	default:
 		return jsonEnc.AppendInterface(dst, f.val)
 	}

--- a/record_test.go
+++ b/record_test.go
@@ -649,6 +649,8 @@ func TestTestSinkCopiesMutableValues(t *testing.T) {
 	}
 }
 
+// FuzzDedupeFields pins the canonical dedupe: every key emitted once,
+// at its last-occurrence position, with its last value.
 //
 // Canonical-key collisions (user fields named "message"/"time"/"level")
 // follow the logrus rename policy (record.go aliasKey): colliding user

--- a/record_test.go
+++ b/record_test.go
@@ -189,11 +189,10 @@ func TestRecordEncodedOnce(t *testing.T) {
 	var wg sync.WaitGroup
 	first := make([][]byte, 8)
 	for i := range 8 {
-		wg.Add(1)
-		go func(i int) {
-			defer wg.Done()
+		wg.Go(func() {
 			first[i] = r.Encoded()
-		}(i)
+
+		})
 	}
 	wg.Wait()
 	for i := 1; i < 8; i++ {
@@ -583,14 +582,13 @@ func TestJSONSinkConcurrency(t *testing.T) {
 	sink := NewJSONSink(&buf)
 	var wg sync.WaitGroup
 	for g := range 8 {
-		wg.Add(1)
-		go func(g int) {
-			defer wg.Done()
+		wg.Go(func() {
 			for i := range 100 {
 				rec := recOf(LevelInfo, "concurrent", fieldOf("g", g), fieldOf("i", i))
 				sink.Write(context.Background(), rec)
 			}
-		}(g)
+
+		})
 	}
 	wg.Wait()
 	lines := strings.Split(strings.TrimRight(buf.String(), "\n"), "\n")

--- a/record_test.go
+++ b/record_test.go
@@ -191,7 +191,6 @@ func TestRecordEncodedOnce(t *testing.T) {
 	for i := range 8 {
 		wg.Go(func() {
 			first[i] = r.Encoded()
-
 		})
 	}
 	wg.Wait()
@@ -587,7 +586,6 @@ func TestJSONSinkConcurrency(t *testing.T) {
 				rec := recOf(LevelInfo, "concurrent", fieldOf("g", g), fieldOf("i", i))
 				sink.Write(context.Background(), rec)
 			}
-
 		})
 	}
 	wg.Wait()

--- a/runtime.go
+++ b/runtime.go
@@ -10,11 +10,11 @@ import (
 // Compile-time error contract (amendment 17).
 var (
 	// ErrInvalidRate wraps out-of-range sampling rates.
-	ErrInvalidRate = errors.New("hc: invalid rate")
+	ErrInvalidRate = errors.New("invalid rate")
 	// ErrInvalidLevel wraps unknown level keys in configuration maps.
-	ErrInvalidLevel = errors.New("hc: invalid level")
+	ErrInvalidLevel = errors.New("invalid level")
 	// ErrInvalidOutcome wraps unknown outcome keys in configuration maps.
-	ErrInvalidOutcome = errors.New("hc: invalid outcome")
+	ErrInvalidOutcome = errors.New("invalid outcome")
 )
 
 // Config describes how a Runtime finalizes events. Bad configuration is
@@ -36,7 +36,11 @@ type Config struct {
 	Sampler Sampler
 
 	// OperationPolicies optionally customizes lifecycle behavior by
-	// domain; a domain SamplingRate overrides generic rates.
+	// domain; a domain SamplingRate overrides generic rates (and, when
+	// both are set, overrides LevelSamplingRates for that domain — v0
+	// precedence, documented in the README). The "" key is an alias
+	// for the default domain ("operation"): it applies only there,
+	// and an explicit "operation" key beats it.
 	OperationPolicies map[Domain]OperationPolicy
 
 	// Message is the default final message, overriding the per-domain

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -569,6 +569,8 @@ func TestFanoutSinkOrder(t *testing.T) {
 	}
 }
 
+// FuzzCompileConfig fuzzes hc.Compile with extreme configurations; the
+// oracle checks the documented contract:
 //
 //  1. Compile never panics.
 //  2. err != nil ⇒ the error wraps one of the three sentinels

--- a/sampling.go
+++ b/sampling.go
@@ -133,8 +133,8 @@ func RateSampler(rate float64) Sampler {
 	case rate >= 1:
 		return AlwaysSampler()
 	default:
-		return func(in SampleInput) bool {
-			return rand.Float64() < rate
+		return func(SampleInput) bool {
+			return shouldSample(rate)
 		}
 	}
 }

--- a/sink.go
+++ b/sink.go
@@ -4,8 +4,10 @@ import "context"
 
 // Sink receives finalized request events as read-only records, following
 // the slog.Handler.Handle shape. Implementations must be safe for
-// concurrent use (amendment 2) and must not retain the record or its
-// bytes past the call (copy anything you keep; amendment 9).
+// concurrent use and must not retain the record or its bytes past the
+// call (copy anything you keep). The ctx is the request's context at
+// End time: valid for cancellation observation, but background work
+// started with it inherits the request's cancellation.
 type Sink interface {
 	Write(ctx context.Context, rec *Record)
 }

--- a/test_sink.go
+++ b/test_sink.go
@@ -1,7 +1,6 @@
 package hc
 
 import (
-	"bytes"
 	"context"
 	"reflect"
 	"sync"
@@ -92,9 +91,6 @@ func copyFields(fields []Field) []Field {
 	out := make([]Field, len(fields))
 	for i, f := range fields {
 		switch f.kind {
-		case KindRaw:
-			raw, _ := f.val.([]byte)
-			out[i] = Field{key: f.key, kind: f.kind, val: bytes.Clone(raw)}
 		case KindAny, KindErr:
 			out[i] = Field{key: f.key, kind: f.kind, val: deepCopyValue(f.val, newVisitSet())}
 		default:

--- a/test_sink.go
+++ b/test_sink.go
@@ -26,12 +26,7 @@ func (c CapturedEvent) Fields() []Field { return c.fields }
 
 // Lookup returns the last value written under key.
 func (c CapturedEvent) Lookup(key string) (any, bool) {
-	for i := len(c.fields) - 1; i >= 0; i-- {
-		if f := c.fields[i]; f.key == key {
-			return valueOf(f), true
-		}
-	}
-	return nil, false
+	return lookupField(c.fields, key)
 }
 
 // TestSink captures events in memory for tests, copying retained values
@@ -47,8 +42,13 @@ func NewTestSink() *TestSink {
 }
 
 // Write captures one event, deep-copying the field values that are
-// mutable (KindAny/KindRaw payloads); typed scalars are immutable by
-// construction.
+// mutable (maps, slices, arrays — including through reflect); typed
+// scalars are immutable by construction. Pointer payloads are NOT
+// cloned (the pointed-to value stays shared with the caller), except
+// that error identity is deliberately preserved so errors.Is works
+// on captured fields. Mutate-through-a-pointer after End is visible
+// in the capture — copy it yourself before End if you need a frozen
+// snapshot of pointer-bearing data.
 func (t *TestSink) Write(_ context.Context, rec *Record) {
 	if t == nil || rec == nil {
 		return

--- a/types.go
+++ b/types.go
@@ -4,25 +4,30 @@ package hc
 type Domain string
 
 const (
-	DomainHTTP    Domain = "http"
-	DomainJob     Domain = "job"
-	DomainMessage Domain = "msg"
-	DomainCLI     Domain = "cli"
+	DomainHTTP    Domain = "http" // the middlewares; http.status is canonical
+	DomainJob     Domain = "job"  // worker integration; op.code is canonical
+	DomainMessage Domain = "msg"  // custom message-consumer operations
+	DomainCLI     Domain = "cli"  // command-line invocations
 )
 
 // Outcome describes operation completion status.
 type Outcome string
 
 const (
-	OutcomeSuccess  Outcome = "success"
-	OutcomeFailure  Outcome = "failure"
-	OutcomePanic    Outcome = "panic"
-	OutcomeCanceled Outcome = "canceled"
-	OutcomeTimeout  Outcome = "timeout"
-	OutcomeRetry    Outcome = "retry"
+	OutcomeSuccess  Outcome = "success"  // default for anything not below
+	OutcomeFailure  Outcome = "failure"  // error, or 5xx canonical code
+	OutcomePanic    Outcome = "panic"    // recovered panic (re-panicked)
+	OutcomeCanceled Outcome = "canceled" // error wrapping context.Canceled
+	OutcomeTimeout  Outcome = "timeout"  // error wrapping context.DeadlineExceeded
+	OutcomeRetry    Outcome = "retry"    // explicit-input only: resolveOutcome never emits it
 )
 
-// OperationPolicy customizes lifecycle defaults per domain.
+// OperationPolicy customizes lifecycle defaults per domain. Zero
+// fields mean the defaults: success logs at INFO, failures and panics
+// at ERROR; OutcomeLevels (checked first) and then the three level
+// fields override that, per outcome or per class. SamplingRate, when
+// set, replaces both the global rate and any LevelSamplingRates entry
+// for the domain.
 type OperationPolicy struct {
 	SuccessLevel  Level
 	FailureLevel  Level

--- a/wal.go
+++ b/wal.go
@@ -186,10 +186,6 @@ func (e *event) appendAny(gen uint64, key string, value any) {
 	e.append(gen, Field{key: key, kind: KindAny, val: value})
 }
 
-func (e *event) setRaw(ref *walRef, key string, raw []byte) {
-	e.append(ref.gen, Field{key: key, kind: KindRaw, val: raw})
-}
-
 // setError records the structured error field and latches hasErr.
 // Armed events serialize the append + latch under mu so a concurrent
 // seal cannot split them (the P5 matrix pins the discipline).

--- a/wal.go
+++ b/wal.go
@@ -284,12 +284,7 @@ func (e *event) snapshotFields() []Field {
 // lookup returns the last value written under key (last-write-wins view
 // of the un-deduped WAL).
 func (e *event) lookup(key string) (any, bool) {
-	for i := len(e.fields) - 1; i >= 0; i-- {
-		if e.fields[i].key == key {
-			return valueOf(e.fields[i]), true
-		}
-	}
-	return nil, false
+	return lookupField(e.fields, key)
 }
 
 func (e *event) release() {

--- a/wal_test.go
+++ b/wal_test.go
@@ -1544,7 +1544,6 @@ func stragglerWrite(ctx context.Context) {
 	SetMessage(ctx, "s-message")
 	SetLevel(ctx, LevelError)
 	Add(ctx, "s-add", "straggler-value")
-	AddRawJSON(ctx, "s-raw", []byte(`{"s":true}`))
 	Error(ctx, errors.New("s-error"))
 	SetRoute(ctx, "/s-route")
 }

--- a/wal_test.go
+++ b/wal_test.go
@@ -1613,7 +1613,6 @@ func TestStragglerInjectionMatrix(t *testing.T) {
 	}
 	for _, phase := range phases {
 		for _, armed := range []bool{false, true} {
-			phase, armed := phase, armed
 			t.Run(fmt.Sprintf("phase=%s armed=%v", phase, armed), func(t *testing.T) {
 				live := phase.live()
 
@@ -1869,7 +1868,6 @@ func TestStragglerArmedBurst(t *testing.T) {
 func TestStragglerSealedErrorNoLatch(t *testing.T) {
 	for _, armed := range []bool{false, true} {
 		for _, phase := range []matrixPhase{phasePreScan, phasePrePostSeal, phasePreCommit} {
-			phase, armed := phase, armed
 			t.Run(fmt.Sprintf("phase=%s armed=%v", phase, armed), func(t *testing.T) {
 				sink := &matrixSink{}
 				rt := MustCompile(Config{Sink: sink, SamplingRate: 0}) // healthy drops

--- a/wal_test.go
+++ b/wal_test.go
@@ -683,6 +683,7 @@ func canaryWrite(stale context.Context) {
 	Error(stale, errors.New("!BUG stale error"))
 }
 
+// Loom-lite oracle note.
 //
 // The one preemption-sensitive fragment is the straggler's append: its
 // single state load happens, then it acts. Between load and act the

--- a/wal_test.go
+++ b/wal_test.go
@@ -1813,9 +1813,7 @@ func TestStragglerArmedBurst(t *testing.T) {
 		const stragglers = 4
 		var wg sync.WaitGroup
 		for range stragglers {
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
+			wg.Go(func() {
 				mu.Lock()
 				ready++
 				start.Broadcast()
@@ -1824,7 +1822,8 @@ func TestStragglerArmedBurst(t *testing.T) {
 				}
 				mu.Unlock()
 				stragglerWrite(ctx) // armed: serialized under ev.mu
-			}()
+
+			})
 		}
 		// release all stragglers at once (logrus start-line technique)
 		mu.Lock()

--- a/wal_test.go
+++ b/wal_test.go
@@ -415,13 +415,11 @@ func TestSealDuringArmedAppend(t *testing.T) {
 		op := Start(context.Background(), rt, OperationStart{Domain: DomainJob, Name: "r"})
 		ctx := op.Context()
 		op.ev.arm() // arm BEFORE End to force the guarded path
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			for i := range 50 {
 				Add(ctx, "armed", i)
 			}
-		}()
+		})
 		op.End(nil)
 		wg.Wait()
 	}
@@ -1911,14 +1909,12 @@ func TestArmedSetterSerialization(t *testing.T) {
 		const writes = 2000
 		var wg sync.WaitGroup
 		for i := range setters {
-			wg.Add(1)
-			go func(i int) {
-				defer wg.Done()
+			wg.Go(func() {
 				for range writes {
 					SetMessage(ctx, fmt.Sprintf("msg-%d", i))
 					SetLevel(ctx, LevelWarn)
 				}
-			}(i)
+			})
 		}
 		// The owner seals while the setters hammer: armed serialization
 		// means every write either lands pre-seal or drops post-seal.

--- a/wal_test.go
+++ b/wal_test.go
@@ -1822,7 +1822,6 @@ func TestStragglerArmedBurst(t *testing.T) {
 				}
 				mu.Unlock()
 				stragglerWrite(ctx) // armed: serialized under ev.mu
-
 			})
 		}
 		// release all stragglers at once (logrus start-line technique)


### PR DESCRIPTION
## Summary — the overnight final PR (supersedes #49–#52)

Five commits, three review generations, one unit:

1. **GLM skill-audit fixes** — parity-test map-order roulette, wire-test quiescence, nested-NaN coverage, typed-nil rendering pins, renames, `zapcore.Lock` (plus the footnote: the lint gate rejected GLM-Flash's function-level `lint:ignore` claim).
2. **Fuzz CI gap closed** — `FuzzCrashAdversarialValues` + `FuzzCrashArmedInterleavings` wired into the 60s `ci.yml` gate and the 10m nightly runs (they were seed-only before).
3. **WaitGroup.Go modernization** — whole-scope sweep (27 sites total), `strings.SplitSeq`.
4. **Comment archaeology** — restored every orphaned contract list the consolidation moves amputated; second-pass GLM review then caught where my own restoration glued one sentence onto the wrong fuzz target — fixed.
5. **Whole-branch GLM core audit** — the full production source through five GLM-5.3 personas + three GLM-5.3-Flash personas. **1 defect + 2 probable-defects, all fixed and pinned**, plus API-freeze polish:
   - **defect**: `%w`-wrapped typed-nil errors defeated the typed-nil containment and panicked inside `End` *after* its recover (probe-verified) → `safeErrorMessage` recover-fence at every extraction site
   - **probable**: `AddRawJSON(ctx, key, nil)` emitted a bare `"key":` member, corrupting every line for that request (probe-verified: `{"blob":,...`) → zero-length blobs are a no-op
   - **probable** (documented): TestSink pointer payloads stay shared — the exact contract now stated, errors keep identity deliberately
   - **freeze polish**: sentinel double-prefix (`hc: ... hc: invalid rate`) fixed at the last free rename; godoc on `OperationPolicy`/`Config.OperationPolicies`/`OutcomeRetry` (explicit-input-only!)/`Domain`/`Level`; `End`/`Sink` public docs de-internalized with ctx-cancellation and nesting semantics; worker doc example taught propagation (its own `hc.Add` calls were no-ops); `frameworkStyleErrorMessage` reflection contract documented; `TestPanicWireShapeParity` pins the two copies of the canonical panic shape

   Architecture verdicts from the auditors: *"the concurrency heart — generation-guarded WAL, seal/arm state machine, one-shot End, LWW encoder — survived a full adversarial re-read with zero new defects"*; *"the core is essentially ready to tag 1.0.0."*

## Validation
Full root suite + `-race` (goleak gate, ~85 tests), all 12 modules test + vet, gofmt/gofumpt/staticcheck clean, both new regression probes red-before/green-after.
