### PR TITLE
refactor(v2): modernize to the go 1.25 idiom set

### DIFF
--- a/.modernize
+++ b/.modernize
@@ -3,3 +3,6 @@
 2026-09-06 vendored-hcjson internal/hcjson vendored loops stay byte-faithful to zerolog v1.34.0 for upstream diffability — go fix loop rewrites reverted there
 2026-09-06 t-context-churn root tests keep context.Background() (290 sites, ctx is a WAL carrier here, not worth freeze-time churn); nested-module conversions from go fix kept
 2026-09-06 b-loop bench_test.go's b.N-coupled rebuild windows are deliberate design; b.Loop() would change the steady-state pool logic
+2026-09-06 go126-errors-astype deferred until go.mod floor >= 1.26: 3 sites ready (echo/fiber/fiberv3 statusFrom*Error); compiles under 1.25 but vet stdversion rejects
+2026-09-06 go126-new-expr deferred until floor >= 1.26: 1 site (copyPolicy SamplingRate copy)
+2026-09-06 go127-generic-methods no call sites: bridge.LastIndices is multi-consumer by design; Sink/Sampler are interfaces and generic methods cannot satisfy interfaces

--- a/.modernize
+++ b/.modernize
@@ -1,0 +1,5 @@
+# Ignored modernization suggestions
+# Format: <date> <category> <description>
+2026-09-06 vendored-hcjson internal/hcjson vendored loops stay byte-faithful to zerolog v1.34.0 for upstream diffability — go fix loop rewrites reverted there
+2026-09-06 t-context-churn root tests keep context.Background() (290 sites, ctx is a WAL carrier here, not worth freeze-time churn); nested-module conversions from go fix kept
+2026-09-06 b-loop bench_test.go's b.N-coupled rebuild windows are deliberate design; b.Loop() would change the steady-state pool logic

--- a/adapter/slog/sink_concurrency_test.go
+++ b/adapter/slog/sink_concurrency_test.go
@@ -113,15 +113,13 @@ func TestStressSlogSustainedCorrectness(t *testing.T) {
 
 	var wg sync.WaitGroup
 	for range goroutines {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			for range writes {
 				op := hc.Start(context.Background(), rt, hc.OperationStart{Domain: hc.DomainJob, Name: "stress"})
 				hc.Add(op.Context(), "a", 1, "b", "two", "c", true)
 				op.End(nil)
 			}
-		}()
+		})
 	}
 	wg.Wait()
 

--- a/adapter/zerolog/sink.go
+++ b/adapter/zerolog/sink.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"slices"
 	"unsafe"
 
 	"github.com/happytoolin/happycontext"
