### PR TITLE
fix(v2): resolve the 1.0.0 release-review findings

### DIFF
--- a/V2_DESIGN.md
+++ b/V2_DESIGN.md
@@ -225,7 +225,7 @@ test passing first (§05's cautionary tale).
 | Gate | v0.4.0 | v1.0.0 requirement |
 | --- | ---: | ---: |
 | OperationLifecycle (kept) | ~615 ns / 14 al | **≤ 250 ns / ≤ 4 al** (stretch 150 / 2) |
-| Dropped event (8 fields) | ~628 ns / 9 al | **End-drop path ≤ 100 ns / ≤ 2 al** (sampler + release + pool; field appends excluded — full dropped lifecycle benched separately, ≤ 300 ns) |
+| Dropped event (8 fields) | ~628 ns / 9 al | **End-drop segment ≤ 100 ns / ≤ 2 al** (sampler + release + pool; the segment only — `BenchmarkEndDropPath` times the full field-less End, which is a superset and is recorded in the 1.0.0 note below); full dropped lifecycle benched separately, ≤ 300 ns |
 | Add steady state | boxing per field | **single pair ≤ 20 ns / 0 al** (constant values); multi-pair variadic and non-constant values may allocate the `[]any` — gate is stated per shape and benched with realistic (non-constant) values |
 | std middleware (discard sink) | ~1,000 ns / 26 al | **≤ 350 ns / ≤ 8 al** |
 | First-party sink, 12 fields | n/a | **≤ 400 ns / ≤ 2 al** |
@@ -233,6 +233,24 @@ test passing first (§05's cautionary tale).
 | Bridges, 12 fields | 1,699 / 858 / 354 ns | **≤ 900 / 450 / 300 ns** — *estimates pending measurement*; slog floor includes ~200–300 ns of host-handler cost the bridge cannot remove |
 | Disabled-level writes | ~3 ns | **no regression** |
 | BufferedSink append (v1.1) | n/a | **≤ 100 ns, never blocks** |
+
+**1.0.0 measurement note** (Go 1.27, Apple M4, quiet machine, `count=8`;
+raw runs and the cross-session check in `.bench/wal-check/`):
+
+- The End-drop *segment* (sampler + release + pool) is ~43 ns, inside the
+  100 ns gate. The full field-less `End` that `BenchmarkEndDropPath`
+  times is 123 ns after the 1.0.0 fix pass (135–146 ns before it); the
+  benchmark name and the gate now name different scopes explicitly.
+- `OperationLifecycle` measures 250.1 ns / 2 al after the 1.0.0 fix pass
+  (259–284 ns before it) — at the ≤ 250 ns target within measurement
+  resolution.
+- The full dropped lifecycle with 8 fields measures 335 ns against the
+  ≤ 300 ns target; tracked.
+- EndDrop 123 ns and CustomSampler 117 ns are ~5 % faster than the
+  pre-modernize tree, so the pass recovered the 1.0.0 regression with
+  margin. Add single pair 19.4 ns / 0 al; first-party sink 12 fields
+  379–388 ns / 2 al (inside their gates).
+
 
 Quality gates (all releases): matrix benchmarks at 0/8/32/128 fields,
 rates 0/0.05/0.5/1, policies 0/1/16/128, enabled+disabled levels,

--- a/adapter/zerolog/sink.go
+++ b/adapter/zerolog/sink.go
@@ -7,7 +7,9 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"reflect"
 	"slices"
+	"time"
 	"unsafe"
 
 	"github.com/happytoolin/happycontext"
@@ -116,15 +118,44 @@ func (v *loggerView) enabled(level hc.Level) bool {
 	return zlvlFor(level) >= v.level && zlvlFor(level) >= zerolog.GlobalLevel()
 }
 
-// defaultFieldNames reports whether zerolog's member-name globals are
-// still the defaults the canonical line writes ("level", "time",
-// "message"). When customized, serving the canonical bytes would emit
-// members the user's pipeline does not expect — the typed path, which
-// honors the globals through zerolog's own constructors, takes over.
-func defaultFieldNames() bool {
+// canonicalSettings reports whether every zerolog global that shapes a
+// rendered line is at the value the canonical bytes assume: member
+// names, the time format, the duration unit and integer mode, the
+// level marshaller, and the timestamp function. When any global is
+// customized, the fast path would emit bytes the user's pipeline does
+// not expect — the typed path, which honors the customization through
+// zerolog's own constructors, takes over.
+//
+// zerolog's defaults: TimeFieldFormat is RFC3339 (the canonical line's
+// format), DurationFieldUnit is the millisecond, and DurationFieldInteger
+// is false. Function values cannot be compared with ==, so the two
+// function globals are identified by code pointer against the defaults
+// captured at package init (a nil or replaced function fails the check).
+func canonicalSettings() bool {
 	return zerolog.LevelFieldName == "level" &&
 		zerolog.TimestampFieldName == "time" &&
-		zerolog.MessageFieldName == "message"
+		zerolog.MessageFieldName == "message" &&
+		zerolog.TimeFieldFormat == time.RFC3339 &&
+		zerolog.DurationFieldUnit == time.Millisecond &&
+		!zerolog.DurationFieldInteger &&
+		funcPointer(zerolog.LevelFieldMarshalFunc) == defaultLevelFieldMarshalFunc &&
+		funcPointer(zerolog.TimestampFunc) == defaultTimestampFunc
+}
+
+var (
+	defaultLevelFieldMarshalFunc = funcPointer(zerolog.LevelFieldMarshalFunc)
+	defaultTimestampFunc         = funcPointer(zerolog.TimestampFunc)
+)
+
+// funcPointer identifies a function value by code pointer. It returns 0
+// for a nil or non-function value, which never matches a captured
+// default.
+func funcPointer(fn any) uintptr {
+	v := reflect.ValueOf(fn)
+	if !v.IsValid() || v.Kind() != reflect.Func {
+		return 0
+	}
+	return v.Pointer()
 }
 
 // writeEncoded serves the record's pre-encoded canonical JSON line
@@ -135,11 +166,11 @@ func defaultFieldNames() bool {
 // Deliberate trade-offs: the line is hc's canonical line, byte-
 // identical to the first-party JSON sink, served via one WriteLevel
 // per record so level-aware writers keep working; errors route through
-// zerolog.ErrorHandler; custom member-name globals and augmented
-// loggers are rejected (defaultFieldNames, plain) and take the typed
+// zerolog.ErrorHandler; customized rendering globals and augmented
+// loggers are rejected (canonicalSettings, plain) and take the typed
 // path.
 func (s *Sink) writeEncoded(view *loggerView, rec *hc.Record) bool {
-	if !view.plain() || !view.enabled(rec.Level()) || !defaultFieldNames() {
+	if !view.plain() || !view.enabled(rec.Level()) || !canonicalSettings() {
 		return false
 	}
 	if _, err := view.w.WriteLevel(zlvlFor(rec.Level()), rec.Encoded()); err != nil {

--- a/adapter/zerolog/sink.go
+++ b/adapter/zerolog/sink.go
@@ -121,16 +121,19 @@ func (v *loggerView) enabled(level hc.Level) bool {
 // canonicalSettings reports whether every zerolog global that shapes a
 // rendered line is at the value the canonical bytes assume: member
 // names, the time format, the duration unit and integer mode, the
-// level marshaller, and the timestamp function. When any global is
-// customized, the fast path would emit bytes the user's pipeline does
-// not expect — the typed path, which honors the customization through
-// zerolog's own constructors, takes over.
+// level name values, the level marshaller, and the timestamp function.
+// When any global is customized, the fast path would emit bytes the
+// user's pipeline does not expect — the typed path, which honors the
+// customization through zerolog's own constructors, takes over.
 //
 // zerolog's defaults: TimeFieldFormat is RFC3339 (the canonical line's
 // format), DurationFieldUnit is the millisecond, and DurationFieldInteger
-// is false. Function values cannot be compared with ==, so the two
-// function globals are identified by code pointer against the defaults
-// captured at package init (a nil or replaced function fails the check).
+// is false. The default LevelFieldMarshalFunc calls Level.String,
+// which reads the exported Level*Value vars — so those vars are checked
+// directly; a customized marshaller is caught by code pointer. Function
+// values cannot be compared with ==, so the two function globals are
+// identified by code pointer against the defaults captured at package
+// init (a nil or replaced function fails the check).
 func canonicalSettings() bool {
 	return zerolog.LevelFieldName == "level" &&
 		zerolog.TimestampFieldName == "time" &&
@@ -138,6 +141,10 @@ func canonicalSettings() bool {
 		zerolog.TimeFieldFormat == time.RFC3339 &&
 		zerolog.DurationFieldUnit == time.Millisecond &&
 		!zerolog.DurationFieldInteger &&
+		zerolog.LevelDebugValue == "debug" &&
+		zerolog.LevelInfoValue == "info" &&
+		zerolog.LevelWarnValue == "warn" &&
+		zerolog.LevelErrorValue == "error" &&
 		funcPointer(zerolog.LevelFieldMarshalFunc) == defaultLevelFieldMarshalFunc &&
 		funcPointer(zerolog.TimestampFunc) == defaultTimestampFunc
 }

--- a/adapter/zerolog/sink_test.go
+++ b/adapter/zerolog/sink_test.go
@@ -327,6 +327,78 @@ func TestSinkCustomizedFieldNamesFallsBackToTypedPath(t *testing.T) {
 	}
 }
 
+// TestSinkCustomizedRenderingFallsBackToTypedPath pins the extended
+// fast-path gate: every global that shapes the rendered line — time
+// format, duration rendering, level marshalling, timestamp function —
+// routes a plain logger to the typed path, which honors it. Each
+// subtest asserts the customized rendering, not only that the fast path
+// was refused.
+func TestSinkCustomizedRenderingFallsBackToTypedPath(t *testing.T) {
+	t.Run("time format", func(t *testing.T) {
+		old := zerolog.TimeFieldFormat
+		zerolog.TimeFieldFormat = zerolog.TimeFormatUnix
+		t.Cleanup(func() { zerolog.TimeFieldFormat = old })
+
+		rec := bridgeRecord(t, func(ctx context.Context) { hc.Add(ctx, "k", "v") })
+		var buf bytes.Buffer
+		logger := zerolog.New(&buf) // plain logger: the fast path would serve it
+		New(&logger).Write(context.Background(), rec)
+
+		payload := lastPayload(t, &buf)
+		if _, ok := payload["time"].(float64); !ok {
+			t.Fatalf("time = %v (%T), want the Unix number from TimeFieldFormat", payload["time"], payload["time"])
+		}
+	})
+
+	t.Run("level marshaller", func(t *testing.T) {
+		old := zerolog.LevelFieldMarshalFunc
+		zerolog.LevelFieldMarshalFunc = func(l zerolog.Level) string { return strings.ToUpper(l.String()) }
+		t.Cleanup(func() { zerolog.LevelFieldMarshalFunc = old })
+
+		rec := bridgeRecord(t, func(ctx context.Context) { hc.Add(ctx, "k", "v") })
+		var buf bytes.Buffer
+		logger := zerolog.New(&buf)
+		New(&logger).Write(context.Background(), rec)
+
+		payload := lastPayload(t, &buf)
+		if payload["level"] != "INFO" {
+			t.Fatalf("level = %v, want the marshalled INFO", payload["level"])
+		}
+	})
+
+	t.Run("duration unit", func(t *testing.T) {
+		oldUnit, oldInt := zerolog.DurationFieldUnit, zerolog.DurationFieldInteger
+		zerolog.DurationFieldUnit, zerolog.DurationFieldInteger = time.Second, true
+		t.Cleanup(func() { zerolog.DurationFieldUnit, zerolog.DurationFieldInteger = oldUnit, oldInt })
+
+		rec := bridgeRecord(t, func(ctx context.Context) { hc.Add(ctx, "d", 2500*time.Millisecond) })
+		var buf bytes.Buffer
+		logger := zerolog.New(&buf)
+		New(&logger).Write(context.Background(), rec)
+
+		payload := lastPayload(t, &buf)
+		if payload["d"] != float64(2) {
+			t.Fatalf("d = %v, want 2 seconds from the customized unit", payload["d"])
+		}
+	})
+
+	t.Run("timestamp function", func(t *testing.T) {
+		old := zerolog.TimestampFunc
+		zerolog.TimestampFunc = func() time.Time { return time.Date(1999, 1, 1, 0, 0, 0, 0, time.UTC) }
+		t.Cleanup(func() { zerolog.TimestampFunc = old })
+
+		rec := bridgeRecord(t, func(ctx context.Context) { hc.Add(ctx, "k", "v") })
+		var buf bytes.Buffer
+		logger := zerolog.New(&buf).With().Timestamp().Logger()
+		New(&logger).Write(context.Background(), rec)
+
+		payload := lastPayload(t, &buf)
+		if payload["time"] != "1999-01-01T00:00:00Z" {
+			t.Fatalf("time = %v, want the customized TimestampFunc value", payload["time"])
+		}
+	})
+}
+
 // TestSinkTypedPathStampsRecordCompletionTime pins the F6 symmetry:
 // the enriched-logger typed path stamps the record's own completion
 // time (rec.Time()) — the instant the canonical line carries — rather

--- a/adapter/zerolog/sink_test.go
+++ b/adapter/zerolog/sink_test.go
@@ -366,6 +366,25 @@ func TestSinkCustomizedRenderingFallsBackToTypedPath(t *testing.T) {
 		}
 	})
 
+	t.Run("level value", func(t *testing.T) {
+		// The default LevelFieldMarshalFunc calls Level.String, which
+		// reads the exported Level*Value vars: a customized value must
+		// not slip past the gate.
+		old := zerolog.LevelInfoValue
+		zerolog.LevelInfoValue = "informational"
+		t.Cleanup(func() { zerolog.LevelInfoValue = old })
+
+		rec := bridgeRecord(t, func(ctx context.Context) { hc.Add(ctx, "k", "v") })
+		var buf bytes.Buffer
+		logger := zerolog.New(&buf)
+		New(&logger).Write(context.Background(), rec)
+
+		payload := lastPayload(t, &buf)
+		if payload["level"] != "informational" {
+			t.Fatalf("level = %v, want the customized LevelInfoValue", payload["level"])
+		}
+	})
+
 	t.Run("duration unit", func(t *testing.T) {
 		oldUnit, oldInt := zerolog.DurationFieldUnit, zerolog.DurationFieldInteger
 		zerolog.DurationFieldUnit, zerolog.DurationFieldInteger = time.Second, true

--- a/bench_test.go
+++ b/bench_test.go
@@ -14,9 +14,12 @@ import (
 // These benches measure the gate segments that the external benches
 // cannot isolate (they run inside package hc with unexported access).
 
-// BenchmarkEndDropPath is the §4 end-drop gate segment: ≤ 100 ns / ≤ 2
-// allocs for sampler + release + pool, excluding Start and field
-// appends — operations are pre-built outside the timed loop.
+// BenchmarkEndDropPath times the complete field-less End on pre-built
+// operations — claim, recover, clock read, seal, scan, post-seal
+// annotations, commit, and release. The §4 100 ns gate names only the
+// sampler + release + pool segment of this path; that segment is
+// measured separately by the WAL micro-benchmarks (RateSampler ≈ 5 ns
+// plus EventReleaseRecycle ≈ 38 ns).
 func BenchmarkEndDropPath(b *testing.B) {
 	rt := MustCompile(Config{Sink: dropCountSink{}, SamplingRate: 0})
 	const pre = 4096

--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -63,6 +63,9 @@ func LastIndices[T any](items []T, key func(T) string) []int {
 // contained and the value rendered via fmt, the same fence the core
 // encoder applies).
 func ErrorMessage(err error) (msg string) {
+	if err == nil {
+		return ""
+	}
 	if v := reflect.ValueOf(err); v.Kind() == reflect.Pointer && v.IsNil() {
 		return fmt.Sprint(err)
 	}

--- a/bridge/bridge_test.go
+++ b/bridge/bridge_test.go
@@ -82,6 +82,9 @@ func (panickingErr) Error() string { panic("Error() boom") }
 // render via fmt ("<nil>"), panicking Error() implementations are
 // contained to a fmt fallback, ordinary errors pass through.
 func TestErrorMessageFencesHostileErrors(t *testing.T) {
+	if got := ErrorMessage(nil); got != "" {
+		t.Fatalf("nil message = %q, want empty", got)
+	}
 	var nilErr *typedNilErr
 	if got := ErrorMessage(nilErr); got != "<nil>" {
 		t.Fatalf("typed-nil message = %q, want %q", got, "<nil>")

--- a/crash_test.go
+++ b/crash_test.go
@@ -345,7 +345,7 @@ func TestCrashStragglerStormArmed(t *testing.T) {
 		wg.Go(func() {
 			for i := range perWorker {
 				op := Start(context.Background(), rt, OperationStart{Domain: DomainHTTP, Name: "request"})
-				op.ev.arm()
+				op.ev.arm(genOf(op.ev))
 				Add(op.Context(), "mine", fmt.Sprintf("a%d-%d", w, i))
 				_ = op.End(nil)
 				Add(op.Context(), "straggler", 1)
@@ -661,6 +661,41 @@ func TestCrashTypedNilAndWeirdAny(t *testing.T) {
 	}
 	if m["chan"] == nil && m["func"] == nil {
 		t.Fatal("both unmarshalable values vanished without a trace")
+	}
+}
+
+// TestTestSinkNestedEmptySlices pins the deep-copy identity fix: empty
+// slices of different types all report Pointer() == 0, and the old
+// uintptr visited key aliased them into one cache entry, then panicked
+// inside End on reflect.Set. The capture must preserve both values.
+func TestTestSinkNestedEmptySlices(t *testing.T) {
+	ts := NewTestSink()
+	rt := MustCompile(Config{Sink: ts, SamplingRate: 1})
+	op := Start(context.Background(), rt, OperationStart{Domain: DomainJob, Name: "x"})
+	Add(op.Context(), "mixed", [2]any{[]string(nil), []int(nil)})
+	Add(op.Context(), "empty", []string{})
+	if !op.End(nil) {
+		t.Fatal("event dropped")
+	}
+
+	mixed, ok := ts.Events()[0].Lookup("mixed")
+	if !ok {
+		t.Fatal("mixed field missing")
+	}
+	arr, ok := mixed.([2]any)
+	if !ok {
+		t.Fatalf("mixed = %#v, want [2]any", mixed)
+	}
+	if s, ok := arr[0].([]string); !ok || s != nil {
+		t.Fatalf("arr[0] = %#v, want a nil []string", arr[0])
+	}
+	if i, ok := arr[1].([]int); !ok || i != nil {
+		t.Fatalf("arr[1] = %#v, want a nil []int", arr[1])
+	}
+	if empty, ok := ts.Events()[0].Lookup("empty"); !ok {
+		t.Fatal("empty field missing")
+	} else if s, ok := empty.([]string); !ok || s == nil {
+		t.Fatalf("empty = %#v, want a non-nil empty []string", empty)
 	}
 }
 
@@ -1595,7 +1630,7 @@ func TestCrashArmedMixedWritersSingleEnd(t *testing.T) {
 	for round := range 10 {
 		rt, ts := testRT(t, nil)
 		op := Start(context.Background(), rt, OperationStart{Domain: DomainHTTP, Name: "request"})
-		op.ev.arm()
+		op.ev.arm(genOf(op.ev))
 
 		var wg sync.WaitGroup
 		stop := make(chan struct{})
@@ -1638,7 +1673,7 @@ func TestCrashArmedMixedWritersSingleEnd(t *testing.T) {
 				case <-stop:
 					return
 				default:
-					_ = op.ev.snapshotFields()
+					_, _ = op.ev.snapshotFields(genOf(op.ev))
 				}
 			}
 		})
@@ -1674,7 +1709,7 @@ func TestCrashArmRacingSeal(t *testing.T) {
 				case <-stop:
 					return
 				default:
-					op.ev.arm()
+					op.ev.arm(genOf(op.ev))
 				}
 			}
 		})
@@ -1696,7 +1731,7 @@ func TestCrashArmedErrorVsSeal(t *testing.T) {
 	for round := range 20 {
 		rt, ts := testRT(t, nil)
 		op := Start(context.Background(), rt, OperationStart{Domain: DomainJob, Name: "j"})
-		op.ev.arm()
+		op.ev.arm(genOf(op.ev))
 
 		var wg sync.WaitGroup
 		wg.Go(func() {
@@ -1734,7 +1769,7 @@ func TestCrashArmedErrorVsSeal(t *testing.T) {
 func TestCrashSnapshotVsPostSealAppends(t *testing.T) {
 	rt, ts := testRT(t, nil)
 	op := Start(context.Background(), rt, OperationStart{Domain: DomainHTTP, Name: "request"})
-	op.ev.arm()
+	op.ev.arm(genOf(op.ev))
 
 	stop := make(chan struct{})
 	var wg sync.WaitGroup
@@ -1744,7 +1779,7 @@ func TestCrashSnapshotVsPostSealAppends(t *testing.T) {
 			case <-stop:
 				return
 			default:
-				_ = op.ev.snapshotFields()
+				_, _ = op.ev.snapshotFields(genOf(op.ev))
 			}
 		}
 	})
@@ -1856,7 +1891,7 @@ func FuzzCrashArmedInterleavings(f *testing.F) {
 		rt, ts := testRT(t, nil)
 		op := Start(context.Background(), rt, OperationStart{Domain: DomainHTTP, Name: "request"})
 		if variant%2 == 0 {
-			op.ev.arm()
+			op.ev.arm(genOf(op.ev))
 		}
 		for i := range writes {
 			Add(op.Context(), key2(i), i)
@@ -1979,7 +2014,7 @@ func TestSynctestArmedWritersAllExit(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		rt, ts := testRT(t, nil)
 		op := Start(context.Background(), rt, OperationStart{Domain: DomainHTTP, Name: "request"})
-		op.ev.arm()
+		op.ev.arm(genOf(op.ev))
 		stop := make(chan struct{})
 		var wg sync.WaitGroup
 		for w := range 6 {
@@ -2000,7 +2035,7 @@ func TestSynctestArmedWritersAllExit(t *testing.T) {
 				case <-stop:
 					return
 				default:
-					_ = op.ev.snapshotFields()
+					_, _ = op.ev.snapshotFields(genOf(op.ev))
 				}
 			}
 		})
@@ -2031,9 +2066,12 @@ func TestSynctestWatchdogShape(t *testing.T) {
 		Add(op.Context(), "phase", "before-stall")
 
 		// The watchdog arms a stalled request and snapshots it.
-		op.ev.arm()
+		op.ev.arm(genOf(op.ev))
 		time.Sleep(500 * time.Millisecond) // virtual: instant, deterministic
-		snap := op.ev.snapshotFields()
+		snap, ok := op.ev.snapshotFields(genOf(op.ev))
+		if !ok {
+			t.Fatal("armed snapshot refused")
+		}
 
 		// The request wakes, REWRITES a snapshotted key, adds a new
 		// one, then commits. The rewrite is what makes the stability

--- a/hc.go
+++ b/hc.go
@@ -18,8 +18,15 @@ func eventFromContext(ctx context.Context) *walRef {
 }
 
 // Add records one or more fields on the request's event. With no event
-// attached (or after End) it is a silent no-op, exactly like the slog
-// helper family.
+// attached it is a silent no-op, exactly like the slog helper family.
+//
+// A write through a context whose operation already ended is dropped in
+// practice, but the drop is not guaranteed: a write that loaded the
+// event state before End sealed it can still land in the nanosecond
+// before the pooled event is recycled (the residual window in the WAL
+// protocol). A goroutine that outlives the request must not rely on
+// post-End writes being dropped — finish the writes before End, or fan
+// results back to the request goroutine.
 //
 // Additional pairs may be passed variadically: Add(ctx, "a", 1, "b", 2).
 // Every pair key must be a non-empty string; empty and non-string keys
@@ -44,7 +51,8 @@ func Add(ctx context.Context, key string, value any, kv ...any) {
 }
 
 // Error records err on the request's event as the structured canonical
-// error field.
+// error field. A write after End has the caveat described on Add: it
+// is not guaranteed to be dropped.
 func Error(ctx context.Context, err error) {
 	if err == nil {
 		return
@@ -55,7 +63,8 @@ func Error(ctx context.Context, err error) {
 }
 
 // SetMessage sets a per-event final message override. An empty message
-// is treated as unset during finalization.
+// is treated as unset during finalization. A write after End has the
+// caveat described on Add: it is not guaranteed to be dropped.
 func SetMessage(ctx context.Context, msg string) {
 	if ref := eventFromContext(ctx); ref != nil {
 		ref.ev.setMessage(ref, msg)
@@ -63,6 +72,8 @@ func SetMessage(ctx context.Context, msg string) {
 }
 
 // SetRoute sets a normalized route template (http.route) on the event.
+// A write after End has the caveat described on Add: it is not
+// guaranteed to be dropped.
 func SetRoute(ctx context.Context, route string) {
 	if ref := eventFromContext(ctx); ref != nil {
 		ref.ev.setRoute(ref, route)
@@ -70,7 +81,8 @@ func SetRoute(ctx context.Context, route string) {
 }
 
 // SetLevel requests a severity floor for the final event; the emitted
-// level is never lower than the request.
+// level is never lower than the request. A write after End has the
+// caveat described on Add: it is not guaranteed to be dropped.
 func SetLevel(ctx context.Context, level Level) {
 	if ref := eventFromContext(ctx); ref != nil {
 		ref.ev.setLevel(ref, level)

--- a/operation.go
+++ b/operation.go
@@ -83,7 +83,9 @@ func (op *Operation) Context() context.Context {
 // silently disables panic capture. Reentrant use is not supported: a
 // second End from inside a sink's Write deadlocks on the one-shot
 // claim. Concurrent first calls are safe: exactly one wins the claim
-// and commits; the others wait and return the published result.
+// and commits; the others wait and return the published result. Writes
+// through the operation context after End returns have the caveat
+// described on Add: they are not guaranteed to be dropped.
 func (op *Operation) End(errp *error) (emitted bool) {
 	// A nil *Operation and the zero Operation are both no-ops: the zero
 	// value carries no event, so there is nothing to commit. This keeps
@@ -92,8 +94,11 @@ func (op *Operation) End(errp *error) (emitted bool) {
 	if op == nil || op.ev == nil {
 		return false
 	}
-	if !op.claim() {
-		return op.emitted // published by the winning caller (race-free, see endState)
+	// Claim the one-shot commit with one inline CAS. Only a concurrent
+	// second End pays for the wait, so the request hot path avoids a
+	// non-inlinable call.
+	if !op.endState.CompareAndSwap(0, 1) {
+		return op.awaitPublication()
 	}
 	// Publish on every exit path, including panics, so waiting callers
 	// can never spin on a winner that died mid-commit. LIFO order: the
@@ -137,7 +142,7 @@ func (op *Operation) End(errp *error) (emitted bool) {
 	}
 	outcome := resolveOutcome(err, recovered, outcomeCode, scan.outcome)
 
-	in := commitInput{
+	in := &commitInput{
 		outcome:  outcome,
 		code:     code,
 		duration: duration,
@@ -157,23 +162,17 @@ func (op *Operation) End(errp *error) (emitted bool) {
 	return emitted
 }
 
-// claim acquires the one-shot commit right (endState 0 → 1 by CAS).
-// A caller that observes the state claimed (1) or published (2) waits
-// for the winner's publication — which every exit path of the
-// winner's End performs, including panics — and then reports false;
-// End reads the published result in that case.
-func (op *Operation) claim() bool {
-	for {
-		switch op.endState.Load() {
-		case 2:
-			return false
-		case 0:
-			if op.endState.CompareAndSwap(0, 1) {
-				return true
-			}
-		}
+// awaitPublication waits for the winning End caller to publish the
+// one-shot result (endState 1 → 2, on every exit path including
+// panics) and returns it. Concurrent End is a rare, documented-safe
+// path; the wait yields with runtime.Gosched instead of blocking on a
+// per-operation primitive, so the common single-caller path pays
+// nothing.
+func (op *Operation) awaitPublication() bool {
+	for op.endState.Load() != 2 {
 		runtime.Gosched()
 	}
+	return op.emitted
 }
 
 // walScan is the single backward walk over the sealed WAL collecting
@@ -182,6 +181,12 @@ func (op *Operation) claim() bool {
 // request wrote any start-metadata key itself (lazy start fields must
 // not clobber a user override — suppressing the canonical append
 // reproduces the old LWW fold exactly).
+//
+// Each scalar takes the last write of its expected kind: a later write
+// of another kind (for example a string http.status) is not a usable
+// canonical value and does not erase an earlier usable one. The
+// encode-time dedupe still resolves the wire member last-write-wins;
+// only the sampler's typed view is kind-sensitive.
 type walScan struct {
 	outcome    Outcome
 	hasOutcome bool
@@ -254,7 +259,9 @@ func scanWAL(ev *event) walScan {
 // for the commit stage — everything that is not already reachable from
 // the Operation itself (ev, rt, start, ctx, record). One struct instead
 // of a ten-parameter call, and the natural home for these semantics:
-// all of it describes the sealed event between seal and commit.
+// all of it describes the sealed event between seal and commit. End
+// passes it by pointer: the struct is 200 bytes (it embeds walScan),
+// and by-value copies showed up in the lifecycle benchmarks.
 type commitInput struct {
 	outcome  Outcome // resolved outcome (panic > error > explicit > 5xx > success)
 	code     int     // resolved http.status (the canonical code for HTTP operations)
@@ -266,7 +273,7 @@ type commitInput struct {
 }
 
 // commit resolves level, message, and sampling, then writes the record.
-func (op *Operation) commit(in commitInput) bool {
+func (op *Operation) commit(in *commitInput) bool {
 	rt := op.rt
 	if rt.noop() {
 		return false
@@ -362,7 +369,7 @@ func annotateOperationFailures(ev *event, ref *walRef, err error, recovered any)
 // Canonical fields: HTTP operations carry http.status; non-HTTP
 // operations surface their explicit op.code here (ledger: canonical
 // fields).
-func (op *Operation) annotatePostSeal(in commitInput) {
+func (op *Operation) annotatePostSeal(in *commitInput) {
 	ev := op.ev
 	// The owner is the only writer past the seal, so the state and the
 	// generation are stable across this entire block (release is
@@ -412,8 +419,12 @@ func resolveOutcome(err error, recovered any, code int, explicit Outcome) Outcom
 	return OutcomeSuccess
 }
 
-func buildSampleInput(ev *event, start OperationStart, in commitInput, level Level) SampleInput {
-	hasError := in.err != nil || in.panicked || ev.hasErr || in.outcome != OutcomeSuccess
+func buildSampleInput(ev *event, start OperationStart, in *commitInput, level Level) SampleInput {
+	// A retry is an explicit non-success outcome, not an error: it does
+	// not bypass sampling (SampleInput.HasError is documented as
+	// error-or-panic).
+	hasError := in.err != nil || in.panicked || ev.hasErr ||
+		(in.outcome != OutcomeSuccess && in.outcome != OutcomeRetry)
 	opName := start.Name
 	if in.scan.name != "" {
 		opName = in.scan.name

--- a/operation_test.go
+++ b/operation_test.go
@@ -298,6 +298,55 @@ func TestErrorsBypassSampling(t *testing.T) {
 	}
 }
 
+// TestRetryDoesNotBypassSampling pins that an explicit non-error
+// outcome is not structurally kept: SampleInput.HasError is documented
+// as error-or-panic, so a retry at rate 0 drops like any healthy event.
+func TestRetryDoesNotBypassSampling(t *testing.T) {
+	ts := NewTestSink()
+	rt := MustCompile(Config{Sink: ts, SamplingRate: 0})
+	op := Start(context.Background(), rt, OperationStart{Domain: DomainJob, Name: "retry"})
+	Add(op.Context(), KeyOpOutcome, string(OutcomeRetry))
+	if op.End(nil) {
+		t.Fatal("retry event bypassed sampling at rate 0")
+	}
+	if got := len(ts.Events()); got != 0 {
+		t.Fatalf("emitted %d events at rate 0, want 0", got)
+	}
+
+	// Control: the same outcome at rate 1 is kept.
+	ts.Reset()
+	rt = MustCompile(Config{Sink: ts, SamplingRate: 1})
+	op = Start(context.Background(), rt, OperationStart{Domain: DomainJob, Name: "retry"})
+	Add(op.Context(), KeyOpOutcome, string(OutcomeRetry))
+	if !op.End(nil) {
+		t.Fatal("retry event was dropped at rate 1")
+	}
+	if got, _ := ts.Events()[0].Lookup(KeyOpOutcome); got != string(OutcomeRetry) {
+		t.Fatalf("outcome = %v, want retry", got)
+	}
+}
+
+// TestCanonicalStatusKeepsLastUsableWrite pins the scanWAL kind rule: a
+// later write of another kind is not a usable canonical value and does
+// not erase an earlier usable one, so a stray string write cannot hide
+// a 5xx.
+func TestCanonicalStatusKeepsLastUsableWrite(t *testing.T) {
+	rt, ts := testRT(t, nil)
+	op := Start(context.Background(), rt, OperationStart{Domain: DomainHTTP, Name: "x"})
+	Add(op.Context(), KeyHTTPStatus, 500)
+	Add(op.Context(), KeyHTTPStatus, "503") // wrong kind: not canonical
+	op.End(nil)
+
+	ev := ts.Events()[0]
+	if got, _ := ev.Lookup(KeyOpOutcome); got != string(OutcomeFailure) {
+		t.Fatalf("outcome = %v, want failure from the usable int status", got)
+	}
+	// Lookup keeps the last-write-wins view: the user's string write.
+	if got, _ := ev.Lookup(KeyHTTPStatus); got != "503" {
+		t.Fatalf("wire status = %v, want the user's last write (503)", got)
+	}
+}
+
 // TestSampleInputUsesWALOpName pins v0 HTTP parity: a last-write
 // op.name on the WAL (the route template) is what Sampler sees as
 // Operation, not the original Start name ("request").
@@ -635,7 +684,7 @@ func TestConcurrentEndArmed(t *testing.T) {
 		rt := MustCompile(Config{Sink: ts, SamplingRate: 1})
 		op := Start(context.Background(), rt, OperationStart{Domain: DomainJob, Name: "armed-race"})
 		ctx := op.Context()
-		op.ev.arm()
+		op.ev.arm(genOf(op.ev))
 
 		var mu sync.Mutex
 		start := sync.NewCond(&mu)

--- a/property_test.go
+++ b/property_test.go
@@ -1241,7 +1241,7 @@ func executeProgramOn(prog lifeProgram, op *Operation) {
 		case opSetRoute:
 			SetRoute(ctx, o.val.(string))
 		case opArm:
-			op.ev.arm()
+			op.ev.arm(genOf(op.ev))
 		case opEndErr:
 			if ended {
 				continue // one-shot End; later ends are no-ops

--- a/runtime_test.go
+++ b/runtime_test.go
@@ -231,6 +231,19 @@ func TestPolicyForDomain(t *testing.T) {
 	}
 }
 
+// TestPolicyOutcomeLevelsCanSelectInfo pins the documented workaround:
+// the three level fields cannot express an explicit INFO because the
+// zero Level is the "use the default" sentinel, but OutcomeLevels can.
+func TestPolicyOutcomeLevelsCanSelectInfo(t *testing.T) {
+	policy := OperationPolicy{OutcomeLevels: map[Outcome]Level{OutcomeFailure: LevelInfo}}
+	if got := levelFromPolicy(policy, OutcomeFailure); got != LevelInfo {
+		t.Fatalf("levelFromPolicy = %v, want INFO via OutcomeLevels", got)
+	}
+	if got := levelFromPolicy(OperationPolicy{FailureLevel: LevelInfo}, OutcomeFailure); got != LevelError {
+		t.Fatalf("zero FailureLevel = %v, want the ERROR default", got)
+	}
+}
+
 type wrappedTestError struct{ err error }
 
 func (w wrappedTestError) Error() string { return "wrapped: " + w.err.Error() }

--- a/test_sink.go
+++ b/test_sink.go
@@ -120,8 +120,8 @@ func deepCopyValue(v any, seen *visitSet) any {
 		case reflect.Map, reflect.Slice, reflect.Array:
 			if rv.CanInterface() {
 				cp := reflect.New(rv.Type()).Elem()
-				seen := map[uintptr]reflect.Value{}
-				deepCopyReflect(rv, cp, seen)
+				local := map[visitKey]reflect.Value{}
+				deepCopyReflect(rv, cp, local)
 				return cp.Interface()
 			}
 		}
@@ -129,27 +129,40 @@ func deepCopyValue(v any, seen *visitSet) any {
 	}
 }
 
-func deepCopyReflect(src, dst reflect.Value, seen map[uintptr]reflect.Value) {
+func deepCopyReflect(src, dst reflect.Value, seen map[visitKey]reflect.Value) {
 	switch k := src.Kind(); k {
 	case reflect.Map:
-		if prior, ok := seen[src.Pointer()]; ok {
+		key := visitKey{typ: src.Type(), ptr: src.Pointer()}
+		if prior, ok := seen[key]; ok {
 			dst.Set(prior)
 			return
 		}
 		dst.Set(reflect.MakeMapWithSize(src.Type(), src.Len()))
-		seen[src.Pointer()] = dst
+		seen[key] = dst
 		for _, k := range src.MapKeys() {
 			ev := reflect.New(src.Type().Elem()).Elem()
 			deepCopyReflect(src.MapIndex(k), ev, seen)
 			dst.SetMapIndex(k, ev)
 		}
 	case reflect.Slice:
-		if prior, ok := seen[src.Pointer()]; ok {
+		// Zero-length slices all report Pointer() == 0. Copy them
+		// directly instead of caching them: a shared cache key would
+		// alias two empty slices of different types and panic on Set.
+		if src.Len() == 0 {
+			if src.IsNil() {
+				dst.SetZero()
+				return
+			}
+			dst.Set(reflect.MakeSlice(src.Type(), 0, src.Cap()))
+			return
+		}
+		key := visitKey{typ: src.Type(), ptr: src.Pointer()}
+		if prior, ok := seen[key]; ok {
 			dst.Set(prior)
 			return
 		}
 		dst.Set(reflect.MakeSlice(src.Type(), src.Len(), src.Cap()))
-		seen[src.Pointer()] = dst
+		seen[key] = dst
 		for i := range src.Len() {
 			deepCopyReflect(src.Index(i), dst.Index(i), seen)
 		}
@@ -161,12 +174,13 @@ func deepCopyReflect(src, dst reflect.Value, seen map[uintptr]reflect.Value) {
 		if src.IsNil() {
 			return
 		}
-		if prior, ok := seen[src.Pointer()]; ok {
+		key := visitKey{typ: src.Type(), ptr: src.Pointer()}
+		if prior, ok := seen[key]; ok {
 			dst.Set(prior)
 			return
 		}
 		cp := reflect.New(src.Type().Elem())
-		seen[src.Pointer()] = cp
+		seen[key] = cp
 		deepCopyReflect(src.Elem(), cp.Elem(), seen)
 		dst.Set(cp)
 	case reflect.Interface:

--- a/test_sink.go
+++ b/test_sink.go
@@ -45,9 +45,12 @@ func NewTestSink() *TestSink {
 // scalars are immutable by construction. Pointer payloads are NOT
 // cloned (the pointed-to value stays shared with the caller), except
 // that error identity is deliberately preserved so errors.Is works
-// on captured fields. Mutate-through-a-pointer after End is visible
-// in the capture — copy it yourself before End if you need a frozen
-// snapshot of pointer-bearing data.
+// on captured fields. Struct payloads copy shallowly: a struct that
+// wraps a map or slice stays shared with the caller, because a
+// reflect field copy cannot set unexported fields (and would break
+// time.Time). Mutate-through-a-pointer after End is visible in the
+// capture — copy it yourself before End if you need a frozen snapshot
+// of pointer-bearing or struct-bearing data.
 func (t *TestSink) Write(_ context.Context, rec *Record) {
 	if t == nil || rec == nil {
 		return

--- a/types.go
+++ b/types.go
@@ -28,6 +28,10 @@ const (
 // fields override that, per outcome or per class. SamplingRate, when
 // set, replaces both the global rate and any LevelSamplingRates entry
 // for the domain.
+//
+// Because the zero Level is INFO, FailureLevel and PanicLevel cannot
+// select INFO explicitly; use OutcomeLevels for that (for example
+// OutcomeLevels[OutcomeFailure] = LevelInfo).
 type OperationPolicy struct {
 	SuccessLevel  Level
 	FailureLevel  Level

--- a/wal.go
+++ b/wal.go
@@ -103,16 +103,19 @@ func (e *event) seal() {
 	}
 }
 
-// arm switches the live event to guarded mode: appends and snapshots
-// serialize under the per-event mutex. The watchdog (v1.1) arms stalled
-// requests; the protocol ships in the core now so arming is never a
-// breaking change.
-func (e *event) arm() {
+// arm switches a live event of the given generation to guarded mode:
+// appends and snapshots serialize under the per-event mutex. The
+// generation check rejects a stale watchdog handle, so a watchdog that
+// fires after End cannot arm the next request's recycled event. It
+// reports whether the event was armed.
+func (e *event) arm(gen uint64) bool {
 	e.mu.Lock()
-	if s := e.state.Load(); walState(s&walStateMask) == walLive {
-		e.state.CompareAndSwap(s, s&^walStateMask|uint64(walArmed))
+	defer e.mu.Unlock()
+	s := e.state.Load()
+	if s>>walStateBits != gen || walState(s&walStateMask) != walLive {
+		return false
 	}
-	e.mu.Unlock()
+	return e.state.CompareAndSwap(s, s&^walStateMask|uint64(walArmed))
 }
 
 // append adds one field for the given generation. One atomic load
@@ -178,6 +181,11 @@ func (e *event) setError(ref *walRef, err error) {
 	if err == nil {
 		return
 	}
+	// Build the structured field before any lock: Error()/Unwrap()
+	// implementations are user code and must not run under the armed
+	// mutex (a slow or reentrant error would stall or deadlock the
+	// watchdog path).
+	field := Field{key: KeyError, kind: KindAny, val: structuredErrorField(err)}
 	s := e.state.Load()
 	if s>>walStateBits != ref.gen {
 		return
@@ -187,11 +195,11 @@ func (e *event) setError(ref *walRef, err error) {
 		e.mu.Lock()
 		defer e.mu.Unlock()
 		if cur := e.state.Load(); cur>>walStateBits == ref.gen && walState(cur&walStateMask) == walArmed {
-			e.fields = append(e.fields, Field{key: KeyError, kind: KindAny, val: structuredErrorField(err)})
+			e.fields = append(e.fields, field)
 			e.hasErr = true // only when the write belonged to this generation
 		}
 	case walLive:
-		e.fields = append(e.fields, Field{key: KeyError, kind: KindAny, val: structuredErrorField(err)})
+		e.fields = append(e.fields, field)
 		e.hasErr = true
 	}
 }
@@ -251,15 +259,26 @@ func (e *event) setLevel(ref *walRef, level Level) {
 	}
 }
 
-// snapshotFields returns a copy of the current WAL tail for an armed
-// event's watchdog read; it shares the append mutex so snapshots are
-// race-clean against concurrent guarded appends.
-func (e *event) snapshotFields() []Field {
+// snapshotFields returns a copy of the WAL tail for the watchdog. It
+// rejects a stale generation and a live (unarmed) event — a live
+// snapshot would race the lock-free fast path — and shares the append
+// mutex, so the copy is race-clean against guarded appends and the
+// owner's post-seal writes. ok is false when the snapshot is refused.
+func (e *event) snapshotFields(gen uint64) (out []Field, ok bool) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
-	out := make([]Field, len(e.fields))
-	copy(out, e.fields)
-	return out
+	s := e.state.Load()
+	if s>>walStateBits != gen {
+		return nil, false
+	}
+	switch walState(s & walStateMask) {
+	case walArmed, walSealedArmed, walSealed:
+		out = make([]Field, len(e.fields))
+		copy(out, e.fields)
+		return out, true
+	default:
+		return nil, false
+	}
 }
 
 // lookup returns the last value written under key (last-write-wins view

--- a/wal.go
+++ b/wal.go
@@ -260,10 +260,14 @@ func (e *event) setLevel(ref *walRef, level Level) {
 }
 
 // snapshotFields returns a copy of the WAL tail for the watchdog. It
-// rejects a stale generation and a live (unarmed) event — a live
-// snapshot would race the lock-free fast path — and shares the append
-// mutex, so the copy is race-clean against guarded appends and the
-// owner's post-seal writes. ok is false when the snapshot is refused.
+// rejects a stale generation, a live (unarmed) event, and a plain
+// sealed event. Live snapshots would race the lock-free fast path;
+// plain-sealed snapshots would race the owner's lock-free post-seal
+// writes (annotatePostSeal writes under mu only for sealedArmed), and
+// a successfully armed event never reaches plain walSealed. The copy
+// shares the append mutex, so it is race-clean against guarded appends
+// and the armed owner's post-seal writes. ok is false when the
+// snapshot is refused.
 func (e *event) snapshotFields(gen uint64) (out []Field, ok bool) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
@@ -272,7 +276,7 @@ func (e *event) snapshotFields(gen uint64) (out []Field, ok bool) {
 		return nil, false
 	}
 	switch walState(s & walStateMask) {
-	case walArmed, walSealedArmed, walSealed:
+	case walArmed, walSealedArmed:
 		out = make([]Field, len(e.fields))
 		copy(out, e.fields)
 		return out, true

--- a/wal_bench_test.go
+++ b/wal_bench_test.go
@@ -1,0 +1,239 @@
+package hc
+
+// Benchmarks for the WAL (event) state machine itself — the append
+// paths, the arming protocol (amendment 1), sealing, straggler no-ops
+// (amendment 20), the watchdog snapshot, and pool recycling. The
+// lifecycle-level gates live in bench_test.go and the benches module;
+// these isolate the wal.go primitives so the armed protocol that v1.1's
+// watchdog will exercise has a perf record before it ships. (The
+// owner's post-seal appends have no primitive since the modernize
+// pass: annotatePostSeal appends directly under one bracketed lock.)
+
+import (
+	"errors"
+	"testing"
+)
+
+// benchPre is the round-robin pool size for the rebuild pattern (same
+// shape as BenchmarkEndDropPath): mutations that grow fields or flip
+// one-shot state run against pre-built events, rebuilt with the timer
+// stopped, so the timed region is only the operation under test.
+const benchPre = 4096
+
+func benchField() Field { return fieldStr("user_id", "u_8472") }
+
+// BenchmarkEventAppendLive is the unarmed fast path: one atomic load,
+// one slice append (amendment 1's ~1 ns budget line).
+func BenchmarkEventAppendLive(b *testing.B) {
+	ev := newEvent()
+	ev.fields = make([]Field, 0, benchPre)
+	gen := ev.state.Load() >> walStateBits
+	f := benchField()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		if n&(benchPre-1) == 0 && n > 0 {
+			b.StopTimer()
+			ev.fields = ev.fields[:0]
+			b.StartTimer()
+		}
+		ev.append(gen, f)
+	}
+	ev.release()
+}
+
+// BenchmarkEventAppendArmed is the guarded path: the same append with
+// the event armed — mutex round trip per field. The armed/live ratio is
+// the cost the v1.1 watchdog imposes on stalled requests.
+func BenchmarkEventAppendArmed(b *testing.B) {
+	ev := newEvent()
+	ev.arm(genOf(ev))
+	ev.fields = make([]Field, 0, benchPre)
+	gen := ev.state.Load() >> walStateBits
+	f := benchField()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		if n&(benchPre-1) == 0 && n > 0 {
+			b.StopTimer()
+			ev.fields = ev.fields[:0]
+			b.StartTimer()
+		}
+		ev.append(gen, f)
+	}
+	ev.release()
+}
+
+// BenchmarkEventAppendStaleGen is the straggler no-op for a recycled
+// event: generation mismatch, one load and return (amendment 20).
+func BenchmarkEventAppendStaleGen(b *testing.B) {
+	ev := newEvent()
+	gen := ev.state.Load() >> walStateBits
+	ev.reset() // bump the generation: the held gen is now stale
+	f := benchField()
+	b.ReportAllocs()
+	for b.Loop() {
+		ev.append(gen, f)
+	}
+	ev.release()
+}
+
+// BenchmarkEventAppendSealed is the straggler no-op for a sealed event:
+// generation matches, state says sealed — the write must not land.
+func BenchmarkEventAppendSealed(b *testing.B) {
+	ev := newEvent()
+	gen := ev.state.Load() >> walStateBits
+	ev.seal()
+	f := benchField()
+	b.ReportAllocs()
+	for b.Loop() {
+		ev.append(gen, f)
+	}
+	ev.release()
+}
+
+// BenchmarkEventArm is the live→armed transition (watchdog arming).
+func BenchmarkEventArm(b *testing.B) {
+	events := make([]*event, benchPre)
+	rebuild := func() {
+		for i := range events {
+			events[i] = newEvent()
+		}
+	}
+	rebuild()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		if n&(benchPre-1) == 0 && n > 0 {
+			b.StopTimer()
+			rebuild()
+			b.StartTimer()
+		}
+		e := events[n&(benchPre-1)]
+		e.arm(genOf(e))
+	}
+	for _, ev := range events {
+		ev.release()
+	}
+}
+
+// BenchmarkEventSealLive is the unarmed seal: one CAS, no mutex.
+func BenchmarkEventSealLive(b *testing.B) {
+	events := make([]*event, benchPre)
+	rebuild := func() {
+		for i := range events {
+			events[i] = newEvent()
+		}
+	}
+	rebuild()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		if n&(benchPre-1) == 0 && n > 0 {
+			b.StopTimer()
+			rebuild()
+			b.StartTimer()
+		}
+		events[n&(benchPre-1)].seal()
+	}
+	for _, ev := range events {
+		ev.release()
+	}
+}
+
+// BenchmarkEventSealArmed is the armed seal: lock, store SealedArmed,
+// unlock — the path a watchdog-stalled request takes through End.
+func BenchmarkEventSealArmed(b *testing.B) {
+	events := make([]*event, benchPre)
+	rebuild := func() {
+		for i := range events {
+			ev := newEvent()
+			ev.arm(genOf(ev))
+			events[i] = ev
+		}
+	}
+	rebuild()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		if n&(benchPre-1) == 0 && n > 0 {
+			b.StopTimer()
+			rebuild()
+			b.StartTimer()
+		}
+		events[n&(benchPre-1)].seal()
+	}
+	for _, ev := range events {
+		ev.release()
+	}
+}
+
+// BenchmarkEventSnapshotFields is the watchdog's read of an armed WAL:
+// copy of the current tail under the append mutex.
+func BenchmarkEventSnapshotFields(b *testing.B) {
+	ev := newEvent()
+	ev.arm(genOf(ev))
+	gen := ev.state.Load() >> walStateBits
+	for i := 0; i < 12; i++ {
+		ev.append(gen, fieldStr("k", "v"))
+	}
+	b.ReportAllocs()
+	for b.Loop() {
+		_, _ = ev.snapshotFields(genOf(ev))
+	}
+	ev.release()
+}
+
+// BenchmarkEventSetError is the failure-path setter on a live event:
+// structuredErrorField builds the map (message, type, cause) that every
+// failing request pays at End.
+func BenchmarkEventSetError(b *testing.B) {
+	ev := newEvent()
+	ev.fields = make([]Field, 0, benchPre)
+	ref := &walRef{ev: ev, gen: ev.state.Load() >> walStateBits}
+	err := errors.New("bench failure")
+	b.ReportAllocs()
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		if n&(benchPre-1) == 0 && n > 0 {
+			b.StopTimer()
+			ev.fields = ev.fields[:0]
+			b.StartTimer()
+		}
+		ev.setError(ref, err)
+	}
+	ev.release()
+}
+
+// BenchmarkEventSetMessage is the message override on a live event.
+func BenchmarkEventSetMessage(b *testing.B) {
+	ev := newEvent()
+	ref := &walRef{ev: ev, gen: ev.state.Load() >> walStateBits}
+	b.ReportAllocs()
+	for b.Loop() {
+		ev.setMessage(ref, "override")
+	}
+	ev.release()
+}
+
+// BenchmarkEventSetLevel is the requested-level floor on a live event —
+// the per-request write the middleware shapes make.
+func BenchmarkEventSetLevel(b *testing.B) {
+	ev := newEvent()
+	ref := &walRef{ev: ev, gen: ev.state.Load() >> walStateBits}
+	b.ReportAllocs()
+	for b.Loop() {
+		ev.setLevel(ref, LevelWarn)
+	}
+	ev.release()
+}
+
+// BenchmarkEventReleaseRecycle is the pool round trip End performs:
+// release (seal + Put) then newEvent (Get + reset, one time.Now).
+func BenchmarkEventReleaseRecycle(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		ev := newEvent()
+		ev.release()
+	}
+}

--- a/wal_test.go
+++ b/wal_test.go
@@ -418,12 +418,23 @@ func TestArmRejectsStaleGeneration(t *testing.T) {
 		t.Fatalf("armed snapshot = %v (ok=%v), want one k field", snap, ok)
 	}
 
-	// A sealed event still snapshots its immutable tail.
+	// A sealedArmed event still snapshots its tail: the owner's
+	// post-seal writes serialize under the same mutex.
 	ev.seal()
 	if snap, ok := ev.snapshotFields(genOf(ev)); !ok || len(snap) != 1 {
-		t.Fatalf("sealed snapshot = %v (ok=%v), want one k field", snap, ok)
+		t.Fatalf("sealedArmed snapshot = %v (ok=%v), want one k field", snap, ok)
 	}
 	ev.release()
+
+	// A plain-sealed event (arm never won) refuses snapshots: the owner
+	// writes its post-seal fields lock-free, so the mutex-taking copy
+	// would race.
+	unarmed := newEvent()
+	unarmed.seal()
+	if snap, ok := unarmed.snapshotFields(genOf(unarmed)); ok {
+		t.Fatalf("plain-sealed snapshot accepted: %v", snap)
+	}
+	unarmed.release()
 }
 
 // TestStragglerStartLine stresses the straggler-vs-recycle window with
@@ -1341,9 +1352,9 @@ func snapshotSteps() []simStep {
 		name: "snap-lock",
 		// The watchdog snapshots armed events; once armed, a snapshot
 		// may be taken before or after the seal (sealedArmed) whenever
-		// the mutex is free — the real snapshotFields has no state
-		// check. Live-state snapshots are excluded by the usage
-		// contract (they would race the owner's lock-free fast path).
+		// the mutex is free. The real snapshotFields accepts exactly
+		// those two states: live and plain-sealed copies would race a
+		// lock-free owner write.
 		runnable: func(s *sim) bool {
 			return (s.ev.state == walArmed || s.ev.state == walSealedArmed) && !s.ev.muHeld
 		},

--- a/wal_test.go
+++ b/wal_test.go
@@ -108,14 +108,14 @@ func TestWALSealingAfterRelease(t *testing.T) {
 func TestWALArmingProtocol(t *testing.T) {
 	ev := newEvent()
 	ref := &walRef{ev: ev, gen: ev.state.Load() >> walStateBits}
-	ev.arm()
+	ev.arm(genOf(ev))
 
 	var wg sync.WaitGroup
 	wg.Add(3)
 	go func() { // watchdog-style snapshots
 		defer wg.Done()
 		for range 2000 {
-			_ = ev.snapshotFields()
+			_, _ = ev.snapshotFields(genOf(ev))
 		}
 	}()
 	go func() { // guarded appends
@@ -360,7 +360,7 @@ func TestSealDuringArmedAppend(t *testing.T) {
 	for range 200 {
 		op := Start(context.Background(), rt, OperationStart{Domain: DomainJob, Name: "r"})
 		ctx := op.Context()
-		op.ev.arm() // arm BEFORE End to force the guarded path
+		op.ev.arm(genOf(op.ev)) // arm BEFORE End to force the guarded path
 		wg.Go(func() {
 			for i := range 50 {
 				Add(ctx, "armed", i)
@@ -376,7 +376,7 @@ func TestSealDuringArmedAppend(t *testing.T) {
 func TestArmingStaleGeneration(t *testing.T) {
 	ev := newEvent()
 	ref := &walRef{ev: ev, gen: ev.state.Load() >> walStateBits}
-	ev.arm()
+	ev.arm(genOf(ev))
 	ev.append(ref.gen-1, fieldStr("past", "x"))   // stale past
 	ev.append(ref.gen+1, fieldStr("future", "x")) // future
 	for _, f := range ev.fields {
@@ -384,6 +384,46 @@ func TestArmingStaleGeneration(t *testing.T) {
 			t.Fatal("generation check failed")
 		}
 	}
+}
+
+// TestArmRejectsStaleGeneration pins the watchdog-handle guard: a stale
+// arm must not arm the next request's recycled event, a live event must
+// refuse snapshots (a live copy would race the fast path), and an armed
+// or sealed event snapshots a race-free copy.
+func TestArmRejectsStaleGeneration(t *testing.T) {
+	ev := newEvent()
+	stale := genOf(ev)
+
+	ev.reset() // pool recycle: a new generation
+	if ev.arm(stale) {
+		t.Fatal("stale arm accepted")
+	}
+	if got := walState(ev.state.Load() & walStateMask); got != walLive {
+		t.Fatalf("state after stale arm = %v, want live", got)
+	}
+	if _, ok := ev.snapshotFields(stale); ok {
+		t.Fatal("stale snapshot accepted")
+	}
+	if _, ok := ev.snapshotFields(genOf(ev)); ok {
+		t.Fatal("live snapshot accepted (a live copy would race the fast path)")
+	}
+
+	// Positive control: the current generation arms and snapshots.
+	if !ev.arm(genOf(ev)) {
+		t.Fatal("current-generation arm refused")
+	}
+	ev.append(genOf(ev), fieldStr("k", "v"))
+	snap, ok := ev.snapshotFields(genOf(ev))
+	if !ok || len(snap) != 1 || snap[0].key != "k" {
+		t.Fatalf("armed snapshot = %v (ok=%v), want one k field", snap, ok)
+	}
+
+	// A sealed event still snapshots its immutable tail.
+	ev.seal()
+	if snap, ok := ev.snapshotFields(genOf(ev)); !ok || len(snap) != 1 {
+		t.Fatalf("sealed snapshot = %v (ok=%v), want one k field", snap, ok)
+	}
+	ev.release()
 }
 
 // TestStragglerStartLine stresses the straggler-vs-recycle window with
@@ -767,9 +807,9 @@ func (s *sim) simAppend(key string) {
 	}
 }
 
-// simAppendSealed mirrors event.appendSealed (owner post-seal writes):
-// the generation always matches (the owner runs it), so it lands on
-// live/sealed and on sealedArmed under the mutex.
+// simAppendSealed mirrors the owner's post-seal writes as inlined in
+// annotatePostSeal: the generation always matches (the owner runs it),
+// so it lands on live/sealed and on sealedArmed under the mutex.
 func (s *sim) simAppendSealed(key string) {
 	s.land(key)
 }
@@ -1209,7 +1249,7 @@ func armOp() simStep {
 		name:     "arm",
 		runnable: func(s *sim) bool { return !s.ev.muHeld },
 		run:      func(s *sim) { s.simArm() },
-		real:     func(ev *event, _ *sim) { ev.arm() },
+		real:     func(ev *event, _ *sim) { ev.arm(genOf(ev)) },
 	}
 }
 
@@ -1318,7 +1358,11 @@ func snapshotSteps() []simStep {
 			})
 		},
 		real: func(ev *event, s *sim) {
-			s.realSnapshots = append(s.realSnapshots, fieldKeys(ev.snapshotFields()))
+			snap, ok := ev.snapshotFields(genOf(ev))
+			if !ok {
+				snap = nil
+			}
+			s.realSnapshots = append(s.realSnapshots, fieldKeys(snap))
 		},
 	}
 	unlock := simStep{name: "snap-unlock", run: func(s *sim) { s.releaseMu() }}
@@ -1542,7 +1586,7 @@ func stagedEnd(op *Operation, fireAt matrixPhase, fire func(ctx context.Context)
 	if fireAt == phasePrePostSeal {
 		fire(op.Context())
 	}
-	op.annotatePostSeal(commitInput{
+	op.annotatePostSeal(&commitInput{
 		outcome:  outcome,
 		code:     code,
 		duration: duration,
@@ -1552,7 +1596,7 @@ func stagedEnd(op *Operation, fireAt matrixPhase, fire func(ctx context.Context)
 	if fireAt == phasePreCommit {
 		fire(op.Context())
 	}
-	return op.commit(commitInput{
+	return op.commit(&commitInput{
 		outcome:  outcome,
 		code:     code,
 		duration: duration,
@@ -1582,7 +1626,7 @@ func TestStragglerInjectionMatrix(t *testing.T) {
 					MustCompile(Config{Sink: controlSink, SamplingRate: 1}),
 					OperationStart{Domain: DomainJob, Name: "m"})
 				if armed {
-					cop.ev.arm()
+					cop.ev.arm(genOf(cop.ev))
 				}
 				if live {
 					stragglerWrite(cop.Context())
@@ -1599,7 +1643,7 @@ func TestStragglerInjectionMatrix(t *testing.T) {
 				op := Start(context.Background(), rt, OperationStart{Domain: DomainJob, Name: "m"})
 				ctx := op.Context()
 				if armed {
-					op.ev.arm()
+					op.ev.arm(genOf(op.ev))
 				}
 				// The state assertion runs at the phase boundary, right
 				// after the straggler fires: live phases must still be
@@ -1765,7 +1809,7 @@ func TestStragglerArmedBurst(t *testing.T) {
 		rt := MustCompile(Config{Sink: sink, SamplingRate: 1})
 		op := Start(context.Background(), rt, OperationStart{Domain: DomainJob, Name: "burst"})
 		ctx := op.Context()
-		op.ev.arm()
+		op.ev.arm(genOf(op.ev))
 
 		var mu sync.Mutex
 		start := sync.NewCond(&mu)
@@ -1831,7 +1875,7 @@ func TestStragglerSealedErrorNoLatch(t *testing.T) {
 				op := Start(context.Background(), rt, OperationStart{Domain: DomainJob, Name: "latch"})
 				ctx := op.Context()
 				if armed {
-					op.ev.arm()
+					op.ev.arm(genOf(op.ev))
 				}
 				stagedEnd(op, phase, func(context.Context) {
 					Error(ctx, errors.New("s-error"))
@@ -1862,7 +1906,7 @@ func TestArmedSetterSerialization(t *testing.T) {
 		rt := MustCompile(Config{Sink: sink, SamplingRate: 1})
 		op := Start(context.Background(), rt, OperationStart{Domain: DomainJob, Name: "setter-race"})
 		ctx := op.Context()
-		op.ev.arm()
+		op.ev.arm(genOf(op.ev))
 
 		const setters = 6
 		const writes = 2000


### PR DESCRIPTION
## Why

PR #59 ships happycontext 1.0.0. The release review found 2 blockers and 7 should-fix items. This PR corrects them. The v2 line has no backward-compatibility constraint, so the fixes are direct.

## What changed

**B1 — the zerolog fast path ignored rendering settings.**
The fast path checked 3 member names only. It ignored `TimeFieldFormat`, `DurationFieldUnit`, `DurationFieldInteger`, `LevelFieldMarshalFunc`, and `TimestampFunc`. The same record had 2 JSON forms. The plain logger took 1 form. The enriched logger took the other form.
The gate now checks every setting that changes the output. A customized setting sends the record to the typed path, which honors it. A test covers each setting.

**B2 — the `hc.Add` doc promised too much.**
The doc said that a write after `End` is always a no-op. A small race window can move a field into the next request's event. The docs for `Add`, `Error`, `SetMessage`, `SetRoute`, `SetLevel`, and `End` now state the caveat. No behavior change.

**S1 — `TestSink` panicked for empty slices.**
The deep copy used a raw pointer as the visited-map key. All empty slices have pointer 0. Two empty slices of different types collided. `End` panicked on `reflect.Set`. The key now contains the type. Empty slices copy directly. A regression test uses the panic case.

**S2 — the watchdog helpers had no generation check.**
`arm()` and `snapshotFields()` could touch the next request's event after a recycle. Both now take a generation. A stale handle is refused. A live event also refuses snapshots, because a live copy would race the fast path.

**S3 — `setError` ran user code under the mutex.**
The structured error field was built while the armed mutex was held. User `Error()` and `Unwrap()` code must not run there. The field is now built before the lock.

**S4 — `op.outcome=retry` bypassed sampling.**
A retry is not an error and not a panic. `SampleInput.HasError` says "error or panic". A retry now samples like a healthy event. A test pins it.

**S6 — the modernize pass slowed the End path.**
`commitInput` is 200 bytes. It was passed by value to 3 functions. Each `End` copied about 600 bytes. `claim()` was a non-inlinable call on every `End`.
`commitInput` now passes by pointer. The one-shot claim is now one inline CAS. The wait path stays in `awaitPublication`.
Measured against the current v2 HEAD:

| Benchmark | Change |
|---|---:|
| EndDropPath | −8.9 % |
| EndDropPathCustomSampler | −9.5 % |
| OperationLifecycle | −3.3 % (250.1 ns) |
| OperationLifecycle12Fields | −3.4 % |
| Dropped/8 fields | −6.2 % |
| RecordEncodeWrite12 | −2.8 % |

The branch is faster than the pre-modernize tree on every measured gate. The allocations do not change.

**S7 — the gate ledger and the benchmark did not agree.**
`V2_DESIGN.md` now separates 2 scopes:
- The End-drop segment (sampler + release + pool) is about 43 ns. It meets the 100 ns gate.
- The full field-less `End` is 123 ns. It was 135–146 ns before this PR.
The ledger records the measured 1.0.0 numbers. `OperationLifecycle` is at the 250 ns target. The dropped lifecycle with 8 fields is 335 ns against the 300 ns target. The note marks this item as tracked. `BenchmarkEndDropPath`'s comment now states its real scope.

**Nits.**
- N1: `OperationPolicy` documents the INFO workaround.
- N2: the wait path stays simple. The hot path pays nothing.
- N3: `bridge.ErrorMessage(nil)` returns `""`.
- N4: the `scanWAL` kind rule is documented and pinned by a test.
- N5: the simulation comment no longer names the deleted `appendSealed`.

**New file.**
`wal_bench_test.go` adds 12 WAL micro-benchmarks: append, arm, seal, straggler, setter, snapshot, and recycle paths.

## Checks

- `gofmt`: clean.
- `go vet ./...`: all 12 modules pass.
- `go test ./...`: all 12 modules pass.
- `go test -race`: root, `bridge`, `internal/hcjson`, adapters, and integrations pass.

## Not in this PR

- The 1.0.0 changelog (S5). This file belongs to release PR #59. Edit it before the merge. Add the 3 legacy fixes (`5526c69`, `ea2344a`, `effc153`) and remove the duplicate entries.
- `BENCHMARK_REPORT.md` is old. Add a WAL section the next time you touch it.
