### PR TITLE
fix(ci): point release-please at v2 with the input that exists

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ name: release
 on:
   push:
     branches: [v2]
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -25,10 +26,13 @@ jobs:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
           config-file: .release-please-config.json
           manifest-file: .release-please-manifest.json
-          # v2 is the release line (§9 amendment): the action's default
-          # branch input is the repo default (main), which made it scan
-          # frozen main and find nothing releasable.
-          branch: v2
+          # v2 is the release line (§9 amendment). v4 of the action has
+          # no `branch` input — the earlier `branch: v2` was silently
+          # ignored, release-please kept scanning frozen main, and no
+          # release PR ever opened (four green runs, zero PRs). The
+          # real input is target-branch: read commits from v2 and open
+          # the release PR against v2.
+          target-branch: v2
 
       - name: Checkout
         if: ${{ steps.release.outputs.release_created == 'true' }}

--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "go",
+  "target-branch": "v2",
   "packages": {
     ".": {
       "include-component-in-tag": false,


### PR DESCRIPTION
release-please-action v4.4.0 has no `branch` input — the `branch: v2` line from 26f46f2 was silently ignored. Logs from all four runs on v2 show it kept fetching config/manifest from frozen `main` (`targetBranch: main`) and ended in *"No user facing commits found since b0cb32f"*. Zero release PRs despite ~40 v2 commits including `feat!`.

The real input is **`target-branch`**. Set it in the workflow and mirror it in `.release-please-config.json` (so a manual CLI run behaves identically). Adds `workflow_dispatch` so the release PR can be regenerated without a push.

Merging this should make the next v2 push produce the **`chore(v2): release 1.0.0`** PR (major bump from the `feat!` commits since v0.5.0, per the release-process spec).

🤖 Generated with pi