@@ -104,12 +105,7 @@ func hasTimestampHook(hooks []zerolog.Hook) bool {
 	if timestampHookSample == nil {
 		return false
 	}
-	for _, h := range hooks {
-		if h == timestampHookSample {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(hooks, timestampHookSample)
 }
 
 // enabled mirrors zerolog's own gate (Logger.should) for a plain

--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -9,6 +9,7 @@ package bridge
 import (
 	"fmt"
 	"reflect"
+	"slices"
 )
 
 // NarrowLimit is the crossover between the allocation-free
@@ -44,17 +45,14 @@ func LastIndices[T any](items []T, key func(T) string) []int {
 	}
 	seen := make(map[string]struct{}, len(items)*2)
 	kept := make([]int, 0, len(items))
-	for i := len(items) - 1; i >= 0; i-- {
-		if _, dup := seen[key(items[i])]; dup {
+	for i, item := range slices.Backward(items) {
+		if _, dup := seen[key(item)]; dup {
 			continue
 		}
-		seen[key(items[i])] = struct{}{}
+		seen[key(item)] = struct{}{}
 		kept = append(kept, i)
 	}
-	// reverse into forward order
-	for l, r := 0, len(kept)-1; l < r; l, r = l+1, r-1 {
-		kept[l], kept[r] = kept[r], kept[l]
-	}
+	slices.Reverse(kept)
 	return kept
 }
 

--- a/bridge/bridge_test.go
+++ b/bridge/bridge_test.go
@@ -30,7 +30,7 @@ func TestLastIndicesResolvesLastWriteWins(t *testing.T) {
 		tests[wideIdx].items[i] = item{fmt.Sprintf("k%d", i%NarrowLimit)} // NarrowLimit distinct keys, each 3×
 	}
 	last := make([]int, 0, NarrowLimit)
-	for k := 0; k < NarrowLimit; k++ {
+	for k := range NarrowLimit {
 		last = append(last, NarrowLimit*2+k) // the final block holds each key's last write
 	}
 	tests[wideIdx].want = last

--- a/crash_test.go
+++ b/crash_test.go
@@ -1546,7 +1546,7 @@ func TestCrashFanoutSinks(t *testing.T) {
 	if got, want := len(ts.Events()), 200; got != want {
 		t.Fatalf("captured = %d, want %d", got, want)
 	}
-	for _, ln := range strings.Split(strings.TrimRight(buf.String(), "\n"), "\n") {
+	for ln := range strings.SplitSeq(strings.TrimRight(buf.String(), "\n"), "\n") {
 		if ln == "" {
 			continue
 		}

--- a/example_test.go
+++ b/example_test.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"sort"
+	"slices"
 	"strings"
 
 	hc "github.com/happytoolin/happycontext"
@@ -28,7 +28,7 @@ func (p printSink) Write(_ context.Context, rec *hc.Record) {
 		seen[f.Key()] = true
 		keys = append(keys, f.Key())
 	}
-	sort.Strings(keys)
+	slices.Sort(keys)
 	fmt.Fprintf(p.w, "%s %s", rec.Level(), rec.Message())
 	for _, k := range keys {
 		var v any

--- a/integration/worker/lifecycle_scenarios_test.go
+++ b/integration/worker/lifecycle_scenarios_test.go
@@ -24,8 +24,7 @@ import (
 func TestWorkerRetryMetadata(t *testing.T) {
 	ts := hc.NewTestSink()
 	rt := hc.MustCompile(hc.Config{Sink: ts, SamplingRate: 1})
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	err := errors.New("retryable")
 	op := Start(ctx, rt, JobMeta{Name: "sync", Attempt: 3, MaxAttempts: 5})

--- a/internal/hcjson/time_test.go
+++ b/internal/hcjson/time_test.go
@@ -84,9 +84,7 @@ func TestAppendTimeRFC3339CachedConcurrent(t *testing.T) {
 	base := time.Now().Truncate(time.Second)
 	var wg sync.WaitGroup
 	for range 8 {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			for j := range 1000 {
 				tt := base.Add(time.Duration(j%1000) * time.Millisecond)
 				got := string(AppendTimeRFC3339(nil, tt))
@@ -96,7 +94,7 @@ func TestAppendTimeRFC3339CachedConcurrent(t *testing.T) {
 					return
 				}
 			}
-		}()
+		})
 	}
 	wg.Wait()
 }

--- a/operation.go
+++ b/operation.go
@@ -1,10 +1,12 @@
 package hc
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
 	"runtime"
+	"slices"
 	"sync/atomic"
 	"time"
 )
@@ -201,8 +203,7 @@ type walScan struct {
 
 func scanWAL(ev *event) walScan {
 	var s walScan
-	for i := len(ev.fields) - 1; i >= 0; i-- {
-		f := ev.fields[i]
+	for _, f := range slices.Backward(ev.fields) {
 		switch f.key {
 		case KeyOpOutcome:
 			if !s.hasOutcome && f.kind == KindString {
@@ -440,16 +441,10 @@ func buildSampleInput(ev *event, start OperationStart, in commitInput, level Lev
 }
 
 func resolveEventMessage(configured string, domain Domain, eventMessage string) string {
-	if eventMessage != "" {
-		return eventMessage
-	}
-	if configured != "" {
-		return configured
-	}
 	if domain == DomainHTTP {
-		return DefaultMessage
+		return cmp.Or(eventMessage, configured, DefaultMessage)
 	}
-	return DefaultOperationMessage
+	return cmp.Or(eventMessage, configured, DefaultOperationMessage)
 }
 
 const defaultDomainValue Domain = "operation"

--- a/property_test.go
+++ b/property_test.go
@@ -13,6 +13,7 @@ import (
 	"math"
 	"math/rand/v2"
 	"reflect"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -978,10 +979,7 @@ func (c *progCursor) next() byte {
 // window returns up to n bytes from the cursor (fewer at the end).
 func (c *progCursor) window(n int) []byte {
 	if c.pos+n > len(c.b) {
-		n = len(c.b) - c.pos
-		if n < 0 {
-			n = 0
-		}
+		n = max(len(c.b)-c.pos, 0)
 	}
 	w := c.b[c.pos : c.pos+n]
 	c.pos += n
@@ -1382,8 +1380,8 @@ func modelPanicField(payload any) map[string]any {
 // scan re-derives the scan scalars the spec reads from the WAL: a
 // backward walk accepting the first field of the matching key+kind.
 func (m *lifeModel) scan() (outcome Outcome, hasOutcome bool, code int, hasCode bool, opCode int, hasOpCode bool) {
-	for i := len(m.appends) - 1; i >= 0; i-- {
-		f := m.appends[i]
+	for _, f := range slices.Backward(m.appends) {
+
 		switch f.key {
 		case "op.outcome":
 			if !hasOutcome && f.kind == KindString {
@@ -2227,8 +2225,8 @@ func encodeValue(b *[]byte, v any) {
 	case time.Duration:
 		// valDuration decodes as int8(mult)*unit: pick the largest unit
 		// that divides x with an int8 multiplier.
-		for i := len(progDurUnits) - 1; i >= 0; i-- {
-			u := progDurUnits[i]
+		for i, u := range slices.Backward(progDurUnits) {
+
 			if x%u == 0 {
 				m := x / u
 				if m >= -128 && m <= 127 {

--- a/record.go
+++ b/record.go
@@ -1,6 +1,7 @@
 package hc
 
 import (
+	"slices"
 	"sync/atomic"
 	"time"
 
@@ -48,8 +49,8 @@ func (r *Record) Lookup(key string) (any, bool) {
 // lookupField is the single last-write-wins backward scan shared by
 // Record.Lookup, CapturedEvent.Lookup, and the event's live lookup.
 func lookupField(fields []Field, key string) (any, bool) {
-	for i := len(fields) - 1; i >= 0; i-- {
-		if f := fields[i]; f.key == key {
+	for _, f := range slices.Backward(fields) {
+		if f.key == key {
 			return valueOf(f), true
 		}
 	}
@@ -173,8 +174,8 @@ func appendDedupedFields(dst []byte, fields []Field) []byte {
 	n := 0
 	var seen map[string]struct{}
 	kept := make([]int, 0, len(fields)) // last-occurrence indices, found backward
-	for i := len(fields) - 1; i >= 0; i-- {
-		key := fields[i].key
+	for i, field := range slices.Backward(fields) {
+		key := field.key
 		dup := false
 		for j := range n {
 			if seenArr[j] == key {
@@ -202,8 +203,8 @@ func appendDedupedFields(dst []byte, fields []Field) []byte {
 		}
 		kept = append(kept, i)
 	}
-	for i := len(kept) - 1; i >= 0; i-- {
-		dst = appendFieldJSON(dst, fields[kept[i]])
+	for _, k := range slices.Backward(kept) {
+		dst = appendFieldJSON(dst, fields[k])
 	}
 	return dst
 }

--- a/runtime.go
+++ b/runtime.go
@@ -85,7 +85,10 @@ func Compile(cfg Config) (*Runtime, error) {
 
 	if len(cfg.LevelSamplingRates) > 0 {
 		rt.levelRates = make(map[Level]float64, len(cfg.LevelSamplingRates))
-		for level, rate := range cfg.LevelSamplingRates {
+		// Sorted iteration (like the policies loop): with multiple
+		// invalid entries, the first error reported is deterministic.
+		for _, level := range slices.Sorted(maps.Keys(cfg.LevelSamplingRates)) {
+			rate := cfg.LevelSamplingRates[level]
 			if !IsValidLevel(level) {
 				return nil, fmt.Errorf("hc: level sampling rate for level %d: %w", int(level), ErrInvalidLevel)
 			}

--- a/wal_test.go
+++ b/wal_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"runtime/debug"
 	"slices"
 	"strings"
@@ -745,9 +746,7 @@ func (s *sim) clone() *sim {
 	c.realSnapshots = append([][]string(nil), s.realSnapshots...)
 	c.postKeys = append([]string(nil), s.postKeys...)
 	c.flags = map[string]bool{}
-	for k, v := range s.flags {
-		c.flags[k] = v
-	}
+	maps.Copy(c.flags, s.flags)
 	return &c
 }
 


### PR DESCRIPTION
## What

Follow-up to #56 (merged): a **modernization pass** to the `go 1.25` idiom set — `go fix` (modernize fixers, Go 1.27 toolchain) plus three hand-picked rewrites, **gated by benchmarks** because it touches the hot encode path that survived the perf round.

## Changes

**From `go fix`:**
- `slices.Backward` for every backward walk: `scanWAL`, `lookupField`, `appendDedupedFields` (both loops), `bridge.LastIndices`, and the property-model mirrors
- `wg.Go` (1.25) for the remaining `wg.Add/go/defer-done` idiom sites (hcjson time tests, slog stress test)
- `slices.Contains` (zerolog timestamp-hook probe), `strings.SplitSeq` (fanout crash test), `maps.Copy` (loom-lite sim clone), builtin `max`, range-over-int

**Hand-picked:**
- `resolveEventMessage`: three sequential emptiness branches → `cmp.Or` chains
- `Compile`: `LevelSamplingRates` iteration sorted like the policies loop (deterministic first error there too)
- `bridge.LastIndices`: manual reverse-swap loop → `slices.Reverse`
- `example_test.go`: `sort.Strings` → `slices.Sort`

**Deliberately not modernized** (recorded in `.modernize`):
- `internal/hcjson` vendored loops stay byte-faithful to zerolog v1.34.0 (go fix rewrite reverted there; its own *tests* were modernized)
- Root tests keep `context.Background()` (290 sites; ctx is a WAL carrier here — not worth freeze-time churn). Nested-module `t.Context()` conversions from go fix kept
- `bench_test.go`'s `b.N`-coupled rebuild windows are deliberate design; `b.Loop()` would change the steady-state pool logic

## Benchmark gate

- `RecordEncodeWrite12`: **flat** — 382.4n → 383.2n (p=0.937), allocs identical
- `OperationLifecycle12Fields`: **neutral** — order-flipped rerun shows +4.6% at p=0.065 (not significant), allocs identical; the first run's −24% was a thermal/ordering artifact (uniform across untouched paths, ±∞ variance) and was chased down rather than reported as a win
- `EndDropPathCustomSampler`: −9% (p=0.002); geomean −3.9%

## Verification

`build` / `vet` / `gofmt` clean and tests green across all modules (root, bridge, hcjson, adapters, integrations, examples) including `-race`.

Context: the tree was already largely modern (`wg.Go`, range-over-int, `slices.Sorted(maps.Keys(…))`, `math/rand/v2`, builtin `min`/`max`, generic `bridge.LastIndices`); this closes the remaining gaps found by a `golang-modernize` scan.

🤖 Generated with pi
