### PR TITLE
fix(v2): apply the final pre-1.0 quality-audit fixes

### DIFF
--- a/adapter/slog/sink.go
+++ b/adapter/slog/sink.go
@@ -5,13 +5,11 @@ package slogadapter
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
-	"reflect"
-	"slices"
 	"sync"
 
 	"github.com/happytoolin/happycontext"
+	"github.com/happytoolin/happycontext/bridge"
 )
 
 const (
@@ -75,18 +73,18 @@ func (s *Sink) Write(ctx context.Context, rec *hc.Record) {
 	bufPtr := slogAttrPool.Get().(*[]slog.Attr)
 	attrs := (*bufPtr)[:0]
 	defer func() { recycleAttrs(bufPtr, attrs) }()
-	for _, i := range lastOccurrences(fields) {
+	for _, i := range bridge.LastIndices(fields, hc.Field.Key) {
 		attrs = append(attrs, attrOf(fields[i]))
 	}
 	s.logger.LogAttrs(ctx, slogLevel, rec.Message(), attrs...)
 }
 
 // attrOf maps a typed field to the matching slog constructor. Error
-// fields render the message string and raw bytes render via slog.Any
-// (base64) — both the v0 adapter's shapes.
+// fields render the message string; everything without a typed slot
+// goes through slog.Any.
 func attrOf(f hc.Field) slog.Attr {
 	if err, ok := f.Err(); ok {
-		return slog.String(f.Key(), errMessage(err))
+		return slog.String(f.Key(), bridge.ErrorMessage(err))
 	}
 	if str, ok := f.Str(); ok {
 		return slog.String(f.Key(), str)
@@ -115,53 +113,4 @@ func attrOf(f hc.Field) slog.Attr {
 	return slog.Any(f.Key(), f.Any())
 }
 
-// lastOccurrences returns the indices of each key's last write, in
-// forward emission order — the same duplicate resolution the core
-// encoder applies (linear scan for narrow events, backward seen-set
-// collection for wide ones).
-// The 24 crossover matches hc's dedupeScanLimit so bridges and the
-// canonical line resolve duplicates identically (cross-module
-// contract, pinned by the golden parity tests).
-func lastOccurrences(fields []hc.Field) []int {
-	if len(fields) <= 24 {
-		var stack [24]int // allocation-free narrow path
-		n := 0
-		for i := range fields {
-			last := true
-			for j := i + 1; j < len(fields); j++ {
-				if fields[j].Key() == fields[i].Key() {
-					last = false
-					break
-				}
-			}
-			if last {
-				stack[n] = i
-				n++
-			}
-		}
-		return stack[:n:n]
-	}
-	seen := make(map[string]struct{}, len(fields)*2)
-	kept := make([]int, 0, len(fields))
-	for i := len(fields) - 1; i >= 0; i-- {
-		if _, dup := seen[fields[i].Key()]; dup {
-			continue
-		}
-		seen[fields[i].Key()] = struct{}{}
-		kept = append(kept, i)
-	}
-	slices.Reverse(kept)
-	return kept
-}
-
 var _ hc.Sink = (*Sink)(nil)
-
-// errMessage renders an error field's message, tolerating typed-nil
-// errors (non-nil interface, nil pointer): their Error() panics on nil
-// dereference, and fmt renders them safely as "<nil>".
-func errMessage(err error) string {
-	if v := reflect.ValueOf(err); v.Kind() == reflect.Pointer && v.IsNil() {
-		return fmt.Sprint(err)
-	}
-	return err.Error()
-}

--- a/adapter/zap/sink.go
+++ b/adapter/zap/sink.go
@@ -5,11 +5,9 @@ package zapadapter
 
 import (
 	"context"
-	"fmt"
-	"reflect"
-	"slices"
 
 	"github.com/happytoolin/happycontext"
+	"github.com/happytoolin/happycontext/bridge"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
@@ -42,18 +40,18 @@ func (s *Sink) Write(ctx context.Context, rec *hc.Record) {
 	}
 
 	zapFields := make([]zap.Field, 0, len(fields))
-	for _, i := range lastOccurrences(fields) {
+	for _, i := range bridge.LastIndices(fields, hc.Field.Key) {
 		zapFields = append(zapFields, fieldOf(fields[i]))
 	}
 	checked.Write(zapFields...)
 }
 
 // fieldOf maps a typed record field to the matching zap constructor.
-// Error fields render the message string and raw bytes render via
-// zap.Any (base64) — both the v0 adapter's shapes for those payloads.
+// Error fields render the message string; everything without a typed
+// slot goes through zap.Any.
 func fieldOf(f hc.Field) zap.Field {
 	if err, ok := f.Err(); ok {
-		return zap.String(f.Key(), errMessage(err))
+		return zap.String(f.Key(), bridge.ErrorMessage(err))
 	}
 	if str, ok := f.Str(); ok {
 		return zap.String(f.Key(), str)
@@ -95,53 +93,4 @@ func (s *Sink) check(level hc.Level, message string) *zapcore.CheckedEntry {
 	}
 }
 
-// lastOccurrences returns the indices of each key's last write, in
-// forward emission order — the same duplicate resolution the core
-// encoder applies (linear scan for narrow events, backward seen-set
-// collection for wide ones).
-// The 24 crossover matches hc's dedupeScanLimit so bridges and the
-// canonical line resolve duplicates identically (cross-module
-// contract, pinned by the golden parity tests).
-func lastOccurrences(fields []hc.Field) []int {
-	if len(fields) <= 24 {
-		var stack [24]int // allocation-free narrow path
-		n := 0
-		for i := range fields {
-			last := true
-			for j := i + 1; j < len(fields); j++ {
-				if fields[j].Key() == fields[i].Key() {
-					last = false
-					break
-				}
-			}
-			if last {
-				stack[n] = i
-				n++
-			}
-		}
-		return stack[:n:n]
-	}
-	seen := make(map[string]struct{}, len(fields)*2)
-	kept := make([]int, 0, len(fields))
-	for i := len(fields) - 1; i >= 0; i-- {
-		if _, dup := seen[fields[i].Key()]; dup {
-			continue
-		}
-		seen[fields[i].Key()] = struct{}{}
-		kept = append(kept, i)
-	}
-	slices.Reverse(kept)
-	return kept
-}
-
 var _ hc.Sink = (*Sink)(nil)
-
-// errMessage renders an error field's message, tolerating typed-nil
-// errors (non-nil interface, nil pointer): their Error() panics on nil
-// dereference, and fmt renders them safely as "<nil>".
-func errMessage(err error) string {
-	if v := reflect.ValueOf(err); v.Kind() == reflect.Pointer && v.IsNil() {
-		return fmt.Sprint(err)
-	}
-	return err.Error()
-}

--- a/adapter/zerolog/sink.go
+++ b/adapter/zerolog/sink.go
@@ -7,11 +7,10 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"reflect"
-	"slices"
 	"unsafe"
 
 	"github.com/happytoolin/happycontext"
+	"github.com/happytoolin/happycontext/bridge"
 	"github.com/rs/zerolog"
 )
 
@@ -177,7 +176,7 @@ func (s *Sink) Write(ctx context.Context, rec *hc.Record) {
 	}
 
 	fields := rec.Fields()
-	for _, i := range lastOccurrences(fields) {
+	for _, i := range bridge.LastIndices(fields, hc.Field.WireKey) {
 		event = appendField(event, fields[i])
 	}
 	// Stamp the record's own completion time (rec.Time) rather than a
@@ -225,8 +224,7 @@ func zlvlFor(level hc.Level) zerolog.Level {
 
 // appendField maps a typed record field to zerolog's constructor — the
 // mapping the v0 adapter used (error → message string, duration →
-// float milliseconds via zerolog defaults, time → RFC3339 string),
-// with RawJSON appending pre-encoded bytes verbatim.
+// float milliseconds via zerolog defaults, time → RFC3339 string).
 func appendField(event *zerolog.Event, f hc.Field) *zerolog.Event {
 	// WireKey matches Encoded(): colliding envelope keys become fields.*.
 	key := f.WireKey()
@@ -255,58 +253,9 @@ func appendField(event *zerolog.Event, f hc.Field) *zerolog.Event {
 		return event.Dur(key, d)
 	}
 	if err, ok := f.Err(); ok {
-		return event.Str(key, errMessage(err))
+		return event.Str(key, bridge.ErrorMessage(err))
 	}
 	return event.Interface(key, f.Any())
 }
 
-// lastOccurrences returns the indices of each key's last write, in
-// forward emission order — the same duplicate resolution the core
-// encoder applies (allocation-free scan for narrow events, backward
-// seen-set collection for wide ones).
-// The 24 crossover matches hc's dedupeScanLimit so bridges and the
-// canonical line resolve duplicates identically (cross-module
-// contract, pinned by the golden parity tests).
-func lastOccurrences(fields []hc.Field) []int {
-	if len(fields) <= 24 {
-		var stack [24]int // allocation-free narrow path
-		n := 0
-		for i := range fields {
-			last := true
-			for j := i + 1; j < len(fields); j++ {
-				if fields[j].WireKey() == fields[i].WireKey() {
-					last = false
-					break
-				}
-			}
-			if last {
-				stack[n] = i
-				n++
-			}
-		}
-		return stack[:n:n]
-	}
-	seen := make(map[string]struct{}, len(fields)*2)
-	kept := make([]int, 0, len(fields))
-	for i := len(fields) - 1; i >= 0; i-- {
-		if _, dup := seen[fields[i].WireKey()]; dup {
-			continue
-		}
-		seen[fields[i].WireKey()] = struct{}{}
-		kept = append(kept, i)
-	}
-	slices.Reverse(kept)
-	return kept
-}
-
 var _ hc.Sink = (*Sink)(nil)
-
-// errMessage renders an error field's message, tolerating typed-nil
-// errors (non-nil interface, nil pointer): their Error() panics on nil
-// dereference, and fmt renders them safely as "<nil>".
-func errMessage(err error) string {
-	if v := reflect.ValueOf(err); v.Kind() == reflect.Pointer && v.IsNil() {
-		return fmt.Sprint(err)
-	}
-	return err.Error()
-}

--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -1,0 +1,77 @@
+// Package bridge provides the helpers shared by the first-party sink
+// bridges (the slog, zap, and zerolog adapters) and the core encoder, so
+// every output path resolves duplicate fields identically and renders
+// error fields with the same panic fencing. The bridges live in separate
+// modules that require this one, so the shared code is exported here
+// rather than under internal/.
+package bridge
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// NarrowLimit is the crossover between the allocation-free
+// last-occurrence scan and the seen-set path for wide field lists. It is
+// a cross-module contract: the canonical encoder and every bridge must
+// resolve duplicate keys identically, so they share this one constant
+// (pinned by the golden parity tests).
+const NarrowLimit = 24
+
+// LastIndices returns the indices of each key's last occurrence, in
+// forward order — last-write-wins duplicate resolution. Narrow lists
+// use an allocation-free scan; wide ones collect seen keys backward in
+// a map. The key function selects each item's comparison key (bridges
+// that alias envelope-colliding keys pass the aliased view).
+func LastIndices[T any](items []T, key func(T) string) []int {
+	if len(items) <= NarrowLimit {
+		var stack [NarrowLimit]int // allocation-free narrow path
+		n := 0
+		for i := range items {
+			last := true
+			for j := i + 1; j < len(items); j++ {
+				if key(items[j]) == key(items[i]) {
+					last = false
+					break
+				}
+			}
+			if last {
+				stack[n] = i
+				n++
+			}
+		}
+		return stack[:n:n]
+	}
+	seen := make(map[string]struct{}, len(items)*2)
+	kept := make([]int, 0, len(items))
+	for i := len(items) - 1; i >= 0; i-- {
+		if _, dup := seen[key(items[i])]; dup {
+			continue
+		}
+		seen[key(items[i])] = struct{}{}
+		kept = append(kept, i)
+	}
+	// reverse into forward order
+	for l, r := 0, len(kept)-1; l < r; l, r = l+1, r-1 {
+		kept[l], kept[r] = kept[r], kept[l]
+	}
+	return kept
+}
+
+// ErrorMessage renders an error field's message, tolerating the two
+// ways a user error can explode: typed-nil errors (non-nil interface,
+// nil pointer — their Error() nil-derefs, and fmt renders them safely
+// as "<nil>") and Error() implementations that panic (the panic is
+// contained and the value rendered via fmt, the same fence the core
+// encoder applies).
+func ErrorMessage(err error) (msg string) {
+	if v := reflect.ValueOf(err); v.Kind() == reflect.Pointer && v.IsNil() {
+		return fmt.Sprint(err)
+	}
+	defer func() {
+		if recover() != nil {
+			msg = fmt.Sprint(err)
+		}
+	}()
+	return err.Error()
+}

--- a/bridge/bridge_test.go
+++ b/bridge/bridge_test.go
@@ -1,0 +1,95 @@
+package bridge
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+type item struct{ k string }
+
+// TestLastIndicesResolvesLastWriteWins is the bridge contract: each key
+// survives exactly once, at its last position, in forward order — the
+// same resolution the canonical encoder applies.
+func TestLastIndicesResolvesLastWriteWins(t *testing.T) {
+	tests := []struct {
+		name  string
+		items []item
+		want  []int
+	}{
+		{"empty", nil, []int{}},
+		{"single", []item{{"a"}}, []int{0}},
+		{"distinct", []item{{"a"}, {"b"}, {"c"}}, []int{0, 1, 2}},
+		{"dup keeps last in order", []item{{"a"}, {"b"}, {"a"}}, []int{1, 2}},
+		{"all dup", []item{{"a"}, {"a"}, {"a"}}, []int{2}},
+		{"wide past crossover", make([]item, NarrowLimit*3), nil}, // filled below
+	}
+	wideIdx := len(tests) - 1
+	tests[wideIdx].items = make([]item, NarrowLimit*3)
+	for i := range tests[wideIdx].items {
+		tests[wideIdx].items[i] = item{fmt.Sprintf("k%d", i%NarrowLimit)} // NarrowLimit distinct keys, each 3×
+	}
+	last := make([]int, 0, NarrowLimit)
+	for k := 0; k < NarrowLimit; k++ {
+		last = append(last, NarrowLimit*2+k) // the final block holds each key's last write
+	}
+	tests[wideIdx].want = last
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := LastIndices(tt.items, func(it item) string { return it.k })
+			if len(got) != len(tt.want) {
+				t.Fatalf("indices = %v, want %v", got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Fatalf("indices = %v, want %v (resolution differs at %d)", got, tt.want, i)
+				}
+			}
+		})
+	}
+}
+
+// TestLastIndicesNarrowPathMatchesWidePath pins the crossover: both
+// sides of NarrowLimit must resolve identically (the golden parity
+// tests rely on bridge and core agreeing).
+func TestLastIndicesNarrowPathMatchesWidePath(t *testing.T) {
+	build := func(n int) []item {
+		items := make([]item, n)
+		for i := range items {
+			items[i] = item{fmt.Sprintf("k%d", i%7)}
+		}
+		return items
+	}
+	narrow := LastIndices(build(NarrowLimit), func(it item) string { return it.k })
+	wide := LastIndices(build(NarrowLimit+1), func(it item) string { return it.k })
+	if len(narrow) != 7 || len(wide) != 7 {
+		t.Fatalf("distinct counts: narrow=%d wide=%d, want 7 both", len(narrow), len(wide))
+	}
+}
+
+type typedNilErr struct{ msg string }
+
+// Error would deref the nil receiver if called — but fmt never calls
+// methods on nil pointer operands, rendering "<nil>" instead.
+func (e *typedNilErr) Error() string { return e.msg }
+
+type panickingErr struct{}
+
+func (panickingErr) Error() string { panic("Error() boom") }
+
+// TestErrorMessageFencesHostileErrors pins the fence: typed-nil errors
+// render via fmt ("<nil>"), panicking Error() implementations are
+// contained to a fmt fallback, ordinary errors pass through.
+func TestErrorMessageFencesHostileErrors(t *testing.T) {
+	var nilErr *typedNilErr
+	if got := ErrorMessage(nilErr); got != "<nil>" {
+		t.Fatalf("typed-nil message = %q, want %q", got, "<nil>")
+	}
+	if got := ErrorMessage(panickingErr{}); got == "" {
+		t.Fatal("panicking Error() yielded an empty message, want a fmt fallback rendering")
+	}
+	if got, want := ErrorMessage(errors.New("boom")), "boom"; got != want {
+		t.Fatalf("ordinary message = %q, want %q", got, want)
+	}
+}

--- a/crash_test.go
+++ b/crash_test.go
@@ -1511,11 +1511,11 @@ func (g *recordGrabber) Write(_ context.Context, rec *Record) { g.rec = rec }
 // Fanout: one sink fanning out to several downstream sinks
 // concurrently — the Sink contract requires the fanout itself to be
 // safe, and the first-party sinks it calls must be too.
-type fanoutSink struct {
+type concurrentFanoutSink struct {
 	inner []Sink
 }
 
-func (f *fanoutSink) Write(ctx context.Context, rec *Record) {
+func (f *concurrentFanoutSink) Write(ctx context.Context, rec *Record) {
 	var wg sync.WaitGroup
 	for _, s := range f.inner {
 		wg.Go(func() {
@@ -1528,7 +1528,7 @@ func (f *fanoutSink) Write(ctx context.Context, rec *Record) {
 func TestCrashFanoutSinks(t *testing.T) {
 	var buf strings.Builder
 	ts := NewTestSink()
-	fan := &fanoutSink{inner: []Sink{NewJSONSink(&buf), ts, NewJSONSink(&strings.Builder{})}}
+	fan := &concurrentFanoutSink{inner: []Sink{NewJSONSink(&buf), ts, NewJSONSink(&strings.Builder{})}}
 	rt := MustCompile(Config{Sink: fan, SamplingRate: 1})
 
 	var wg sync.WaitGroup

--- a/errorfield.go
+++ b/errorfield.go
@@ -81,11 +81,16 @@ func safeErrorMessage(err error) (msg string) {
 	return err.Error()
 }
 
+// maxUnwrapDepth bounds the Unwrap walk in deepestUnwrappedError.
+// Real wrapped chains are shallow; the bound also ends any chain that
+// manages to cycle without repeating a comparable error value.
+const maxUnwrapDepth = 100
+
 func deepestUnwrappedError(err error) error {
 	current := err
 	seen := make(map[error]struct{})
 	for depth := 0; current != nil; depth++ {
-		if depth >= 100 {
+		if depth >= maxUnwrapDepth {
 			return current
 		}
 		if isComparableError(current) {

--- a/hc.go
+++ b/hc.go
@@ -22,7 +22,8 @@ func eventFromContext(ctx context.Context) *walRef {
 // helper family.
 //
 // Additional pairs may be passed variadically: Add(ctx, "a", 1, "b", 2).
-// Every pair key must be a string; malformed tails are skipped.
+// Every pair key must be a non-empty string; empty and non-string keys
+// are skipped uniformly, leading pair included.
 //
 // The request goroutine is the sole writer: passing the enriched
 // context to child goroutines is fine, but hc.Add from a child
@@ -34,7 +35,9 @@ func Add(ctx context.Context, key string, value any, kv ...any) {
 		return
 	}
 	if len(kv) == 0 {
-		ref.ev.append(ref.gen, fieldOf(key, value)) // single-pair fast path
+		if key != "" { // single-pair fast path
+			ref.ev.append(ref.gen, fieldOf(key, value))
+		}
 		return
 	}
 	ref.ev.addKV(ref, key, value, kv...)

--- a/integration/common/lifecycle.go
+++ b/integration/common/lifecycle.go
@@ -19,7 +19,7 @@ func StartRequest(baseCtx context.Context, rt *hc.Runtime, method, path string) 
 		Domain: hc.DomainHTTP,
 		Name:   "request",
 	})
-	hc.Add(op.Context(), "http.method", method, "http.path", path)
+	hc.Add(op.Context(), hc.KeyHTTPMethod, method, hc.KeyHTTPPath, path)
 	return op
 }
 
@@ -42,29 +42,25 @@ func FinalizeRequest(op *hc.Operation, route string, statusCode int, err error, 
 		// One ctx lookup for all three canonical writes (v0 parity:
 		// op.name is the resolved route template, last-write-wins over
 		// StartRequest's "request").
-		hc.Add(op.Context(), "http.route", route, "op.name", route, "http.status", statusCode)
+		hc.Add(op.Context(), hc.KeyHTTPRoute, route, hc.KeyOpName, route, hc.KeyHTTPStatus, statusCode)
 	} else {
-		hc.Add(op.Context(), "http.status", statusCode)
+		hc.Add(op.Context(), hc.KeyHTTPStatus, statusCode)
 	}
 
 	if recovered != nil {
-		hc.Add(op.Context(), "panic", PanicField(recovered))
+		hc.Add(op.Context(), hc.KeyPanic, PanicField(recovered))
 		// The real error (if any) wins over the synthetic panic one.
 		if err != nil {
 			hc.Error(op.Context(), err)
 		} else {
 			hc.Error(op.Context(), fmt.Errorf("panic: %v", recovered))
 		}
-		hc.Add(op.Context(), "op.outcome", string(hc.OutcomePanic))
+		hc.Add(op.Context(), hc.KeyOpOutcome, string(hc.OutcomePanic))
 		_ = op.End(nil)
 		return
 	}
-	if err != nil {
-		// No explicit hc.Error here: End(&err) writes the canonical
-		// error field itself (annotateOperationFailures). The v0 map
-		// folded a double write invisibly; the append-only WAL would
-		// keep both entries in Fields().
-	}
+	// No explicit hc.Error on the error path: End(&err) writes the
+	// canonical error field itself (annotateOperationFailures).
 	_ = op.End(&err)
 }
 
@@ -77,22 +73,37 @@ func PanicField(recovered any) map[string]any {
 	}
 }
 
-// ResolveStatus determines the final HTTP status to log.
-func ResolveStatus(currentStatus int, err error, recovered any, responseStarted bool, errorStatus int) int {
-	if recovered != nil && !responseStarted {
+// StatusInput carries what a middleware knows when it finalizes: the
+// status the framework writer currently holds, the terminal error and
+// recovered panic, whether the response already started, and the HTTP
+// status the error implies (0 if none).
+type StatusInput struct {
+	Committed       int
+	Err             error
+	Recovered       any
+	ResponseStarted bool
+	ErrorStatus     int
+}
+
+// ResolveStatus determines the final HTTP status to log from in:
+// panics and handler errors before the response started resolve to a
+// 5xx (the error's own status when it carries one), an unwritten
+// writer resolves to 200, and a committed status stands.
+func ResolveStatus(in StatusInput) int {
+	if in.Recovered != nil && !in.ResponseStarted {
 		return http.StatusInternalServerError
 	}
 
-	if err != nil && !responseStarted {
-		if errorStatus >= 400 {
-			return errorStatus
+	if in.Err != nil && !in.ResponseStarted {
+		if in.ErrorStatus >= 400 {
+			return in.ErrorStatus
 		}
 		return http.StatusInternalServerError
 	}
 
-	if currentStatus == 0 {
+	if in.Committed == 0 {
 		return http.StatusOK
 	}
 
-	return currentStatus
+	return in.Committed
 }

--- a/integration/echo/middleware.go
+++ b/integration/echo/middleware.go
@@ -7,7 +7,7 @@ import (
 	"errors"
 	"net/http"
 
-	hc "github.com/happytoolin/happycontext"
+	"github.com/happytoolin/happycontext"
 	"github.com/happytoolin/happycontext/integration/common"
 	"github.com/labstack/echo/v4"
 )
@@ -32,13 +32,13 @@ func Middleware(rt *hc.Runtime) echo.MiddlewareFunc {
 			defer func() {
 				recovered := recover()
 				route := c.Path()
-				status := common.ResolveStatus(
-					c.Response().Status,
-					finalizeErr,
-					recovered,
-					c.Response().Committed,
-					statusFromEchoError(finalizeErr),
-				)
+				status := common.ResolveStatus(common.StatusInput{
+					Committed:       c.Response().Status,
+					Err:             finalizeErr,
+					Recovered:       recovered,
+					ResponseStarted: c.Response().Committed,
+					ErrorStatus:     statusFromEchoError(finalizeErr),
+				})
 				common.FinalizeRequest(op, route, status, finalizeErr, recovered)
 
 				if recovered != nil {

--- a/integration/fiber/middleware.go
+++ b/integration/fiber/middleware.go
@@ -32,8 +32,22 @@ func Middleware(rt *hc.Runtime) fiber.Handler {
 				routePath = route.Path
 			}
 			status := c.Response().StatusCode()
+			// Fiber's response struct defaults its status to 200 and does
+			// not track whether the handler committed anything, so "the
+			// response started" must be inferred: any status other than
+			// the 200 default, or a non-empty body under 200, means bytes
+			// or a status actually went out. A bare 200 with no body is
+			// treated as not started so a pre-response panic still
+			// resolves to 500. Do not "simplify" this — it is the
+			// panic-vs-committed-status contract.
 			responseStarted := status != 0 && (status != http.StatusOK || len(c.Response().Body()) > 0)
-			status = common.ResolveStatus(status, finalizeErr, recovered, responseStarted, statusFromFiberError(finalizeErr))
+			status = common.ResolveStatus(common.StatusInput{
+				Committed:       status,
+				Err:             finalizeErr,
+				Recovered:       recovered,
+				ResponseStarted: responseStarted,
+				ErrorStatus:     statusFromFiberError(finalizeErr),
+			})
 			common.FinalizeRequest(op, routePath, status, finalizeErr, recovered)
 
 			if recovered != nil {

--- a/integration/fiberv3/middleware.go
+++ b/integration/fiberv3/middleware.go
@@ -32,8 +32,22 @@ func Middleware(rt *hc.Runtime) fiber.Handler {
 				routePath = route.Path
 			}
 			status := c.Response().StatusCode()
+			// Fiber's response struct defaults its status to 200 and does
+			// not track whether the handler committed anything, so "the
+			// response started" must be inferred: any status other than
+			// the 200 default, or a non-empty body under 200, means bytes
+			// or a status actually went out. A bare 200 with no body is
+			// treated as not started so a pre-response panic still
+			// resolves to 500. Do not "simplify" this — it is the
+			// panic-vs-committed-status contract.
 			responseStarted := status != 0 && (status != http.StatusOK || len(c.Response().Body()) > 0)
-			status = common.ResolveStatus(status, finalizeErr, recovered, responseStarted, statusFromFiberError(finalizeErr))
+			status = common.ResolveStatus(common.StatusInput{
+				Committed:       status,
+				Err:             finalizeErr,
+				Recovered:       recovered,
+				ResponseStarted: responseStarted,
+				ErrorStatus:     statusFromFiberError(finalizeErr),
+			})
 			common.FinalizeRequest(op, routePath, status, finalizeErr, recovered)
 
 			if recovered != nil {

--- a/integration/gin/middleware.go
+++ b/integration/gin/middleware.go
@@ -5,7 +5,7 @@ package ginhappycontext
 
 import (
 	"github.com/gin-gonic/gin"
-	hc "github.com/happytoolin/happycontext"
+	"github.com/happytoolin/happycontext"
 	"github.com/happytoolin/happycontext/integration/common"
 )
 
@@ -30,7 +30,12 @@ func Middleware(rt *hc.Runtime) gin.HandlerFunc {
 					err = last.Err
 				}
 			}
-			status := common.ResolveStatus(c.Writer.Status(), err, recovered, c.Writer.Written(), 0)
+			status := common.ResolveStatus(common.StatusInput{
+				Committed:       c.Writer.Status(),
+				Err:             err,
+				Recovered:       recovered,
+				ResponseStarted: c.Writer.Written(),
+			})
 			common.FinalizeRequest(op, c.FullPath(), status, err, recovered)
 
 			if recovered != nil {

--- a/integration/std/middleware.go
+++ b/integration/std/middleware.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"sync"
 
-	hc "github.com/happytoolin/happycontext"
+	"github.com/happytoolin/happycontext"
 	"github.com/happytoolin/happycontext/integration/common"
 )
 
@@ -36,7 +36,11 @@ func Middleware(rt *hc.Runtime) func(http.Handler) http.Handler {
 				statusCode, wroteHeader := core.statusCode, core.wroteHeader
 				core.release()
 				recovered := recover()
-				status := common.ResolveStatus(statusCode, nil, recovered, wroteHeader, 0)
+				status := common.ResolveStatus(common.StatusInput{
+					Committed:       statusCode,
+					Recovered:       recovered,
+					ResponseStarted: wroteHeader,
+				})
 				common.FinalizeRequest(op, req.Pattern, status, nil, recovered)
 
 				if recovered != nil {

--- a/integration/worker/lifecycle_scenarios_test.go
+++ b/integration/worker/lifecycle_scenarios_test.go
@@ -1,4 +1,4 @@
-package workerhc
+package workerhappycontext
 
 // P8.2 worker lifecycle scenario battery (dst-research §8.2): the
 // job-shaped scenarios assembled as end-to-end flows with real
@@ -15,7 +15,7 @@ import (
 	"testing"
 	"time"
 
-	hc "github.com/happytoolin/happycontext"
+	"github.com/happytoolin/happycontext"
 )
 
 // TestWorkerRetryMetadata: attempt/max_attempts survive to the wire

--- a/integration/worker/worker.go
+++ b/integration/worker/worker.go
@@ -1,13 +1,13 @@
-// Package workerhc provides the background-job happycontext lifecycle:
-// Start opens a job operation from JobMeta and returns the deferred-End
-// handle.
-package workerhc
+// Package workerhappycontext provides the background-job happycontext
+// lifecycle: Start opens a job operation from JobMeta and returns the
+// deferred-End handle.
+package workerhappycontext
 
 import (
 	"context"
 	"time"
 
-	hc "github.com/happytoolin/happycontext"
+	"github.com/happytoolin/happycontext"
 )
 
 // JobMeta describes background job execution metadata.
@@ -27,7 +27,7 @@ type JobMeta struct {
 // no-op (the original ctx carries no WAL):
 //
 //	func run(ctx context.Context, rt *hc.Runtime) (err error) {
-//		op := workerhc.Start(ctx, rt, meta)
+//		op := workerhappycontext.Start(ctx, rt, meta)
 //		ctx = op.Context()
 //		defer op.End(&err)
 //		hc.Add(ctx, "rows", 42)
@@ -51,6 +51,6 @@ func Start(ctx context.Context, rt *hc.Runtime, meta JobMeta) *hc.Operation {
 // canonical-field pass; scheduled_at has no op.* equivalent.
 func addJobFields(ctx context.Context, meta JobMeta) {
 	if !meta.ScheduledAt.IsZero() {
-		hc.Add(ctx, "job.scheduled_at", meta.ScheduledAt.UTC())
+		hc.Add(ctx, hc.KeyJobScheduledAt, meta.ScheduledAt.UTC())
 	}
 }

--- a/integration/worker/worker_test.go
+++ b/integration/worker/worker_test.go
@@ -1,4 +1,4 @@
-package workerhc
+package workerhappycontext
 
 import (
 	"context"
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	hc "github.com/happytoolin/happycontext"
+	"github.com/happytoolin/happycontext"
 )
 
 func TestStartAddsWorkerFields(t *testing.T) {
@@ -62,14 +62,14 @@ func TestStartAddsWorkerFields(t *testing.T) {
 	}
 }
 
-func TestFinishSuccessDefaultMessage(t *testing.T) {
+func TestEndSuccessDefaultMessage(t *testing.T) {
 	sink := hc.NewTestSink()
 	rt := hc.MustCompile(hc.Config{Sink: sink, SamplingRate: 1})
 	op := Start(context.Background(), rt, JobMeta{Name: "cleanup", ID: "job_1", Queue: "nightly"})
 	var err error
 
 	if !op.End(&err) {
-		t.Fatal("expected finish to write")
+		t.Fatal("expected End to write")
 	}
 
 	events := sink.Events()
@@ -84,7 +84,7 @@ func TestFinishSuccessDefaultMessage(t *testing.T) {
 	}
 }
 
-func TestFinishErrorAndPanic(t *testing.T) {
+func TestEndErrorAndPanic(t *testing.T) {
 	t.Run("error", func(t *testing.T) {
 		sink := hc.NewTestSink()
 		rt := hc.MustCompile(hc.Config{Sink: sink, SamplingRate: 0})

--- a/internal/hcjson/hcjson.go
+++ b/internal/hcjson/hcjson.go
@@ -1,6 +1,9 @@
 // Package hcjson is a minimal append-only JSON encoder, vendored from
 // zerolog v1.34.0's internal/json package (MIT; see LICENSE and README.md
-// in this directory) and trimmed to what happycontext uses.
+// in this directory). The hot paths happycontext uses (string/bytes
+// escaping, scalars, time, interface fallback) were kept verbatim in
+// shape — including the unused-width scalar constructors — for easy
+// diffing against the upstream original.
 //
 // The upgrade over the vendored original is a hybrid SWAR escape fast path
 // in AppendString/AppendBytes: strings of 16 bytes or more are scanned 8

--- a/json_sink.go
+++ b/json_sink.go
@@ -8,11 +8,12 @@ import (
 
 // JSONSink is a first-party sink that writes one canonical JSON line per
 // event with a single Write call to the underlying writer — no logger
-// dependency required. The line is the record's Encoded() form, byte-
-// identical to the v0.6 zerolog-parity sink. A JSONSink is safe for
-// concurrent use: encoding happens without a lock, then Write is
-// serialized so unsynchronized writers (bytes.Buffer) stay race-clean.
-// Write errors are ignored (events are best-effort, like the bridges).
+// dependency required. The line is the record's Encoded() form: the
+// canonical hc line (level, deduped fields, RFC3339 completion time,
+// message). A JSONSink is safe for concurrent use: encoding happens
+// without a lock, then Write is serialized so unsynchronized writers
+// (bytes.Buffer) stay race-clean. Write errors are ignored (events are
+// best-effort, like the bridges).
 type JSONSink struct {
 	mu sync.Mutex
 	w  io.Writer

--- a/keys.go
+++ b/keys.go
@@ -1,0 +1,31 @@
+package hc
+
+// The canonical field keys the library writes: start metadata, HTTP
+// request fields, completion annotations, and the error/panic fields.
+// Every hc-side write and scan goes through these constants; user code
+// may use them with Record.Lookup, CapturedEvent.Lookup, and
+// SampleInput.Lookup. The values are a wire contract — pinned by the
+// golden and property tests, they must never change.
+const (
+	KeyOpDomain      = "op.domain"
+	KeyOpName        = "op.name"
+	KeyOpID          = "op.id"
+	KeyOpSource      = "op.source"
+	KeyOpAttempt     = "op.attempt"
+	KeyOpMaxAttempts = "op.max_attempts"
+	KeyOpCode        = "op.code"
+	KeyOpOutcome     = "op.outcome"
+
+	KeyHTTPMethod = "http.method"
+	KeyHTTPPath   = "http.path"
+	KeyHTTPRoute  = "http.route"
+	KeyHTTPStatus = "http.status"
+
+	KeyDurationMS = "duration_ms"
+	KeyError      = "error"
+	KeyPanic      = "panic"
+
+	// KeyJobScheduledAt is written by the worker integration for job
+	// metadata that has no op.* equivalent.
+	KeyJobScheduledAt = "job.scheduled_at"
+)

--- a/operation.go
+++ b/operation.go
@@ -11,7 +11,9 @@ import (
 
 // OperationStart describes operation metadata initialized at start.
 type OperationStart struct {
-	Domain               Domain // http | job | msg | cli | custom
+	// Domain is the operation category, one of the Domain constants;
+	// the zero value defaults to the "operation" domain.
+	Domain               Domain
 	Name, ID, Source     string
 	Attempt, MaxAttempts int
 }
@@ -71,8 +73,9 @@ func (op *Operation) Context() context.Context {
 // state, committing exactly one event, and returns whether an event was
 // emitted. One-shot: a second call is a no-op returning the first
 // result (false, by definition, if the first call crashed mid-commit —
-// a panic in the sampler or a sink never publishes an emission). If the surrounding function is panicking, End records the
-// panic, commits, and re-panics.
+// a panic in the sampler or a sink never publishes an emission). If the
+// surrounding function is panicking, End records the panic, commits,
+// and re-panics.
 //
 // End MUST be deferred directly (defer op.End(&err)) — the closure form
 // silently disables panic capture. Reentrant use is not supported: a
@@ -80,25 +83,21 @@ func (op *Operation) Context() context.Context {
 // claim. Concurrent first calls are safe: exactly one wins the claim
 // and commits; the others wait and return the published result.
 func (op *Operation) End(errp *error) (emitted bool) {
-	if op == nil {
+	// A nil *Operation and the zero Operation are both no-ops: the zero
+	// value carries no event, so there is nothing to commit. This keeps
+	// the zero value from dereferencing a nil event in release, matching
+	// the nil-guards on Context.
+	if op == nil || op.ev == nil {
 		return false
 	}
-	// Claim the one-shot: published returns the cached result, claimed
-	// means another caller is committing — wait for it.
-	for {
-		switch op.endState.Load() {
-		case 2:
-			return op.emitted // published: the read is race-free (see above)
-		case 0:
-			if op.endState.CompareAndSwap(0, 1) {
-				goto claimed
-			}
-		}
-		runtime.Gosched()
+	if !op.claim() {
+		return op.emitted // published by the winning caller (race-free, see endState)
 	}
-claimed:
 	// Publish on every exit path, including panics, so waiting callers
-	// can never spin on a winner that died mid-commit.
+	// can never spin on a winner that died mid-commit. LIFO order: the
+	// event is released (sealed + pooled) first, then the claim word
+	// publishes — waiters only read Operation fields, never the pooled
+	// event, so recycling before publication is safe.
 	defer func() { op.endState.Store(2) }()
 	defer func() { op.ev.release() }()
 
@@ -110,11 +109,10 @@ claimed:
 
 	ev := op.ev
 	start := op.start
-	rt := op.rt
 
 	// The owner's final writes, then SEAL before any WAL read: from
 	// here on the event is immutable, so stragglers cannot race the
-	// scan, the record handed to sinks, or the encode .
+	// scan, the record handed to sinks, or the encode.
 	now := time.Now() // one clock read: completion stamp + duration base
 	duration := now.Sub(ev.startedAt)
 	annotateOperationFailures(ev, &op.ref, err, recovered)
@@ -135,16 +133,45 @@ claimed:
 	} else if scan.hasOpCode {
 		outcomeCode = scan.opCode
 	}
-	outcome := resolveOutcomeV2(err, recovered, outcomeCode, scan.outcome)
-	annotatePostSeal(ev, &op.ref, start, duration, isHTTP, scan, outcome)
+	outcome := resolveOutcome(err, recovered, outcomeCode, scan.outcome)
 
-	emitted = op.commit(ev, rt, start, outcome, code, duration, now, err, recovered != nil, scan)
+	in := commitInput{
+		outcome:  outcome,
+		code:     code,
+		duration: duration,
+		now:      now,
+		err:      err,
+		panicked: recovered != nil,
+		scan:     scan,
+	}
+	op.annotatePostSeal(in)
+
+	emitted = op.commit(in)
 	op.emitted = emitted
 
 	if recovered != nil {
 		panic(recovered)
 	}
 	return emitted
+}
+
+// claim acquires the one-shot commit right (endState 0 → 1 by CAS).
+// A caller that observes the state claimed (1) or published (2) waits
+// for the winner's publication — which every exit path of the
+// winner's End performs, including panics — and then reports false;
+// End reads the published result in that case.
+func (op *Operation) claim() bool {
+	for {
+		switch op.endState.Load() {
+		case 2:
+			return false
+		case 0:
+			if op.endState.CompareAndSwap(0, 1) {
+				return true
+			}
+		}
+		runtime.Gosched()
+	}
 }
 
 // walScan is the single backward walk over the sealed WAL collecting
@@ -177,85 +204,101 @@ func scanWAL(ev *event) walScan {
 	for i := len(ev.fields) - 1; i >= 0; i-- {
 		f := ev.fields[i]
 		switch f.key {
-		case "op.outcome":
+		case KeyOpOutcome:
 			if !s.hasOutcome && f.kind == KindString {
 				if o := Outcome(f.str); IsValidOutcome(o) {
 					s.outcome = o
 					s.hasOutcome = true
 				}
 			}
-		case "http.status":
+		case KeyHTTPStatus:
 			if !s.hasCode && f.kind == KindInt {
 				s.code = int(f.num)
 				s.hasCode = true
 			}
-		case "op.code":
+		case KeyOpCode:
 			if !s.hasOpCode && f.kind == KindInt {
 				s.opCode = int(f.num)
 				s.hasOpCode = true
 			}
-		case "http.method":
+		case KeyHTTPMethod:
 			if s.method == "" && f.kind == KindString {
 				s.method = f.str
 			}
-		case "http.path":
+		case KeyHTTPPath:
 			if s.path == "" && f.kind == KindString {
 				s.path = f.str
 			}
-		case "op.domain":
+		case KeyOpDomain:
 			s.hasDomain = true
-		case "op.name":
+		case KeyOpName:
 			s.hasName = true
 			if s.name == "" && f.kind == KindString {
 				s.name = f.str
 			}
-		case "op.id":
+		case KeyOpID:
 			s.hasID = true
-		case "op.source":
+		case KeyOpSource:
 			s.hasSource = true
-		case "op.attempt":
+		case KeyOpAttempt:
 			s.hasAttempt = true
-		case "op.max_attempts":
+		case KeyOpMaxAttempts:
 			s.hasMaxAttempts = true
 		}
 	}
 	return s
 }
 
+// commitInput bundles what End resolved about the completed operation
+// for the commit stage — everything that is not already reachable from
+// the Operation itself (ev, rt, start, ctx, record). One struct instead
+// of a ten-parameter call, and the natural home for these semantics:
+// all of it describes the sealed event between seal and commit.
+type commitInput struct {
+	outcome  Outcome // resolved outcome (panic > error > explicit > 5xx > success)
+	code     int     // resolved http.status (the canonical code for HTTP operations)
+	duration time.Duration
+	now      time.Time // completion stamp (single clock read from End)
+	err      error
+	panicked bool
+	scan     walScan
+}
+
 // commit resolves level, message, and sampling, then writes the record.
-func (op *Operation) commit(ev *event, rt *Runtime, start OperationStart, outcome Outcome, code int, duration time.Duration, now time.Time, err error, panicked bool, scan walScan) bool {
+func (op *Operation) commit(in commitInput) bool {
+	rt := op.rt
 	if rt.noop() {
 		return false
 	}
 
+	ev := op.ev
+	start := op.start
 	policy := rt.policyFor(start.Domain)
-	level := levelFloor(levelFromPolicy(policy, outcome), ev.requestedLevel, ev.hasRequestedLvl)
+	level := levelFloor(levelFromPolicy(policy, in.outcome), ev.requestedLevel, ev.hasRequestedLvl)
 
-	in := buildSampleInput(ev, start, outcome, code, duration, level, err, panicked, scan)
+	sampleIn := buildSampleInput(ev, start, in, level)
 
 	// The keep-everything fast path (rate == 1.0, no sampler, no level
 	// rates, no policies): healthy events can never be dropped, so the
 	// gate is skipped entirely. Error/panic events bypass the gate
-	// structurally, so the flag only short-circuits the
-	// healthy branch.
+	// structurally, so the flag only short-circuits the healthy branch.
 	if !rt.alwaysKeep {
-		if !in.HasError {
+		if !sampleIn.HasError {
 			if rt.sampler != nil {
-				if !rt.sampler(in) {
+				if !rt.sampler(sampleIn) {
 					return false
 				}
-			} else if !shouldWriteHealthy(rt, policy, in) {
+			} else if !shouldWriteHealthy(rt, policy, sampleIn) {
 				return false
 			}
 		}
 	}
 
-	msg := resolveEventMessage(rt.message, start.Domain, ev.msg)
 	rec := &op.record
 	rec.level = level
-	rec.msg = msg
+	rec.msg = resolveEventMessage(rt.message, start.Domain, ev.msg)
 	rec.fields = ev.fields
-	rec.completedAt = now
+	rec.completedAt = in.now
 	rt.emit(op.ctx, rec)
 	return true
 }
@@ -280,28 +323,28 @@ func shouldWriteHealthy(rt *Runtime, policy OperationPolicy, in SampleInput) boo
 // route-name contract in the HTTP integrations depends on this).
 func appendStartFields(start OperationStart, scan walScan, add func(Field)) {
 	if !scan.hasDomain {
-		add(fieldStr("op.domain", string(start.Domain)))
+		add(fieldStr(KeyOpDomain, string(start.Domain)))
 	}
 	if !scan.hasName {
-		add(fieldStr("op.name", start.Name))
+		add(fieldStr(KeyOpName, start.Name))
 	}
 	if !scan.hasID && start.ID != "" {
-		add(fieldStr("op.id", start.ID))
+		add(fieldStr(KeyOpID, start.ID))
 	}
 	if !scan.hasSource && start.Source != "" {
-		add(fieldStr("op.source", start.Source))
+		add(fieldStr(KeyOpSource, start.Source))
 	}
 	if !scan.hasAttempt && start.Attempt > 0 {
-		add(fieldInt64("op.attempt", int64(start.Attempt)))
+		add(fieldInt64(KeyOpAttempt, int64(start.Attempt)))
 	}
 	if !scan.hasMaxAttempts && start.MaxAttempts > 0 {
-		add(fieldInt64("op.max_attempts", int64(start.MaxAttempts)))
+		add(fieldInt64(KeyOpMaxAttempts, int64(start.MaxAttempts)))
 	}
 }
 
 func annotateOperationFailures(ev *event, ref *walRef, err error, recovered any) {
 	if recovered != nil {
-		ev.appendAny(ref.gen, "panic", structuredPanicField(recovered))
+		ev.appendAny(ref.gen, KeyPanic, structuredPanicField(recovered))
 	}
 	if err != nil {
 		ev.setError(ref, err)
@@ -318,13 +361,14 @@ func annotateOperationFailures(ev *event, ref *walRef, err error, recovered any)
 // Canonical fields: HTTP operations carry http.status; non-HTTP
 // operations surface their explicit op.code here (ledger: canonical
 // fields).
-func annotatePostSeal(ev *event, ref *walRef, start OperationStart, duration time.Duration, isHTTP bool, scan walScan, outcome Outcome) {
+func (op *Operation) annotatePostSeal(in commitInput) {
+	ev := op.ev
 	// The owner is the only writer past the seal, so the state and the
 	// generation are stable across this entire block (release is
 	// deferred to post-commit, reset requires a pool round-trip): one
 	// armed check and one lock/unlock bracket replace the per-append
-	// atomic-load-and-maybe-mutex round trip of the old appendSealed
-	// loop — ~9 atomic loads and N indirect calls saved per request.
+	// atomic-load-and-maybe-mutex round trip of a per-field sealed
+	// append — ~9 atomic loads and N indirect calls saved per request.
 	armed := walState(ev.state.Load()&walStateMask) == walSealedArmed
 	if armed {
 		ev.mu.Lock()
@@ -333,18 +377,18 @@ func annotatePostSeal(ev *event, ref *walRef, start OperationStart, duration tim
 
 	fields := ev.fields
 	add := func(f Field) { fields = append(fields, f) }
-	appendStartFields(start, scan, add)
-	add(fieldInt64("duration_ms", duration.Milliseconds()))
-	if !isHTTP && scan.hasOpCode {
-		add(fieldInt64("op.code", int64(scan.opCode)))
+	appendStartFields(op.start, in.scan, add)
+	add(fieldInt64(KeyDurationMS, in.duration.Milliseconds()))
+	if op.start.Domain != DomainHTTP && in.scan.hasOpCode {
+		add(fieldInt64(KeyOpCode, int64(in.scan.opCode)))
 	}
-	add(fieldStr("op.outcome", string(outcome)))
+	add(fieldStr(KeyOpOutcome, string(in.outcome)))
 	ev.fields = fields
 }
 
-// resolveOutcomeV2 applies the v2 precedence: panic > error > explicit
+// resolveOutcome applies the precedence: panic > error > explicit
 // (a valid op.outcome the caller wrote) > 5xx > success.
-func resolveOutcomeV2(err error, recovered any, code int, explicit Outcome) Outcome {
+func resolveOutcome(err error, recovered any, code int, explicit Outcome) Outcome {
 	if recovered != nil {
 		return OutcomePanic
 	}
@@ -367,33 +411,32 @@ func resolveOutcomeV2(err error, recovered any, code int, explicit Outcome) Outc
 	return OutcomeSuccess
 }
 
-func buildSampleInput(ev *event, start OperationStart, outcome Outcome, code int, duration time.Duration, level Level, err error, panicked bool, scan walScan) SampleInput {
-	hasError := err != nil || panicked || ev.hasErr || outcome != OutcomeSuccess
+func buildSampleInput(ev *event, start OperationStart, in commitInput, level Level) SampleInput {
+	hasError := in.err != nil || in.panicked || ev.hasErr || in.outcome != OutcomeSuccess
 	opName := start.Name
-	if scan.name != "" {
-		opName = scan.name
+	if in.scan.name != "" {
+		opName = in.scan.name
 	}
 	// HTTP samplers see http.status; non-HTTP samplers see their
 	// canonical op.code (the README's non-HTTP contract for Code).
 	// StatusCode stays the HTTP-compat view of http.status in both.
-	samplerCode := code
-	if start.Domain != DomainHTTP && scan.hasOpCode {
-		samplerCode = scan.opCode
+	samplerCode := in.code
+	if start.Domain != DomainHTTP && in.scan.hasOpCode {
+		samplerCode = in.scan.opCode
 	}
-	in := SampleInput{
+	return SampleInput{
 		Domain:     start.Domain,
 		Operation:  opName,
-		Outcome:    outcome,
+		Outcome:    in.outcome,
 		Code:       samplerCode,
-		StatusCode: code,
-		Method:     scan.method,
-		Path:       scan.path,
-		Duration:   duration,
+		StatusCode: in.code,
+		Method:     in.scan.method,
+		Path:       in.scan.path,
+		Duration:   in.duration,
 		Level:      level,
 		HasError:   hasError,
 		ev:         ev,
 	}
-	return in
 }
 
 func resolveEventMessage(configured string, domain Domain, eventMessage string) string {

--- a/operation_test.go
+++ b/operation_test.go
@@ -225,7 +225,7 @@ func TestOutcomePrecedence(t *testing.T) {
 // TestPanicBeatsErrorWhenCoDelivered pins the panic > error precedence
 // for the shape the table test cannot reach: the error pointer is
 // already set when End runs AND a panic is in flight (defer op.End(&err)
-// with err non-nil, then panic). resolveOutcomeV2 must still resolve
+// with err non-nil, then panic). resolveOutcome must still resolve
 // OutcomePanic — a swap to error-first precedence silently turns the
 // event into OutcomeFailure. Found as a gap by mutation testing (M7):
 // every panic test deferred op.End(nil), so the error was never
@@ -1112,5 +1112,47 @@ func TestAddJSONRawMessage(t *testing.T) {
 	nested, _ := m["meta"].(map[string]any)
 	if nested["batch"] != true || m["sib"] != float64(1) {
 		t.Fatalf("line = %s", rec.Encoded())
+	}
+}
+
+// TestZeroOperationEndIsNoop pins the zero-value contract: End on a
+// zero Operation (never Start-ed) is a no-op returning false, matching
+// the nil-*Operation guard instead of dereferencing the nil event.
+func TestZeroOperationEndIsNoop(t *testing.T) {
+	var op Operation
+	if op.End(nil) {
+		t.Fatal("zero Operation End reported an emission")
+	}
+	if op.Context() != nil {
+		t.Fatalf("zero Operation context = %v, want nil", op.Context())
+	}
+}
+
+// TestAddSkipsEmptyKeysUniformly pins the key-skipping contract: the
+// empty key is skipped in the leading pair exactly as in the variadic
+// tail (the doc's "non-empty string" rule).
+func TestAddSkipsEmptyKeysUniformly(t *testing.T) {
+	ts := NewTestSink()
+	rt := MustCompile(Config{Sink: ts, SamplingRate: 1})
+	op := Start(context.Background(), rt, OperationStart{Name: "skip"})
+	Add(op.Context(), "", 1)
+	Add(op.Context(), "", 2, "kept", 3)
+	Add(op.Context(), "also", 4)
+	op.End(nil)
+
+	events := ts.Events()
+	if len(events) != 1 {
+		t.Fatalf("events = %d, want 1", len(events))
+	}
+	for _, f := range events[0].Fields() {
+		if f.Key() == "" {
+			t.Fatal("an empty-key field reached the record")
+		}
+	}
+	if v, _ := events[0].Lookup("kept"); v != int64(3) {
+		t.Fatalf("kept = %v, want 3", v)
+	}
+	if v, _ := events[0].Lookup("also"); v != int64(4) {
+		t.Fatalf("also = %v, want 4", v)
 	}
 }

--- a/property_test.go
+++ b/property_test.go
@@ -1428,7 +1428,7 @@ func (m *lifeModel) outcome() Outcome {
 		return explicit
 	}
 	// The 5xx rule reads the canonical code: http.status for HTTP,
-	// op.code for everything else (mirrors resolveOutcomeV2).
+	// op.code for everything else (mirrors resolveOutcome).
 	if normalizeDomain(m.start) == DomainHTTP {
 		if hasCode && code >= 500 {
 			return OutcomeFailure

--- a/record.go
+++ b/record.go
@@ -4,6 +4,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/happytoolin/happycontext/bridge"
 	"github.com/happytoolin/happycontext/internal/hcjson"
 )
 
@@ -17,7 +18,8 @@ type Record struct {
 	fields      []Field // the sealed WAL slice; nobody mutates it after End
 	completedAt time.Time
 
-	encoded atomic.Pointer[encodedLine] // lazy-once publish (amendment 6)
+	// computed lazily on first Encoded
+	encoded atomic.Pointer[encodedLine]
 }
 
 type encodedLine struct{ b []byte }
@@ -56,9 +58,8 @@ func lookupField(fields []Field, key string) (any, bool) {
 
 // Encoded returns the canonical JSON line (one line, trailing newline)
 // for this record, computing it at most once: concurrent callers race
-// benignly on the publish and share the winner (amendment 6). The bytes
-// belong to the record — copy them if you retain them past Write
-// (amendment 9).
+// benignly on the publish and share the winner. The bytes belong to
+// the record — copy them if you retain them past Write.
 func (r *Record) Encoded() []byte {
 	if e := r.encoded.Load(); e != nil {
 		return e.b
@@ -140,11 +141,11 @@ func aliasFields(fields []Field) []Field {
 }
 
 // dedupeScanLimit sets the crossover between the allocation-free
-// last-occurrence scan and the seen-set path for wide events. It is a
-// cross-module contract: the adapters' lastOccurrences narrow path
-// uses the same literal 24 so bridges and the canonical line resolve
-// duplicates identically (pinned by the golden parity tests).
-const dedupeScanLimit = 24
+// last-occurrence scan and the seen-set path for wide events. It is the
+// same constant the sink bridges use (bridge.NarrowLimit), so the
+// canonical line and every bridge resolve duplicates identically
+// (pinned by the golden parity tests).
+const dedupeScanLimit = bridge.NarrowLimit
 
 // appendDedupedFields emits each key once — its last value, at its last
 // position (amendment 3). Narrow events use the allocation-free scan;

--- a/runtime.go
+++ b/runtime.go
@@ -5,9 +5,11 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"slices"
 )
 
-// Compile-time error contract (amendment 17).
+// Compile-time error contract: Compile returns errors wrapping these
+// sentinels with an "hc: " prefix; errors.Is works.
 var (
 	// ErrInvalidRate wraps out-of-range sampling rates.
 	ErrInvalidRate = errors.New("invalid rate")
@@ -32,7 +34,7 @@ type Config struct {
 	LevelSamplingRates map[Level]float64
 
 	// Sampler overrides built-in rate sampling when set. Errors and
-	// panics bypass it structurally (amendment 4).
+	// panics bypass it structurally.
 	Sampler Sampler
 
 	// OperationPolicies optionally customizes lifecycle behavior by
@@ -96,19 +98,18 @@ func Compile(cfg Config) (*Runtime, error) {
 
 	if len(cfg.OperationPolicies) > 0 {
 		rt.policies = make(map[Domain]OperationPolicy, len(cfg.OperationPolicies))
-		alias, hasAlias := cfg.OperationPolicies[""]
-		if hasAlias {
-			if err := validatePolicy(alias); err != nil {
-				return nil, fmt.Errorf("hc: policy for domain %q: %w", defaultDomainValue, err)
-			}
-		}
-		for domain, policy := range cfg.OperationPolicies {
+		// Sorted iteration: the "" alias (which sorts first) lands before
+		// any explicit key, so an explicit "operation" overwrites it
+		// deterministically — and with multiple invalid policies, the
+		// first error reported is deterministic too.
+		for _, domain := range slices.Sorted(maps.Keys(cfg.OperationPolicies)) {
+			policy := cfg.OperationPolicies[domain]
 			explicit := domain != ""
 			if !explicit {
 				domain = defaultDomainValue
 			}
 			if _, clash := rt.policies[domain]; clash && !explicit {
-				continue // an explicit key wins over the "" alias deterministically
+				continue // unreachable under sorted iteration; kept as a guard
 			}
 			if err := validatePolicy(policy); err != nil {
 				return nil, fmt.Errorf("hc: policy for domain %q: %w", domain, err)
@@ -173,23 +174,23 @@ func copyPolicy(policy OperationPolicy) OperationPolicy {
 }
 
 // levelFromPolicy resolves the final severity for an outcome under a
-// domain policy (zero fields mean the defaults).
+// domain policy. Zero fields mean the defaults; every other value was
+// validated by Compile, so no re-validation is needed here.
 func levelFromPolicy(policy OperationPolicy, outcome Outcome) Level {
-	if outcomeLevel, ok := policy.OutcomeLevels[outcome]; ok && IsValidLevel(outcomeLevel) {
+	if outcomeLevel, ok := policy.OutcomeLevels[outcome]; ok {
 		return outcomeLevel
 	}
 
-	// Zero policy fields mean the defaults; the zero Level is Info, which
-	// is the success default anyway. Explicit per-outcome control beyond
-	// that goes through OutcomeLevels.
+	// Zero policy fields mean the defaults; the zero Level is Info,
+	// which is the success default anyway.
 	successLevel, failureLevel, panicLevel := LevelInfo, LevelError, LevelError
-	if policy.SuccessLevel != 0 && IsValidLevel(policy.SuccessLevel) {
+	if policy.SuccessLevel != 0 {
 		successLevel = policy.SuccessLevel
 	}
-	if policy.FailureLevel != 0 && IsValidLevel(policy.FailureLevel) {
+	if policy.FailureLevel != 0 {
 		failureLevel = policy.FailureLevel
 	}
-	if policy.PanicLevel != 0 && IsValidLevel(policy.PanicLevel) {
+	if policy.PanicLevel != 0 {
 		panicLevel = policy.PanicLevel
 	}
 
@@ -205,6 +206,15 @@ func levelFromPolicy(policy OperationPolicy, outcome Outcome) Level {
 
 // noop reports whether the runtime can never emit (nil sink).
 func (rt *Runtime) noop() bool { return rt == nil || rt.sink == nil }
+
+// normalizeDomain maps the zero Domain to the default "operation"
+// domain; every other value passes through unchanged.
+func normalizeDomain(domain Domain) Domain {
+	if domain == "" {
+		return defaultDomainValue
+	}
+	return domain
+}
 
 // policyFor returns the domain policy (zero value when unconfigured).
 func (rt *Runtime) policyFor(domain Domain) OperationPolicy {

--- a/sampling.go
+++ b/sampling.go
@@ -11,18 +11,31 @@ import (
 // decisions: the resolved scalars plus read access to the request's
 // fields (Lookup and a zero-copy Fields view).
 type SampleInput struct {
+	// Domain is the operation's domain; Operation is the resolved
+	// operation name (an op.name field write overrides the start
+	// metadata); Outcome is the resolved outcome.
 	Domain    Domain
 	Operation string
 	Outcome   Outcome
-	Code      int
 
-	// HTTP compatibility fields. For non-HTTP operations, these may be empty/zero.
+	// Code is the canonical status scalar: http.status for HTTP
+	// operations, the explicit op.code for everything else.
+	Code int
+
+	// Method, Path, and StatusCode are the HTTP compatibility view.
+	// For non-HTTP operations they may be empty or zero; StatusCode is
+	// always the http.status field, even when Code carries op.code.
 	Method     string
 	Path       string
 	StatusCode int
-	Duration   time.Duration
-	Level      Level
-	HasError   bool
+
+	// Duration, Level, and HasError are domain-independent: the
+	// resolved wall time, the final severity, and whether the request
+	// ended in an error or panic. HasError events always bypass
+	// sampling.
+	Duration time.Duration
+	Level    Level
+	HasError bool
 
 	// ev backs Lookup/Fields; nil when the input was built synthetically.
 	ev *event
@@ -37,7 +50,7 @@ func (in SampleInput) Lookup(key string) (any, bool) {
 }
 
 // Fields returns a read-only view of the request's fields in insertion
-// order (amendment 8).
+// order.
 func (in SampleInput) Fields() []Field {
 	if in.ev == nil {
 		return nil

--- a/types.go
+++ b/types.go
@@ -36,13 +36,6 @@ type OperationPolicy struct {
 	SamplingRate  *float64
 }
 
-func normalizeDomain(domain Domain) Domain {
-	if domain == "" {
-		return defaultDomainValue
-	}
-	return domain
-}
-
 // IsValidOutcome reports whether outcome is a valid operation outcome.
 func IsValidOutcome(outcome Outcome) bool {
 	switch outcome {

--- a/wal.go
+++ b/wal.go
@@ -146,10 +146,12 @@ func (e *event) append(gen uint64, f Field) {
 }
 
 // addKV appends the leading pair plus any well-formed kv pairs
-// (k, v, k, v, ...). Malformed tails are skipped silently; the first
-// key is positional and cannot be malformed (amendment 19).
+// (k, v, k, v, ...). Empty keys and non-string keys are skipped
+// uniformly; an odd trailing value is dropped.
 func (e *event) addKV(ref *walRef, key string, value any, kv ...any) {
-	e.append(ref.gen, fieldOf(key, value))
+	if key != "" {
+		e.append(ref.gen, fieldOf(key, value))
+	}
 	for i := 0; i+1 < len(kv); i += 2 {
 		k, ok := kv[i].(string)
 		if !ok || k == "" {
@@ -157,23 +159,6 @@ func (e *event) addKV(ref *walRef, key string, value any, kv ...any) {
 		}
 		e.append(ref.gen, fieldOf(k, kv[i+1]))
 	}
-}
-
-// appendSealed is the owner's post-seal write: same generation check
-// against torn recycling; the state check accepts sealed (by
-// construction the owner performs these after sealing). Events that
-// were armed keep serializing under mu so watchdog snapshots taken
-// during the seal window can never race the owner's final appends.
-func (e *event) appendSealed(gen uint64, f Field) {
-	s := e.state.Load()
-	if s>>walStateBits != gen {
-		return // event recycled under us: not our buffer anymore
-	}
-	if walState(s&walStateMask) == walSealedArmed {
-		e.mu.Lock()
-		defer e.mu.Unlock()
-	}
-	e.fields = append(e.fields, f)
 }
 
 // Typed append helpers for the canonical fields: no interface boundary,
@@ -202,11 +187,11 @@ func (e *event) setError(ref *walRef, err error) {
 		e.mu.Lock()
 		defer e.mu.Unlock()
 		if cur := e.state.Load(); cur>>walStateBits == ref.gen && walState(cur&walStateMask) == walArmed {
-			e.fields = append(e.fields, Field{key: "error", kind: KindAny, val: structuredErrorField(err)})
+			e.fields = append(e.fields, Field{key: KeyError, kind: KindAny, val: structuredErrorField(err)})
 			e.hasErr = true // only when the write belonged to this generation
 		}
 	case walLive:
-		e.fields = append(e.fields, Field{key: "error", kind: KindAny, val: structuredErrorField(err)})
+		e.fields = append(e.fields, Field{key: KeyError, kind: KindAny, val: structuredErrorField(err)})
 		e.hasErr = true
 	}
 }
@@ -239,7 +224,7 @@ func (e *event) setRoute(ref *walRef, route string) {
 	if route == "" {
 		return
 	}
-	e.appendStr(ref.gen, "http.route", route)
+	e.appendStr(ref.gen, KeyHTTPRoute, route)
 }
 
 // setLevel records the requested level floor. Same liveness rules and
@@ -283,9 +268,15 @@ func (e *event) lookup(key string) (any, bool) {
 	return lookupField(e.fields, key)
 }
 
+// pooledFieldCap is the maximum field-slice capacity returned to the
+// pool. Wider events are dropped from the pool and left for the GC so
+// a single pathological request cannot pin a large buffer for the
+// process lifetime.
+const pooledFieldCap = 1024
+
 func (e *event) release() {
 	e.seal()
-	if cap(e.fields) <= 1024 {
+	if cap(e.fields) <= pooledFieldCap {
 		eventPool.Put(e)
 	}
 }

--- a/wal_test.go
+++ b/wal_test.go
@@ -200,61 +200,6 @@ func TestWALStartedAt(t *testing.T) {
 	}
 }
 
-// TestWALAppendSealedStaleGeneration pins the appendSealed generation
-// check — the owner's post-seal write path must reject a stale
-// generation exactly like append does. The state word alone is not
-// enough: a post-seal write against an event a newer request already
-// reset belongs to that request. Found as a gap by mutation testing
-// (M3): removing the check passed the whole suite because no test
-// drove appendSealed with a stale generation.
-//
-// Recycle is simulated in place with seal()+reset() — exactly the
-// release-then-newEvent sequence — rather than through the pool: the
-// race runtime drops a share of sync.Pool Puts (zap internal/pool
-// note; TestPoolReuseCanary retries around it), which would make a
-// pool round-trip nondeterministic here. reset() is the operation
-// that must invalidate the old generation.
-func TestWALAppendSealedStaleGeneration(t *testing.T) {
-	ev := newEvent()
-	staleGen := ev.state.Load() >> walStateBits
-	ev.append(staleGen, fieldStr("own", "first"))
-	ev.seal()  // End's terminal step (release() seals before pooling)
-	ev.reset() // the next request's newEvent() after the pool hands it out
-
-	currentGen := ev.state.Load() >> walStateBits
-	if currentGen == staleGen {
-		t.Fatal("reset did not advance the generation")
-	}
-
-	// The stale owner-style post-seal write must no-op: the event now
-	// belongs to another request.
-	ev.appendSealed(staleGen, fieldStr("stale", "x"))
-	for _, f := range ev.fields {
-		if f.key == "stale" {
-			t.Fatalf("appendSealed with stale generation %d landed on the recycled event", staleGen)
-		}
-	}
-
-	// Positive controls: the current generation writes through the same
-	// path both before sealing and after it (the real annotatePostSeal
-	// shape runs post-seal under the sealed state).
-	ev.appendSealed(currentGen, fieldStr("live", "1"))
-	ev.seal()
-	ev.appendSealed(currentGen, fieldStr("sealed", "2"))
-	keys := map[string]bool{}
-	for _, f := range ev.fields {
-		keys[f.key] = true
-	}
-	for _, want := range []string{"live", "sealed"} {
-		if !keys[want] {
-			t.Fatalf("current-generation appendSealed lost %q", want)
-		}
-	}
-	if keys["stale"] {
-		t.Fatal("stale write landed next to the current-generation fields")
-	}
-}
-
 // TestWALStaleSettersAfterReset pins the live() generation checks in
 // the setter entry points that do not route through append's gen check:
 // setMessage, setLevel, and setError's hasErr latch all trust live()
@@ -593,7 +538,7 @@ func TestStragglerStartLine(t *testing.T) {
 // of runs never see the exact event again), so the test fires its
 // sentinel writes across a churn of requests and guards whichever
 // events the pool hands out; the deterministic reset-path half lives
-// in TestWALAppendSealedStaleGeneration.
+// in TestWALStaleSettersAfterReset.
 func TestPoolReuseCanary(t *testing.T) {
 	oldGC := debug.SetGCPercent(-1) // zap: keep the pool hot for the whole test
 	defer debug.SetGCPercent(oldGC)
@@ -617,7 +562,7 @@ func TestPoolReuseCanary(t *testing.T) {
 	// fires the stale writes against whatever event the pool returned
 	// (recycled or fresh — both must reject them), and the reset-path
 	// generation bump is deterministically covered by
-	// TestWALAppendSealedStaleGeneration. A round that gets op1's event
+	// TestWALStaleSettersAfterReset. A round that gets op1's event
 	// back additionally guards the write-after-reset window.
 	ctx2 := context.Background()
 	recycled := false
@@ -698,7 +643,8 @@ func canaryWrite(stale context.Context) {
 //     generation never lands; live-load landings may land late (the
 //     documented nanosecond-scale residual) but always exactly once;
 //     armed-load landings depend on the in-lock recheck.
-//  2. The owner's post-seal writes (appendSealed) always land.
+//  2. The owner's post-seal writes (the inline annotatePostSeal
+//     appends) always land.
 //  3. Snapshots are never torn: each equals the field prefix at its
 //     copy point.
 //  4. Recycle: a stale-generation write never lands when its load
@@ -1238,7 +1184,15 @@ func postOp(key string) simStep {
 	return simStep{
 		name: "post-" + key,
 		run:  func(s *sim) { s.simAppendSealed(key) },
-		real: func(ev *event, _ *sim) { ev.appendSealed(genOf(ev), fieldOf(key, key)) },
+		// The real owner post-seal fragment, as inlined in
+		// annotatePostSeal: lock only when the event was armed, append.
+		real: func(ev *event, _ *sim) {
+			if walState(ev.state.Load()&walStateMask) == walSealedArmed {
+				ev.mu.Lock()
+				defer ev.mu.Unlock()
+			}
+			ev.fields = append(ev.fields, fieldOf(key, key))
+		},
 	}
 }
 
@@ -1569,35 +1523,43 @@ func (s *matrixSink) Write(_ context.Context, rec *Record) {
 // boundary fire (used when the sink fires instead). The caller
 // releases the event when it wants the pool phases.
 func stagedEnd(op *Operation, fireAt matrixPhase, fire func(ctx context.Context)) bool {
-	ev := op.ev
-	rt := op.rt
-	start := op.start
-
 	now := time.Now()
-	duration := now.Sub(ev.startedAt)
+	duration := now.Sub(op.ev.startedAt)
 
 	if fireAt == phasePreAnnotate {
 		fire(op.Context())
 	}
-	annotateOperationFailures(ev, &op.ref, nil, nil)
+	annotateOperationFailures(op.ev, &op.ref, nil, nil)
 	if fireAt == phasePreSeal {
 		fire(op.Context())
 	}
-	ev.seal()
+	op.ev.seal()
 	if fireAt == phasePreScan {
 		fire(op.Context())
 	}
-	scan := scanWAL(ev)
+	scan := scanWAL(op.ev)
 	code := scan.code
-	outcome := resolveOutcomeV2(nil, nil, code, scan.outcome)
+	outcome := resolveOutcome(nil, nil, code, scan.outcome)
 	if fireAt == phasePrePostSeal {
 		fire(op.Context())
 	}
-	annotatePostSeal(ev, &op.ref, start, duration, normalizeDomain(start.Domain) == DomainHTTP, scan, outcome)
+	op.annotatePostSeal(commitInput{
+		outcome:  outcome,
+		code:     code,
+		duration: duration,
+		now:      now,
+		scan:     scan,
+	})
 	if fireAt == phasePreCommit {
 		fire(op.Context())
 	}
-	return op.commit(ev, rt, start, outcome, code, duration, now, nil, false, scan)
+	return op.commit(commitInput{
+		outcome:  outcome,
+		code:     code,
+		duration: duration,
+		now:      now,
+		scan:     scan,
+	})
 }
 
 // TestStragglerInjectionMatrix drives every phase in both armed modes


### PR DESCRIPTION
## What

The final pre-1.0 code-quality pass, implemented. This applies **every finding** from the last quality audit (3 must-fix, 11 should-fix, plus the mechanical nits) — a multi-pass review cross-checked by an independent **DeepSeek v4 Pro** subagent run clean-room through `pi`, with every claim verified against the tree before merging into the fix list.

No bug hunting, no perf work — those rounds already landed. This is release hygiene for the 1.0.0 freeze.

## The headline changes

| | Change |
|---|---|
| **godoc freeze** | Amendment-ledger references purged from all four exported docs (`ErrInvalid*`, `Config.Sampler`, `Record.Encoded`, `SampleInput.Fields`). `go doc -all` → zero occurrences. |
| **`commit` signature** | 10 params (3 of them its own receiver's fields, 186-char line) → `commit(in commitInput) bool`; `annotatePostSeal` → 1-param method; `buildSampleInput` → 4 params; the library's only `goto` replaced by `claim()`. |
| **dead code** | `appendSealed` removed — production-dead since the perf pass, only its test called it. Coverage remapped; loom-lite sim replays the real inline owner fragment. |
| **`keys.go`** | 16 exported `Key*` canonical constants; every hc write/scan, `integration/common`, and the worker integration now share one spelling. Tests deliberately keep raw literals — they pin the wire values. |
| **`bridge` package** | New public package in the root module: generic `LastIndices`, `NarrowLimit`, panic-fenced `ErrorMessage`. Collapses 3× `lastOccurrences` + 3× unfenced `errMessage`; `dedupeScanLimit = bridge.NarrowLimit` turns the cross-module dedupe contract from prose into a symbol. Also fixes the bridges' missing `Error()` panic fence. |
| **zero-value `Operation`** | `End` on `(&Operation{}).End(nil)` was a SIGSEGV; now a no-op returning false (consistent with the existing nil guards). |

Plus: `resolveOutcomeV2` → `resolveOutcome`; fiber `responseStarted` heuristic documented (with a "do not simplify" warning) in both middlewares; `ResolveStatus(StatusInput)` named-field literals at all five call sites; `SampleInput` field docs regrouped accurately; `pooledFieldCap` named; `TestFinish*` → `TestEnd*`; `workerhc` → `workerhappycontext`; `metadata.go` → `errorfield.go`; deterministic `Compile` policy errors (sorted iteration); uniform empty-key skip in `Add`; redundant import aliases removed; hcjson doc claim corrected.

## Behavior changes (pre-1.0, both pinned by new tests)

1. `Add` now skips an **empty leading key**, matching the variadic-tail rule — `TestAddSkipsEmptyKeysUniformly`
2. Zero-value `Operation.End` is a no-op — `TestZeroOperationEndIsNoop`

## Verification

- `go build` / `go vet` / `gofmt` clean across **all modules** (root, `bridge`, `internal/hcjson`, 3 adapters, 6 integrations, `cmd/examples`, `benches`)
- Full suite green under `-race -count=2`
- Exported-doc AST audit: still 100% coverage (now including `keys.go`, `bridge`, `StatusInput`)
- `go doc -all`: zero amendment references; zero `goto` statements in the library

Net: **+603 / −438 across 29 files** — the codebase got smaller while getting cleaner.

## Not changed (conscious freeze decisions, documented in the audit)

The watchdog `arm()`/`snapshotFields` forward-compat machinery, `CloseNotify` v0-parity nil channel, and `TestSink` in the root package were reviewed and deliberately kept.

🤖 Generated with pi
